### PR TITLE
Prisma Docs - Introduction | Minor Detail Fixes

### DIFF
--- a/content/02-understand-prisma/01-introduction.mdx
+++ b/content/02-understand-prisma/01-introduction.mdx
@@ -20,13 +20,13 @@ Prisma is an [open source](https://github.com/prisma/prisma) database toolkit. I
 - **Prisma Migrate** (_experimental_): Declarative data modeling & migration system
 - **Prisma Studio** (_experimental_): GUI to view and edit data in your database
 
-Prisma Client can be used in _any_ Node.js or TypeScript backend application (including serverless applications and microservices). This can be a [REST API](prisma-in-your-stack/rest), a [GraphQL API](prisma-in-your-stack/graphql) a gRPC API or anything else that needs a database.
+Prisma Client can be used in _any_ Node.js or TypeScript backend application (including serverless applications and microservices). This can be a [REST API](prisma-in-your-stack/rest), a [GraphQL API](prisma-in-your-stack/graphql), a gRPC API, or anything else that needs a database.
 
 ## How does Prisma work?
 
 ### The Prisma schema
 
-Every project that use a tool from the Prisma toolkit starts with a [Prisma schema file](../reference/tools-and-interfaces/prisma-schema/prisma-schema-file). The Prisma schema allows developers to define their _application models_ in an intuitive data modeling language. It also contains the connection to a database and defines a _generator_:
+Every project that uses a tool from the Prisma toolkit starts with a [Prisma schema file](../reference/tools-and-interfaces/prisma-schema/prisma-schema-file). The Prisma schema allows developers to define their _application models_ in an intuitive data modeling language. It also contains the connection to a database and defines a _generator_:
 
 ```prisma
 datasource db {
@@ -78,7 +78,7 @@ The data model is a collection of [models](../reference/tools-and-interfaces/pri
 
 There are two major workflows for "getting" a data model into your Prisma schema:
 
-- Generate the data model from [introspecting](../reference/tools-and-interfaces/introspection) a database
+- Generating the data model from [introspecting](../reference/tools-and-interfaces/introspection) a database
 - Manually writing the data model and mapping it to the database with [Prisma Migrate](../reference/tools-and-interfaces/prisma-migrate)
 
 Once the data model is defined, you can [generate Prisma Client](../reference/tools-and-interfaces/prisma-client/generating-prisma-client) which will expose CRUD and more queries for the defined models. If you're using TypeScript, you'll get full type-safety for all queries (even when only retrieving the subsets of a model's fields). 
@@ -105,7 +105,7 @@ Note that because the Prisma Client node module contains specific context about 
 
 #### Using Prisma Client to send queries to your database 
 
-Once Prisma Client was generated, you can import in your code and send queries to your database. This is what the setup code looks like.
+Once Prisma Client has been generated, you can import in your code and send queries to your database. This is what the setup code looks like.
 
 ##### Import and instantiate Prisma Client
 


### PR DESCRIPTION
## Description

Just a few small improvements that I found:

- a couple of missing commas in a list
- a few small grammar fixes ('use' > 'uses' & 'was' > 'has been')
- this is a small detail but there was a section of bullets that had inconsistent verbs: we had "generate" and then "writing" so I simply made them consistent ✌🏼🤓