### PR TITLE
Typescript getting-started fixes

### DIFF
--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -530,9 +530,21 @@ async function main() {
 
 Now run the code with this command:
 
+<SwitchTech technologies={['typescript', '*']}>
+
+```
+npx ts-node index.ts
+```
+
+</SwitchTech>
+
+<SwitchTech technologies={['node', '*']}>
+
 ```
 node index.js
 ```
+
+</SwitchTech>
 
 This should print an empty arrays because there are no `User` records in the database yet:
 
@@ -575,16 +587,6 @@ async function main() {
 This code creates a new `User` record together with new `Post` and `Profile` records using a [nested write](#nested-writes) query. The `User` record is connected to the two other ones via the `Post.author` ↔ `User.posts` and `Profile.user` ↔ `User.profile` [relation fields](../../reference/tools-and-interfaces/prisma-schema/relations#relation-fields) respectively.
 
 Notice that you're passing the [`include`](../../reference/tools-and-interfaces/prisma-client/field-selection#include) option to `findMany` which tells Prisma Client to include the `posts` and `profile` relations on the returned `User` objects.
-
-<SwitchTech technologies={['typescript', '*']}>
-
-Run the code with this command:
-
-```
-npx ts-node index.ts
-```
-
-</SwitchTech>
 
 <SwitchTech technologies={['typescript', '*']}>
 


### PR DESCRIPTION
Fixing a couple typos in the typescript version of "getting started
sql": One command that uses node instead of ts-node, and one that is a
duplicate of the few lines above it.