### PR TITLE
Remove duplicate example reference of `rest-nextjs`

### DIFF
--- a/content/02-understand-prisma/03-prisma-in-your-stack/01-rest.md
+++ b/content/02-understand-prisma/03-prisma-in-your-stack/01-rest.md
@@ -145,5 +145,4 @@ You can find several ready-to-run examples that show how to implement a REST API
 | :---------------------------------------------------------------------------------------------- | :--------- | ------------ | ----------------------------------------------------------------- |
 | [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/master/typescript/rest-nextjs)   | TypeScript | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API |
 | [`rest-express`](https://github.com/prisma/prisma-examples/tree/master/typescript/rest-express) | TypeScript | Backend only | Simple REST API with Express                                      |
-| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/master/javascript/rest-nextjs)   | JavaScript | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API |
 | [`rest-express`](https://github.com/prisma/prisma-examples/tree/master/javascript/rest-express) | JavaScript | Backend only | Simple REST API with Express                                      |


### PR DESCRIPTION
`rest-nextjs` example appears in two times.

![image](https://user-images.githubusercontent.com/7611746/85758024-ca16e500-b731-11ea-8dc3-83abd1b8821f.png)
