### PR TITLE
fix(code): make bg more bright

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -16,7 +16,7 @@ body {
   --white-color: #ffffff;
   --link-color: #3182ce;
   --border-color: #e2e8f0;
-  --code-bgd-color: #edf2f7;
+  --code-bgd-color: #f6f8fa;
   --list-bullet-color: #a0aec0;
   --search-highlight-bg-color: #ebf8ff;
   --tag-media-color: #2d3748;


### PR DESCRIPTION
To have higher contrast and ease readability for the code blocks, I suggest using the same background color as the default GitHub syntax highlighting.

## Before

![image](https://user-images.githubusercontent.com/1094804/83732731-c5887080-a64c-11ea-84f4-87b5e6a99b2d.png)



## After

![image](https://user-images.githubusercontent.com/1094804/83732770-d507b980-a64c-11ea-80ea-5126cd9d575f.png)

