### PR TITLE
Added <kbd> styling, fixed vertical alignment of inline code

### DIFF
--- a/src/components/customMdx/prism/index.css
+++ b/src/components/customMdx/prism/index.css
@@ -55,7 +55,7 @@ pre[class*='language-'] {
 
 code.inline-code {
   display: inline;
-  vertical-align: middle;
+  vertical-align: baseline;
   padding: 0.2em 0.2em 0.3em 0.2em;
   background: var(--code-bgd-color);
   font-size: 14px;

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -145,6 +145,17 @@ li {
   line-height: 24px;
 }
 
+kbd {
+  background: var(--white-color);
+  box-shadow: 0px 1px 1px rgba(47, 55, 71, 0.6),0px 1px 4px rgba(47, 55, 71, 0.2);;
+  border-bottom: 1px solid  rgba(47, 55, 71, 0.2);
+  border-radius: 4px;
+  padding: 2px 6px;
+  vertical-align: baseline;
+  font-size: 14px;
+  font-family: 'Roboto Mono';
+}
+
 table {
   width: 100%;
   word-break: normal;


### PR DESCRIPTION
fixes #350 

Preview: 
![image](https://user-images.githubusercontent.com/753458/83068559-88155900-a036-11ea-970f-ecb4b34e9d16.png)

Also took the liberty of adjusting inline code blocks that were dipping under the baseline in majority of the instances
![image](https://user-images.githubusercontent.com/753458/83068631-9d8a8300-a036-11ea-93ab-c16a4ba607f9.png)

