### PR TITLE
Improve search

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -39,24 +39,22 @@ const HitsWrapper = styled.div`
 `;
 
 const indexName = config.header.search.indexName;
+const searchClient = algoliasearch(
+  config.header.search.algoliaAppId,
+  config.header.search.algoliaSearchKey
+);
+
+const Results = connectStateResults(({ searchState: state, searchResults: res, children }: any) =>
+  res && res.nbHits > 0 ? (
+    children
+  ) : (
+    <div className="no-results">No results for '{state.query}'</div>
+  )
+);
 
 export default function Search() {
   const [query, setQuery] = useState(``);
-  const searchClient = algoliasearch(
-    config.header.search.algoliaAppId,
-    config.header.search.algoliaSearchKey
-  );
-
   const [showHits, setShowHits] = React.useState(true);
-
-  const Results = connectStateResults(({ searchState: state, searchResults: res, children }: any) =>
-    res && res.nbHits > 0 ? (
-      children
-    ) : (
-      <div className="no-results">No results for '{state.query}'</div>
-    )
-  );
-
   const hideSearch = () => setShowHits(false);
   const showSearch = () => setShowHits(true);
 


### PR DESCRIPTION
I noticed the search was **extremely** slow and made the whole website freeze, which is caused by requests being fired on **every single** keystroke… I started debouncing the search in my first commit but then realized the search wasn’t set up properly, so I tried to improve that in my second commit.

I followed the algolia doc for the implementation. See https://www.algolia.com/doc/guides/building-search-ui/going-further/improve-performance/react/#debouncing.

⚠️ I’d suggest manually testing this PR before merging because there seems to be one more tiny issue: an empty query is fired on page load, which is then cached and flashes before showing the results of the very first search 🤷‍♂️It’s not caused by this PR because I can also see it happening in the network tab of the current website, but this PR kinda makes it more obvious (see the after GIF).

# Before

I start typing at normal speed directly after the GIF starts. The whole UI freezes.

![Kapture 2020-04-13 at 17 37 21](https://user-images.githubusercontent.com/9154236/79134169-8d338700-7dad-11ea-8ab6-622ffdf40f4c.gif) 

1 query/network request is made per character.

<img width="567" alt="Screenshot 2020-04-13 at 17 41 15" src="https://user-images.githubusercontent.com/9154236/79134428-fca97680-7dad-11ea-9062-e2f7bd488849.png">  

# After

The UI doesn’t freeze.

![Kapture 2020-04-13 at 19 01 36](https://user-images.githubusercontent.com/9154236/79141076-5e231280-7db9-11ea-85d8-5f79d339e1b0.gif)

A single query is made.

<img width="564" alt="Screenshot 2020-04-13 at 19 02 41" src="https://user-images.githubusercontent.com/9154236/79141080-5f543f80-7db9-11ea-9e70-22523b9db007.png">

You might want to add a loading indicator for people on slow networks, too. 🤷‍♂️ 