### PR TITLE
fix robots.txt so netlify deployment won't be indexed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -66,14 +66,10 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
-        env: {
-          development: {
-            policy: [{ userAgent: '*', disallow: ['/'] }],
-          },
-          production: {
-            policy: [{ userAgent: '*', allow: '/' }],
-          },
-        },
+            policy: [{
+              userAgent: '*',
+              disallow: '/'
+        }]
       },
     },
     // 'gatsby-plugin-offline', // it causes infinite loop issue with workbox


### PR DESCRIPTION
Current robots.txt

```
User-agent: *
Allow: /
Sitemap: https://www.prisma.io/sitemap.xml
Host: https://www.prisma.io
```

https://www.prisma.io/docs/robots.txt
https://prisma2.netlify.app/robots.txt

This will change it so `https://prisma2.netlify.app` won't appear in the search results anymore.

`https://www.prisma.io/docs/` will still be indexed.

Related to https://github.com/prisma/prisma/issues/1949