### PR TITLE
Fix user model annotation on 1-1 relations

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/01-prisma-schema/06-relations.mdx
+++ b/content/03-reference/01-tools-and-interfaces/01-prisma-schema/06-relations.mdx
@@ -267,7 +267,7 @@ model Profile {
 
 In the code above, the `userId` relation scalar is a direct representation of the foreign key in the underlying database.
 
-This example annotates the relation field on the `Profile` model:
+This example annotates the relation field on the `User` model:
 
 ```prisma
 model User {


### PR DESCRIPTION
Example is annotated on the `User` model rather than on the `Profile` one