### PR TITLE
Fix connectors env variable syntax

### DIFF
--- a/core/connectors/mysql.md
+++ b/core/connectors/mysql.md
@@ -9,7 +9,7 @@ To connect to a MySQL database server, you need to configure a [`datasource`](..
 ```groovy
 datasource pg {
   provider = "mysql"
-  url      = env(MYSQL_URL)
+  url      = env("MYSQL_URL")
 }
 
 // ... the file should also contain a data model definition and (optionally) generators

--- a/core/connectors/postgres.md
+++ b/core/connectors/postgres.md
@@ -9,7 +9,7 @@ To connect to a PostgreSQL database server, you need to configure a [`datasource
 ```groovy
 datasource pg {
   provider = "postgres"
-  url      = env(POSTGRES_URL)
+  url      = env("POSTGRES_URL")
 }
 
 // ... the file should also contain a data model definition and (optionally) generators


### PR DESCRIPTION
There is a syntax error in `mysql.md` and `postgres.md`
Lift cannot create migration when environment variable is not in quotes.

It's correct in `prisma-project-file.md`

Here is the stack trace:
```bash
thread 'main' panicked at 'loading the connector failed.: DataModelErrors { code: 1001, errors: ["Unexpected token. Expected one of: ."] }', src/libcore/result.rs:997:5
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:39
   1: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at src/libstd/sys_common/backtrace.rs:59
             at src/libstd/panicking.rs:197
   3: std::panicking::default_hook
             at src/libstd/panicking.rs:211
   4: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:474
   5: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:381
   6: rust_begin_unwind
             at src/libstd/panicking.rs:308
   7: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
   8: core::result::unwrap_failed
   9: migration_core::migration_engine::MigrationEngine::init
  10: <F as jsonrpc_core::calls::RpcMethodSimple>::call
  11: <F as jsonrpc_core::calls::RpcMethod<T>>::call
  12: <futures::future::lazy::Lazy<F,R> as futures::future::Future>::poll
  13: <futures::future::then::Then<A,B,F> as futures::future::Future>::poll
  14: <futures::future::map::Map<A,F> as futures::future::Future>::poll
  15: <futures::future::either::Either<A,B> as futures::future::Future>::poll
  16: futures::task_impl::std::set
  17: std::thread::local::LocalKey<T>::with
  18: futures::future::Future::wait
  19: jsonrpc_core::io::IoHandler<M>::handle_request_sync
  20: migration_core::rpc_api::RpcApi::handle
  21: migration_engine::main
  22: std::rt::lang_start::{{closure}}
  23: std::panicking::try::do_call
             at src/libstd/rt.rs:49
             at src/libstd/panicking.rs:293
  24: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:87
  25: std::rt::lang_start_internal
             at src/libstd/panicking.rs:272
             at src/libstd/panic.rs:388
             at src/libstd/rt.rs:48
  26: main
  27: __libc_start_main
  28: _start

```