### PR TITLE
Tech switch updates

### DIFF
--- a/content/01-getting-started/01-quickstart.mdx
+++ b/content/01-getting-started/01-quickstart.mdx
@@ -3,7 +3,7 @@ title: 'Quickstart'
 metaTitle: 'Quickstart (5 min)'
 metaDescription: 'Get started with Prisma in 5 minutes. You will learn how to send queries to a SQL database in a plain Node.js or TypeScript script using Prisma Client.'
 duration: '5 min' 
-langSwitcher: true
+langSwitcher: ['typescript', 'node']
 ---
 
 ## Overview

--- a/content/01-getting-started/02-setup-prisma/01-add-to-existing-project.mdx
+++ b/content/01-getting-started/02-setup-prisma/01-add-to-existing-project.mdx
@@ -2,8 +2,8 @@
 title: 'Add to existing project'
 metaTitle: 'Add Prisma to an existing project (15 min)'
 metaDescription: 'Learn how to add Prisma to an existing Node.js or TypeScript project by connecting it to your database and generating Prisma Client for database access.'
-dbSwitcher: true
-langSwitcher: true
+langSwitcher: ['typescript', 'node']
+dbSwitcher: ["postgres", "sqlite", "mysql"]
 ---
 
 ## Overview

--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -2,8 +2,8 @@
 title: 'Start from scratch'
 metaTitle: 'Set up a new project with Prisma from scratch (SQL)'
 metaDescription: 'Learn how to create a new Node.js or TypeScript project from scratch by connecting Prisma to your database and generating Prisma Client for database access.'
-dbSwitcher: true
-langSwitcher: true
+langSwitcher: ['typescript', 'node']
+dbSwitcher: ["postgres", "sqlite", "mysql"]
 ---
 
 ## Overview

--- a/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
+++ b/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
@@ -2,8 +2,8 @@
 title: 'Start from scratch (Prisma Migrate)'
 metaTitle: 'Set up a new project with Prisma from scratch (Prisma Migrate)'
 metaDescription: 'Learn how to create a new Node.js or TypeScript project from scratch by connecting Prisma to your database and generating Prisma Client for database access.'
-dbSwitcher: true
-langSwitcher: true
+langSwitcher: ['typescript', 'node']
+dbSwitcher: ["postgres", "sqlite", "mysql"]
 ---
 
 ## Overview

--- a/content/01-getting-started/04-example.mdx
+++ b/content/01-getting-started/04-example.mdx
@@ -2,14 +2,16 @@
 title: 'Example'
 metaTitle: ''
 metaDescription: ''
-langSwitcher: true
-dbSwitcher: true
+langSwitcher: ['node', 'typescript']
+dbSwitcher: ["postgres", "mysql"]
 ---
 
 ## Overview
 
 This page won't be shown in sidebar. For now, h2 tags cannot be written inside `SwitchTech` block. But still can include headings using `<h3>, <h4>` tags and not using `### headings`.
 `<h2>` tags wont be shown in TOC yet.
+
+<SwitchTech technologies={['*', 'mysql']}>
 
 ```js
 // comment here
@@ -27,6 +29,10 @@ prisma postgresql {
 }
 ```
 
+</SwitchTech>
+
+<SwitchTech technologies={['node', 'postgres']}>
+
 <ButtonLink color="dark" type="primary" href="/" target="_blank">
   Quickstart (5 min)
 </ButtonLink>
@@ -38,3 +44,5 @@ prisma postgresql {
 >
   Quickstart (5 min)
 </ButtonLink>
+
+</SwitchTech>

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,10 +46,10 @@ module.exports = {
     'gatsby-image',
     'gatsby-plugin-styled-components',
     `gatsby-plugin-smoothscroll`,
-    {
-      resolve: `gatsby-plugin-algolia`,
-      options: require(`./src/utils/algolia`),
-    },
+    // {
+    //   resolve: `gatsby-plugin-algolia`,
+    //   options: require(`./src/utils/algolia`),
+    // },
     {
       resolve: `gatsby-plugin-sitemap`,
       options: {

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import favicon from '../images/favicon-32x32.png';
+import { urlGenerator } from '../utils/urlGenerator';
 import { useStaticQuery, graphql } from 'gatsby';
-import { useLocation } from '@reach/router';
 
 type SEOProps = {
   title?: string;
@@ -11,13 +11,17 @@ type SEOProps = {
   slug?: string;
 };
 
-const SEO = ({ title, description, keywords }: SEOProps) => {
+const SEO = ({ title, description, keywords, slug }: SEOProps) => {
   const { site } = useStaticQuery(query);
   const {
     siteMetadata: {
       pathPrefix,
       siteUrl,
-      twitter: { site: tSite, creator: tCreator, image: tUrl },
+      twitter: {
+        site: tSite,
+        creator: tCreator,
+        image: tUrl
+      },
       og: {
         site_name: oSite,
         type: oType,
@@ -25,7 +29,9 @@ const SEO = ({ title, description, keywords }: SEOProps) => {
       },
     },
   } = site;
-  const canonicalUrl = useLocation().href;
+
+  let canonicalUrl = pathPrefix ? (siteUrl + pathPrefix) : siteUrl;
+  canonicalUrl = slug ? canonicalUrl + urlGenerator(slug) : canonicalUrl;
   return (
     <Helmet>
       {/* <meta charSet="utf-8" /> */}
@@ -40,14 +46,14 @@ const SEO = ({ title, description, keywords }: SEOProps) => {
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:creator" content={tCreator} />
-      <meta name="twitter:image" content={`${siteUrl + pathPrefix}${tUrl}`} />
+      <meta name="twitter:image" content={`${siteUrl+pathPrefix}${tUrl}`} />
       {/* Open Graph */}
       <meta property="og:url" content={canonicalUrl} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:site_name" content={oSite} />
       <meta property="og:type" content={oType} />
-      <meta property="og:image" content={`${siteUrl + pathPrefix}${oUrl}`} />
+      <meta property="og:image" content={`${siteUrl+pathPrefix}${oUrl}`} />
       <meta property="og:image:alt" content={oImgAlt} />
       <meta property="og:image:type" content={oImgType} />
       <meta property="og:image:width" content={oImgWidth} />

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import favicon from '../images/favicon-32x32.png';
-import { urlGenerator } from '../utils/urlGenerator';
 import { useStaticQuery, graphql } from 'gatsby';
+import { useLocation } from '@reach/router';
 
 type SEOProps = {
   title?: string;
@@ -11,17 +11,13 @@ type SEOProps = {
   slug?: string;
 };
 
-const SEO = ({ title, description, keywords, slug }: SEOProps) => {
+const SEO = ({ title, description, keywords }: SEOProps) => {
   const { site } = useStaticQuery(query);
   const {
     siteMetadata: {
       pathPrefix,
       siteUrl,
-      twitter: {
-        site: tSite,
-        creator: tCreator,
-        image: tUrl
-      },
+      twitter: { site: tSite, creator: tCreator, image: tUrl },
       og: {
         site_name: oSite,
         type: oType,
@@ -29,9 +25,7 @@ const SEO = ({ title, description, keywords, slug }: SEOProps) => {
       },
     },
   } = site;
-
-  let canonicalUrl = pathPrefix ? (siteUrl + pathPrefix) : siteUrl;
-  canonicalUrl = slug ? canonicalUrl + urlGenerator(slug) : canonicalUrl;
+  const canonicalUrl = useLocation().href;
   return (
     <Helmet>
       {/* <meta charSet="utf-8" /> */}
@@ -46,14 +40,14 @@ const SEO = ({ title, description, keywords, slug }: SEOProps) => {
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:creator" content={tCreator} />
-      <meta name="twitter:image" content={`${siteUrl+pathPrefix}${tUrl}`} />
+      <meta name="twitter:image" content={`${siteUrl + pathPrefix}${tUrl}`} />
       {/* Open Graph */}
       <meta property="og:url" content={canonicalUrl} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:site_name" content={oSite} />
       <meta property="og:type" content={oType} />
-      <meta property="og:image" content={`${siteUrl+pathPrefix}${oUrl}`} />
+      <meta property="og:image" content={`${siteUrl + pathPrefix}${oUrl}`} />
       <meta property="og:image:alt" content={oImgAlt} />
       <meta property="og:image:type" content={oImgType} />
       <meta property="og:image:width" content={oImgWidth} />

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import favicon from '../images/favicon-32x32.png';
-import { urlGenerator } from '../utils/urlGenerator';
 import { useStaticQuery, graphql } from 'gatsby';
+import { useLocation } from '@reach/router';
 
 type SEOProps = {
   title?: string;
@@ -11,17 +11,13 @@ type SEOProps = {
   slug?: string;
 };
 
-const SEO = ({ title, description, keywords, slug }: SEOProps) => {
+const SEO = ({ title, description, keywords }: SEOProps) => {
   const { site } = useStaticQuery(query);
   const {
     siteMetadata: {
       pathPrefix,
       siteUrl,
-      twitter: {
-        site: tSite,
-        creator: tCreator,
-        image: tUrl
-      },
+      twitter: { site: tSite, creator: tCreator, image: tUrl },
       og: {
         site_name: oSite,
         type: oType,
@@ -30,30 +26,36 @@ const SEO = ({ title, description, keywords, slug }: SEOProps) => {
     },
   } = site;
 
-  let canonicalUrl = pathPrefix ? (siteUrl + pathPrefix) : siteUrl;
-  canonicalUrl = slug ? canonicalUrl + urlGenerator(slug) : canonicalUrl;
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const canonicalUrl = location.href;
+  const lang = searchParams ? searchParams.get('lang') : '';
+  const db = searchParams ? searchParams.get('db') : '';
+
+  const seoTitle = `${title}${lang ? '-' + lang.toUpperCase() : ''}${
+    db ? '-' + db.toUpperCase() : ''
+  }`;
   return (
     <Helmet>
       {/* <meta charSet="utf-8" /> */}
       {/* <meta name="viewport" content="width=device-width, initial-scale=1" /> */}
-      {title && <title>{title}</title>}
-      {description && <meta name="title" content={description} />}
+      {title && <title>{seoTitle}</title>}
       {description && <meta name="description" content={description} />}
       {keywords && <meta name="keywords" content={keywords} />}
       {/* Twitter */}
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content={tSite} />
-      <meta name="twitter:title" content={title} />
+      <meta name="twitter:title" content={seoTitle} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:creator" content={tCreator} />
-      <meta name="twitter:image" content={`${siteUrl+pathPrefix}${tUrl}`} />
+      <meta name="twitter:image" content={`${siteUrl + pathPrefix}${tUrl}`} />
       {/* Open Graph */}
       <meta property="og:url" content={canonicalUrl} />
-      <meta property="og:title" content={title} />
+      <meta property="og:title" content={seoTitle} />
       <meta property="og:description" content={description} />
       <meta property="og:site_name" content={oSite} />
       <meta property="og:type" content={oType} />
-      <meta property="og:image" content={`${siteUrl+pathPrefix}${oUrl}`} />
+      <meta property="og:image" content={`${siteUrl + pathPrefix}${oUrl}`} />
       <meta property="og:image:alt" content={oImgAlt} />
       <meta property="og:image:type" content={oImgType} />
       <meta property="og:image:width" content={oImgWidth} />

--- a/src/components/techSwitcher.tsx
+++ b/src/components/techSwitcher.tsx
@@ -10,6 +10,8 @@ import JS from '../icons/technologies/JS';
 interface TechSwitchProps {
   type: string;
   onChangeTech: (item: any) => void;
+  technologies: string[];
+  defaultTech: string;
 }
 
 interface TechItem {
@@ -37,9 +39,9 @@ export const technologyNames = {
   sqlite: 'SQLite',
 };
 
-const TechnologySwitch = ({ type, onChangeTech }: TechSwitchProps) => {
-  const langDefault = { technology: 'typescript' };
-  const dbDefault = { technology: 'postgres' };
+const TechnologySwitch = ({ type, onChangeTech, technologies, defaultTech }: TechSwitchProps) => {
+  const langDefault = { technology: defaultTech || 'typescript' };
+  const dbDefault = { technology: defaultTech || 'postgres' };
   const defaultItem = type === 'lang' ? langDefault : dbDefault;
 
   const [selectedItem, setSelectedItem] = React.useState(defaultItem);
@@ -60,10 +62,14 @@ const TechnologySwitch = ({ type, onChangeTech }: TechSwitchProps) => {
     onChangeTech(item);
   };
 
-  const items =
+  let items =
     type === 'lang'
       ? technologyTypes.languages.map((lang: any) => ({ technology: lang }))
       : technologyTypes.databases.map((db: any) => ({ technology: db }));
+
+  if (technologies) {
+    items = items.filter((item: any) => technologies.includes(item.technology));
+  }
 
   return (
     <Container>

--- a/src/components/topSection.tsx
+++ b/src/components/topSection.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import TOC from './toc';
 import TechnologySwitch from './techSwitcher';
 import ParentTitle from './parentTitleComp';
+import { useNavigate } from '@reach/router';
+import { urlGenerator } from '../utils/urlGenerator';
 
 const TopSectionWrapper = styled.div`
   position: relative;
@@ -30,8 +32,27 @@ const SwitcherWrapper = styled.div`
 `;
 
 const TopSection = ({ location, title, slug, indexPage, langSwitcher, dbSwitcher }: any) => {
-  const [langSelected, setLangSelected] = React.useState('typescript');
-  const [dbSelected, setDbSelected] = React.useState('postgres');
+  const navigate = useNavigate();
+  const getTechFromParam = (type: string, defaultVal: string) => {
+    const searchParam = new URLSearchParams(location.search).get(type);
+    return searchParam ? searchParam : defaultVal;
+  };
+
+  const [langSelected, setLangSelected] = React.useState(
+    langSwitcher ? getTechFromParam('lang', langSwitcher[0]) : 'typescript'
+  );
+  const [dbSelected, setDbSelected] = React.useState(
+    dbSwitcher ? getTechFromParam('db', dbSwitcher[0]) : 'postgres'
+  );
+
+  const goToNewPath = () => {
+    const newParams = `?${langSwitcher ? `lang=${langSelected}${dbSwitcher ? '&' : ''}` : ''}${
+      dbSwitcher ? `db=${dbSelected}` : ''
+    }`;
+    if (!(location.pathname.includes(urlGenerator(slug)) && location.search === newParams)) {
+      navigate(newParams);
+    }
+  };
 
   // TODO : Simplify the function!
   const techChanged = (item: any, type: string) => {
@@ -69,6 +90,7 @@ const TopSection = ({ location, title, slug, indexPage, langSwitcher, dbSwitcher
       }
     });
     elemToShow && elemToShow.forEach((eShow: any) => eShow.classList.add('show'));
+    goToNewPath();
   };
 
   const langChanged = (item: any) => {
@@ -98,8 +120,22 @@ const TopSection = ({ location, title, slug, indexPage, langSwitcher, dbSwitcher
       <MainTitle>{title}</MainTitle>
       {!indexPage && <hr className={`${langSwitcher || dbSwitcher ? 'bigger-margin' : ''}`} />}
       <SwitcherWrapper>
-        {langSwitcher && <TechnologySwitch type="lang" onChangeTech={langChanged} />}
-        {dbSwitcher && <TechnologySwitch type="db" onChangeTech={dbChanged} />}
+        {langSwitcher && (
+          <TechnologySwitch
+            type="lang"
+            onChangeTech={langChanged}
+            technologies={langSwitcher}
+            defaultTech={langSelected}
+          />
+        )}
+        {dbSwitcher && (
+          <TechnologySwitch
+            type="db"
+            onChangeTech={dbChanged}
+            technologies={dbSwitcher}
+            defaultTech={dbSelected}
+          />
+        )}
       </SwitcherWrapper>
       {!indexPage && <TOC location={location} />}
     </TopSectionWrapper>

--- a/src/interfaces/Article.interface.ts
+++ b/src/interfaces/Article.interface.ts
@@ -17,8 +17,8 @@ export interface ArticleData {
       title: string;
       metaTitle?: string;
       metaDescription?: string;
-      langSwitcher?: boolean;
-      dbSwitcher?: boolean;
+      langSwitcher?: string[];
+      dbSwitcher?: string[];
     };
   };
   allMdx: AllEdges;

--- a/src/layouts/articleLayout.tsx
+++ b/src/layouts/articleLayout.tsx
@@ -17,7 +17,13 @@ const ArticleLayout = ({ data, ...props }: ArticleLayoutProps) => {
   const {
     mdx: {
       fields: { slug },
-      frontmatter: { title, metaTitle, metaDescription, langSwitcher, dbSwitcher },
+      frontmatter: {
+        title,
+        metaTitle,
+        metaDescription,
+        langSwitcher,
+        dbSwitcher
+      },
       body,
       parent,
     },


### PR DESCRIPTION
- In the meta data in the frontmatter instead of providing a bool we could provide a list of technologies which is the source of truth for that page. So the it would look smth like this:

dbSwitcher: ["sqlite", "mysql"]
langSwitcher: ["javascript", "typescript"]

- Add url params to current path to indicate selected lang and db
- update canonical url