### PR TITLE
Fix : Diff block doesn't highlight first line #526

### DIFF
--- a/content/04-guides/03-upgrade-from-prisma-1/07-upgrading-a-rest-api.mdx
+++ b/content/04-guides/03-upgrade-from-prisma-1/07-upgrading-a-rest-api.mdx
@@ -472,7 +472,7 @@ model User {
   id      String    @id
   email   String    @unique
   name    String?
-+ posts   Post[]
++  posts   Post[]
   Profile Profile[]
 }
 ```
@@ -489,7 +489,7 @@ model User {
   email   String    @unique
   name    String?
   posts   Post[]
-+ profile Profile
++  profile Profile
 }
 ```
 
@@ -497,7 +497,7 @@ Finally, you need to ensure that the `id` field is populated with default values
 
 ```diff
 model User {
-+ id      String    @id @default(cuid())
++  id      String    @id @default(cuid())
   email   String    @unique
   name    String?
   posts   Post[]
@@ -551,8 +551,8 @@ The `@createdAt` attribute from Prisma 1 is represented via the `@default(now())
 ```diff
 model Post {
   id        String     @id
-+ createdAt DateTime   @default(now())
-+ updatedAt DateTime   @updatedAt
++  createdAt DateTime   @default(now())
++  updatedAt DateTime   @updatedAt
   published Boolean
   title     String
   content   String?
@@ -569,7 +569,7 @@ model Post {
   id        String     @id
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
-+ published Boolean    @default(false)
++  published Boolean    @default(false)
   title     String
   content   String?
   author    String?
@@ -592,8 +592,8 @@ model Post {
   published Boolean    @default(false)
   title     String
   content   String?
-+ authorId  String?    @map("author")
-+ author    User?      @relation(fields: [authorId], references: [id])
++  authorId  String?    @map("author")
++  author    User?      @relation(fields: [authorId], references: [id])
   Category  Category[] @relation(references: [id])
 }
 ```
@@ -610,7 +610,7 @@ model Post {
   content    String?
   authorId   String?    @map("author")
   author     User?      @relation(fields: [authorId], references: [id])
-+ categories Category[] @relation(references: [id])
++  categories Category[] @relation(references: [id])
 }
 ```
 
@@ -656,8 +656,8 @@ Similar to how the issue with the two relation fields was resolved on `Post` (by
 model Profile {
   id     String  @id
   bio    String?
-+ userId String? 
-+ user   User?   @relation(fields: [userId], references: [id])
++  userId String? 
++  user   User?   @relation(fields: [userId], references: [id])
 }
 ```
 
@@ -695,7 +695,7 @@ Because the `Post` relation field does not manifest in the database schema, you 
 model Category {
   id    String @id
   name  String
-+ posts Post[] @relation(references: [id])
++  posts Post[] @relation(references: [id])
 }
 ```
 

--- a/src/components/customMdx/code.tsx
+++ b/src/components/customMdx/code.tsx
@@ -81,20 +81,10 @@ const Code = ({ children, className, ...props }: PreCodeProps) => {
                   }
 
                   if (
-                    (line[0] &&
-                      line[0].content.length &&
-                      (line[0].content[0] === '+' ||
-                        line[0].content[0] === '-' ||
-                        line[0].content[0] === '|')) ||
-                    (line[0] &&
-                      line[0].content === '' &&
-                      line[1] &&
-                      (line[1].content === '+' ||
-                        line[1].content === '-' ||
-                        line[1].content === '|'))
+                    (line[0] && /[+|-]/.test(line[0].content[0])) ||
+                    (line[1] && /[+|-]/.test(line[1].content[0]))
                   ) {
-                    diffSymbol =
-                      line[0] && line[0].content.length ? line[0].content[0] : line[1].content
+                    diffSymbol = line[0] && line[0].content.length ? line[0].content[0] : line[1].content[0]
                     lineClass = {
                       backgroundColor: diffBgColorMap[diffSymbol],
                       symbColor: symColorMap[diffSymbol],
@@ -124,22 +114,15 @@ const Code = ({ children, className, ...props }: PreCodeProps) => {
                       )}
                       <LineContent className={`${tokenCopyClass}`}>
                         {line.map((token: any, key: any) => {
-                          if (isDiff) {
-                            if (
-                              ((key === 0 || key === 1) &&
-                                (token.content.charAt(0) === '+' ||
-                                  token.content.charAt(0) === '-')) ||
-                              token.content.charAt(0) === '|'
-                            ) {
-                              return (
-                                <span
-                                  {...getTokenProps({
-                                    token: { ...token, content: token.content.slice(1) },
-                                    key,
-                                  })}
-                                />
-                              )
-                            }
+                          if (isDiff && (key === 0 || key === 1) && /[+|-]/.test(token.content[0])) {
+                            return (
+                              <span
+                                {...getTokenProps({
+                                  token: { ...token, content: token.content.slice(1) },
+                                  key,
+                                })}
+                              />
+                            )
                           }
                           return <span {...getTokenProps({ token, key })} />
                         })}


### PR DESCRIPTION
Well, when using `diff`, you  **must add a single space** just after any used symbol so that it can be replaced by the symbol used when rendering 

fix #526