### PR TITLE
Fixing typo in docs for relation table models

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/01-prisma-schema/06-relations.mdx
+++ b/content/03-reference/01-tools-and-interfaces/01-prisma-schema/06-relations.mdx
@@ -202,13 +202,13 @@ Here is an example for a relation table called `CategoriesOnPosts`:
 model Post {
   id         Int        @id @default(autoincrement())
   title      String
-  categories Category[]
+  categories CategoriesOnPosts[]
 }
 
 model Category {
   id    Int    @id @default(autoincrement())
   name  String
-  posts Post[]
+  posts CategoriesOnPosts[]
 }
 
 model CategoriesOnPosts {


### PR DESCRIPTION
While trying to create a relation table with Prisma, I found what I believe to be a typo in the docs.

We are referring to the actual models and not the relation model in the example, this PR fixes that.