### PR TITLE
[WIP] Sticky navbar on page scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-instantsearch-dom": "^6.4.0",
     "react-live": "^2.2.2",
     "react-loadable": "^5.5.0",
+    "react-sticky": "^6.0.3",
     "react-testing-library": "^6.0.0",
     "smooth-scroll": "^16.1.2",
     "styled-components": "^4.1.3",

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
+import { StickyContainer, Sticky } from 'react-sticky';
 import Tree from './tree';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useAllArticlesQuery } from '../../hooks/useAllArticlesQuery';
 import { AllArticles } from '../../interfaces/AllArticles.interface';
 
-const Sidebar = styled.aside`
+const Sidebar = styled.div`
   margin: 0;
-  max-width: 215px;
-  width: 20%;
-  @media (min-width: 1024px) {
-    align-self: flex-start;
-    position: sticky;
-    top: 0;
-  }
+  overflow-y: auto;
+  ${({ isSticky }) =>
+    isSticky &&
+    css`
+      max-height: 100vh;
+    `};
 `;
 
 const List = styled.ul`
@@ -20,14 +20,26 @@ const List = styled.ul`
   padding: 0;
 `;
 
+const NavigationContainer = styled.aside`
+  width: 235px;
+`;
+
 const SidebarLayout = () => {
   const { allMdx }: AllArticles = useAllArticlesQuery();
   return (
-    <Sidebar>
-      <List>
-        <Tree edges={allMdx.edges} />
-      </List>
-    </Sidebar>
+    <StickyContainer>
+      <NavigationContainer>
+        <Sticky topOffset={0}>
+          {({ style, isSticky }) => (
+            <Sidebar style={style} isSticky={isSticky}>
+              <List>
+                <Tree edges={allMdx.edges} />
+              </List>
+            </Sidebar>
+          )}
+        </Sticky>
+      </NavigationContainer>
+    </StickyContainer>
   );
 };
 

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -5,9 +5,13 @@ import styled, { css } from 'styled-components';
 import { useAllArticlesQuery } from '../../hooks/useAllArticlesQuery';
 import { AllArticles } from '../../interfaces/AllArticles.interface';
 
+const SidebarContainer = styled.aside`
+  width: 235px;
+`;
+
 const Sidebar = styled.div`
   margin: 0;
-  overflow-y: auto;
+  overflow: auto;
   ${({ isSticky }) =>
     isSticky &&
     css`
@@ -17,18 +21,13 @@ const Sidebar = styled.div`
 
 const List = styled.ul`
   list-style: none;
-  padding: 0;
-`;
-
-const NavigationContainer = styled.aside`
-  width: 235px;
 `;
 
 const SidebarLayout = () => {
   const { allMdx }: AllArticles = useAllArticlesQuery();
   return (
     <StickyContainer>
-      <NavigationContainer>
+      <SidebarContainer>
         <Sticky topOffset={0}>
           {({ style, isSticky }) => (
             <Sidebar style={style} isSticky={isSticky}>
@@ -38,7 +37,7 @@ const SidebarLayout = () => {
             </Sidebar>
           )}
         </Sticky>
-      </NavigationContainer>
+      </SidebarContainer>
     </StickyContainer>
   );
 };

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -8,6 +8,11 @@ const Sidebar = styled.aside`
   margin: 0;
   max-width: 215px;
   width: 20%;
+  @media (min-width: 1024px) {
+    align-self: flex-start;
+    position: sticky;
+    top: 0;
+  }
 `;
 
 const List = styled.ul`

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -29,7 +29,7 @@ const ListItem = styled.li`
 
     .tag {
       position: absolute;
-      right: 0;
+      right: 5%;
       color: #a0aec0;
       font-size: 14px;
       font-style: normal;


### PR DESCRIPTION
pr exists as a result of [this twitter conversation](https://twitter.com/nikolasburk/status/1245712496570351616) :)

As the version 2 docs are not mobile responsive so far, I've wrapped the proper CSS code within a standard media query for large screens (>1024px) to support upcoming mobile/responsive tweaks.

The CSS code uses the `position: sticky` CSS feature, which means that [compatibility is given for the majority of browsers](https://caniuse.com/#search=sticky), except Internet Explorers. 

Done so far:
- [ ] feature code
- [ ] tested manually on Safari @ Mac
- [ ] tested manually on Firefox @ Mac
- [ ] tested manually on Chrome @ Mac
- [ ] run `prettify` node script
