### PR TITLE
Fix typo in output after publishing post

### DIFF
--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -734,7 +734,7 @@ You will see the following output:
   content: null,
   createdAt: 2020-04-09T09:25:07.663Z,
   id: 1,
-  published: false,
+  published: true,
   title: 'Hello World'
 }
 ```


### PR DESCRIPTION
Typo in the output after publishing a post
`published: false` => `published: true`

The output is right in the equivalent doc for [prisma migrate](https://github.com/prisma/prisma2-docs/blob/cc73e493f0cd7efa3475cae38105903e6e22e486/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx)