### PR TITLE
Fix typo

### DIFF
--- a/content/02-understand-prisma/02-why-prisma.mdx
+++ b/content/02-understand-prisma/02-why-prisma.mdx
@@ -6,7 +6,7 @@ metaDescription: 'Learn about the motivation for Prisma and how it compares to o
 
 ## Overview
 
-On this page, you'll learn about the motivation for Prisma and how it compares to ther database tools like ORMs and SQL query builders.
+On this page, you'll learn about the motivation for Prisma and how it compares to other database tools like ORMs and SQL query builders.
 
 Working with relational databases is a major bottleneck in application development. Debugging SQL queries or complex ORM objects often consume hours of development time.
 


### PR DESCRIPTION
### Problem

There is a typo ("ther" – should be "other") on the [why prisma](https://www.prisma.io/docs/understand-prisma/why-prisma) page.

### Solution

Fix the typo!