### PR TITLE
Fix ahmed tools links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ content/00-example.mdx
 
 # History
 .history/
+
+# webStorm settings
+.idea

--- a/content/04-guides/03-upgrade-from-prisma-1/02-schema-incompatibilities.mdx
+++ b/content/04-guides/03-upgrade-from-prisma-1/02-schema-incompatibilities.mdx
@@ -814,5 +814,5 @@ If your relation is configured via `table: INLINE`, you can still get the same b
 
 Cascading deletes are not yet supported in Prisma 2. For _inline_ relations, you can configure similar behaviour as in Prisma 1 in plain SQL (find the guides [here](../database-workflows/cascading-deletes/postgresql)). For relations that were represented as relation tables in Prisma 1, you won't be able to configure cascading deletes on the database layer for now and might have to resort to implementing it inside your application code with Prisma Client.
 
-> **Note**: If you need to implement cascading deletes in your application layer, this [tool](https://github.com/AhmedElywa/prisma-tools/tree/master/packages/delete) by our community member [Ahmed Elywa](https://github.com/AhmedElywa/) might come in handy. 
+> **Note**: If you need to implement cascading deletes in your application layer, this [tool](https://paljs.com/plugins/delete) by our community member [Ahmed Elywa](https://github.com/AhmedElywa/) might come in handy.
 

--- a/content/04-guides/03-upgrade-from-prisma-1/07-upgrading-a-rest-api.mdx
+++ b/content/04-guides/03-upgrade-from-prisma-1/07-upgrading-a-rest-api.mdx
@@ -39,7 +39,7 @@ Both scenarios will be covered in other upgrade guides that are [coming soon](ht
 
 In this guide, we'll take a look at migrating a REST API from Prisma 1 to Prisma 2.0 based on this [Prisma 1 example](https://github.com/prisma/prisma1-examples/tree/master/typescript/rest-express).
 
-> **Note**: If you're upgrading a project that uses `nexus-prisma`, be sure to check out [Robert Cooper](https://www.robertcooper.me/)'s [upgrade guide](https://www.robertcooper.me/migrating-prisma1-to-prisma2) as well as [Ahmed Elywa](https://github.com/AhmedElywa)'s project [`create-nexus-type`](https://github.com/oahtech/create-nexus-type) that converts Prisma models into Nexus `objectType` definitions.
+> **Note**: If you're upgrading a project that uses `nexus-prisma`, be sure to check out [Robert Cooper](https://www.robertcooper.me/)'s [upgrade guide](https://www.robertcooper.me/migrating-prisma1-to-prisma2) as well as [Ahmed Elywa](https://github.com/AhmedElywa)'s project [`create-nexus-type`](https://paljs.com/cli/cnt) that converts Prisma models into Nexus `objectType` definitions.
 
 ## 1. Install Prisma 2.0 CLI 
 


### PR DESCRIPTION
Update `create-nexus-type` and `cascading deletes` links  in upgrade from Prisma 1