### PR TITLE
docs(deployment): fix incorrect Serverless link

### DIFF
--- a/content/04-guides/02-deployment/02-deploying-to-aws-lambda.mdx
+++ b/content/04-guides/02-deployment/02-deploying-to-aws-lambda.mdx
@@ -37,7 +37,7 @@ exports.server = (event, context, cb) => {
 
 - Hosted PostgreSQL database and a URL from which it can be accessed, e.g. `postgresql://username:password@your_postgres_db.cloud.com/db_identifier` (you can use Heroku, which offers a [free plan](https://dev.to/prisma/how-to-setup-a-free-postgresql-database-on-heroku-1dc1)).
 - [AWS](https://aws.amazon.com/) account and a corresponding [access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey) for programmatic access.
-- [Serverless Framework CLI](https://docs.netlify.com/cli/get-started/) installed.
+- [Serverless Framework CLI](https://www.serverless.com/framework/docs/getting-started/) installed.
 - Node.js installed.
 - PostgreSQL CLI `psql` installed.
 


### PR DESCRIPTION
I think the installation link of the `Serverless Framework CLI` is not correctly documented.