### PR TITLE
Minor fixes to Prisma Migrate docs

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/03-prisma-migrate.mdx
+++ b/content/03-reference/01-tools-and-interfaces/03-prisma-migrate.mdx
@@ -71,7 +71,7 @@ prisma migrate save --experimental
 prisma migrate up --experimental
 ```
 
-The first command _saves_ a new migration to the file system and updates the `_Migration` table. It stores information about the migration in a dedicated directory inside the `prisma/migrations` directory of your project. Each migration that is stored has its own `README.md` file which contains detailed information about the migration (e.g. the generated SQL statements which will be executed when you run `prisma migrate up`).
+The first command _saves_ a new migration to the `prisma/migrations` directory in the file system of your project and updates the `_Migration` table in your database. It stores information about the migration in a new, dedicated directory inside the main `prisma/migrations` directory. Each migration that is stored has its own `README.md` file in its directory which contains detailed information about the migration (e.g. the generated SQL statements which will be executed when you run `prisma migrate up`).
 
 The second command _executes_ the migration against your database.
 

--- a/content/03-reference/01-tools-and-interfaces/03-prisma-migrate.mdx
+++ b/content/03-reference/01-tools-and-interfaces/03-prisma-migrate.mdx
@@ -20,15 +20,15 @@ Prisma Migrate is a _declarative_ migration system, as opposed to SQL which can 
 
 Here's a quick comparison. Assume you have the following scenario:
 
-1. You need to create `User` table to store user information (name, email, ...)
+1. You need to create the `User` table to store user information (name, email, ...)
 1. Create two new tables `Post` and `Profile` with foreign keys to `User`
-1. Add a new column with default value to the `Post` table
+1. Add a new column with a default value to the `Post` table
 
 ### SQL
 
 In SQL, you'd have to send three subsequent SQL statements to account for this scenario:
 
-**1. Create `User` table to store user information (name, email, ...)**
+**1. Create the `User` table to store user information (name, email, ...)**
 
 ```sql
 CREATE TABLE "User" (
@@ -55,7 +55,7 @@ CREATE TABLE "Post" (
 );
 ```
 
-**3. Add a new column with default value to the `Post` table**
+**3. Add a new column with a default value to the `Post` table**
 
 ```sql
 ALTER TABLE "Post"
@@ -71,13 +71,13 @@ prisma migrate save --experimental
 prisma migrate up --experimental
 ```
 
-The first command _saves_ a new migration to the file system and updates the `_Migration` table. It stores information about the migration in a dedicated directory inside the `migrations` directory. Each migration that is stored has its own `README.md` file which contains detailled information about the migration (e.g. the generated SQL statements which will be executed when you run `prisma migrate up`).
+The first command _saves_ a new migration to the file system and updates the `_Migration` table. It stores information about the migration in a dedicated directory inside the `prisma/migrations` directory of your project. Each migration that is stored has its own `README.md` file which contains detailed information about the migration (e.g. the generated SQL statements which will be executed when you run `prisma migrate up`).
 
 The second command _executes_ the migration against your database.
 
-**1. Create `User` table to store user information (name, email, ...)**
+**1. Create the `User` table to store user information (name, email, ...)**
 
-Add a model to your Prisma schema:
+Add the model to your Prisma schema:
 
 ```prisma
 model User {
@@ -96,7 +96,7 @@ prisma migrate up --experimental
 
 **2. Create two new tables `Post` and `Profile` with foreign keys to `User`**
 
-Add two models with [relation fields]() to your Prisma schema:
+Add two models with [relation fields](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/relations#relation-fields) to your Prisma schema:
 
 ```prisma
 model User {
@@ -120,7 +120,7 @@ model Post {
 }
 ```
 
-Notice that in addition to the [annotated relation fields](prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields) and its relation scalar field (which represent the foreign keys), you also must specify the Prisma-level [relation fields](prisma-schema/relations#relation-fields) on the other side of the relation.
+Notice that in addition to the [annotated relation fields](prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields) and its relation scalar field (which represent the foreign keys), you must also specify the Prisma-level [relation fields](prisma-schema/relations#relation-fields) on the other side of the relation.
 
 Now run the two commands mentioned above:
 
@@ -180,30 +180,30 @@ The following table shows which SQL operations are currently supported by Prisma
 | Make columns [optional/required]()  | `NOT NULL`                      |                                          ✔️                                          |
 | Set [unique constraints]()          | `UNIQUE`                        |                                          ✔️                                          |
 | Set [default]() values              | `DEFAULT`                       |                                          ✔️                                          |
-| Defining [enums]()                  | `ENUM`                          |                                          ✔️                                          |
+| Define [enums]()                  | `ENUM`                          |                                          ✔️                                          |
 | Create [indexes]()                  | `CREATE INDEX`                  |                                          ✔️                                          |
 | Cascading deletes                   | `ON DELETE`                     | Not yet ([workaround](../../guides/database-workflows/cascading-deletes/postgresql)) |
 | Cascading updates                   | `ON UPDATE`                     |                           Not yet (workaround coming soon)                           |
 | Data validation                     | `CHECK`                         |  Not yet ([workaround](../../guides/database-workflows/data-validation/postgresql))  |
 
-Note that this table assumes that the operation is also supported by the underlying database. For example, `ENUM` is not supported in SQLite, this means that you also can't use `enum` using Prisma Migrate.
+Note that this table assumes that the operation is also supported by the underlying database. For example, `ENUM` is not supported in SQLite. This means that you also can't use `enum` when using Prisma Migrate.
 
 ## Migration history
 
 Prisma Migrate stores the migration history of your project in two places:
 
 - A directory called `migrations` on your file system
-- A table called `_Migrations` in your database
+- A table called `_Migration` in your database
 
 ### The `migrations` directory
 
-The `migrations` directory stores information about the migrations that have been or will be executed against your database. You should never make any manual changes to the files in `migrations`, the only way to change the content of this directory should be using the `prisma migrate save` command.
+The `migrations` directory stores information about the migrations that have been or will be executed against your database. You should never make any manual changes to the files in `migrations`. The only way to change the content of this directory should be using the `prisma migrate save` command.
 
 The `migrations` directory should be checked into version control (e.g. Git).
 
-### The `_Migrations` table
+### The `_Migration` table
 
-The `_Migrations` table additionally stores information about each migration that was ever executed against the database by Prisma Migrate.
+The `_Migration` table additionally stores information about each migration that was ever executed against the database by Prisma Migrate.
 
 ## Typical workflow
 

--- a/content/03-reference/01-tools-and-interfaces/03-prisma-migrate.mdx
+++ b/content/03-reference/01-tools-and-interfaces/03-prisma-migrate.mdx
@@ -71,7 +71,7 @@ prisma migrate save --experimental
 prisma migrate up --experimental
 ```
 
-The first command _saves_ a new migration to the `prisma/migrations` directory in the file system of your project and updates the `_Migration` table in your database. It stores information about the migration in a new, dedicated directory inside the main `prisma/migrations` directory. Each migration that is stored has its own `README.md` file in its directory which contains detailed information about the migration (e.g. the generated SQL statements which will be executed when you run `prisma migrate up`).
+The first command _saves_ a new migration to the `prisma/migrations` directory in the file system of your project and updates the `_Migration` table in your database. Each time you run this command to save a new migration, it creates a dedicated directory inside of `prisma/migrations` for that specific migration, which will have its own `README.md` file containing detailed information about the migration (e.g. the generated SQL statements which will be executed when you run `prisma migrate up`).
 
 The second command _executes_ the migration against your database.
 


### PR DESCRIPTION
## Description

This PR contains a few types of minor fixes:
- A small typo/spelling mistake ("detailled" > "detailed")
- Some very small language details but that I think makes things a little bit clearer
- Tiny detail to make things consistent in the *Supported Operations* table (most use "define", "rename", "delete", but one was "defining")
- I think we were actually using the wrong name for the migration table. In one place we refer to it as `_Migration` and in several other places `_Migrations` (plural). I checked my database to be sure and the former is correct.