### PR TITLE
Fix backward slash typos

### DIFF
--- a/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
+++ b/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
@@ -393,6 +393,7 @@ This command reads your Prisma schema and generates your Prisma Client library i
 
 The `@prisma/client` node module references a folder named `.prisma/client`, which contains your unique, generated Prisma client:
 
+// THIS IS BROKEN IN PROD
 ![The .prisma and @prisma folders](generating-prisma-client/prisma-client-node-module.png)
 
 ## Write your first query with Prisma Client

--- a/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
+++ b/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
@@ -382,7 +382,7 @@ To get started with Prisma Client, you need to install the `@prisma/client` pack
 npm install @prisma/client
 ```
 
-Notice that the [`@prisma/client` node module](/../../../reference/tools-and-interfaces/prisma-client/generating-prisma-client#the-prisma-client-npm-module) references a folder named `.prisma\client`. The `.prisma\client` folder contains your generated Prisma client, and is modified each time you change the schema and run the following command:
+Notice that the [`@prisma/client` node module](/../../../reference/tools-and-interfaces/prisma-client/generating-prisma-client#the-prisma-client-npm-module) references a folder named `.prisma/client`. The `.prisma/client` folder contains your generated Prisma client, and is modified each time you change the schema and run the following command:
 ```
 npx prisma generate
 ```


### PR DESCRIPTION
- Fix a couple of typos with back-slashes instead of forward-slashes in file paths.
- Fix broken link:
![image](https://user-images.githubusercontent.com/34203886/83717479-af949480-a5e7-11ea-8847-a5cfd4100940.png)
