### PR TITLE
Typo: Filter all `Post` records examples

### DIFF
--- a/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
+++ b/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
@@ -689,8 +689,8 @@ Here are a few suggestions for a number of more queries you can send with Prisma
 const filteredPosts = await prisma.post.findMany({
   where: {
     OR: [
-      { title: { contains: "hello" },
-      { content: { contains: "hello" },
+      { title: { contains: "hello" } },
+      { content: { contains: "hello" } },
     ],
   },
 })


### PR DESCRIPTION
I believe there are missing brackets here.

Current:
```js
const filteredPosts = await prisma.post.findMany({
  where: {
    OR: [
      { title: { contains: "hello" },
      { content: { contains: "hello" },
    ],
  },
})
```

Proposed:

```js
const filteredPosts = await prisma.post.findMany({
  where: {
    OR: [
      { title: { contains: "hello" } },
      { content: { contains: "hello" } },
    ],
  },
})
```

Running the example with the Proposed solution works.