### PR TITLE
findMany input object type updates

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/02-prisma-client/04-crud.mdx
+++ b/content/03-reference/01-tools-and-interfaces/02-prisma-client/04-crud.mdx
@@ -209,11 +209,9 @@ export type FindManyUserArgs = {
   include?: UserInclude | null
   where?: UserWhereInput | null
   orderBy?: UserOrderByInput | null
+  cursor?: UserWhereUniqueInput | null
+  take?: number | null
   skip?: number | null
-  after?: UserWhereUniqueInput | null
-  before?: UserWhereUniqueInput | null
-  first?: number | null
-  last?: number | null
 }
 ```
 
@@ -264,10 +262,8 @@ export declare const OrderByArg: {
 | `where`   | `UserWhereInput`       | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                        |
 | `orderBy` | `UserOrderByInput`     | No       | Lets you order the returned list by any property.                                                           |
 | `skip`    | `string`               | No       | Specifies how many of the returned objects in the list should be skipped.                                   |
-| `after`   | `UserWhereUniqueInput` | No       | Specifies the starting object for the list (the value typically specifies an `id` or another unique value). |
-| `before`  | `UserWhereUniqueInput` | No       | Specifies the last object for the list (the value typically specifies an `id` or another unique value).     |
-| `first`   | `number`               | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ of the list).       |
-| `last`    | `number`               | No       | Specifies how many objects should be returned in the list (as seen from the _end_ of the list).             |
+| `cursor`   | `UserWhereUniqueInput` | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value). |
+| `take`   | `number`               | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (+ve value) or _end_ (-ve value) **either** of the list **or** from the `cursor` position if mentioned)  |
 | `select`  | `UserSelect`           | No       | Specifies which properties to include on the returned object.                                               |
 | `include` | `UserInclude`          | No       | Specifies which relations should be eagerly loaded on the returned object.                                  |
 


### PR DESCRIPTION
Well, Now the prisma-client generates "**cursor** and **take**" as of the **findMany**  object type removing "**after**, **before**, **first** and **last**"