### PR TITLE
feat: subsections rootpath + prefix-suffix for title

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,6 +2,8 @@ const config = {
   gatsby: {
     pathPrefix: '/docs',
     siteUrl: 'https://www.prisma.io',
+    titlePrefix: '',
+    titleSuffix: '',
   },
   redirects: [
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -115,6 +115,8 @@ module.exports = {
   siteMetadata: {
     pathPrefix: config.gatsby.pathPrefix,
     title: config.siteMetadata.title,
+    titlePrefix: config.gatsby.titlePrefix,
+    titleSuffix: config.gatsby.titleSuffix,
     description: config.siteMetadata.description,
     keywords: config.siteMetadata.keywords,
     twitter: config.siteMetadata.twitter,

--- a/src/components/customMdx/code.tsx
+++ b/src/components/customMdx/code.tsx
@@ -102,23 +102,18 @@ const Code = ({ children, className, ...props }: PreCodeProps) => {
                     isDiff = true
                   }
 
-                  // if (
-                  //   (line[0] && line[0].content.length && line[0].content[0] === '!') ||
-                  //   (line[0] && line[0].content === '' && line[1] && line[1].content === '!')
-                  // ) {
-                  //   isHidden = true
-                  // }
-
                   const lineProps = getLineProps({ line, key: i })
 
                   lineProps.style = { ...lineClass }
 
                   return (
                     <Line key={line + i} {...lineProps}>
-                      {hasTerminalSymbol && !isDiff && <LineNo>$</LineNo>}
-                      {!hasTerminalSymbol && !isDiff && !hasNoLine && <LineNo>{i + 1}</LineNo>}
+                      {hasTerminalSymbol && !isDiff && <LineNo className="line-no">$</LineNo>}
+                      {!hasTerminalSymbol && !isDiff && !hasNoLine && (
+                        <LineNo className="line-no">{i + 1}</LineNo>
+                      )}
                       {isDiff && (
-                        <LineNo style={{ color: lineClass.symbColor }}>
+                        <LineNo className="line-no" style={{ color: lineClass.symbColor }}>
                           {diffSymbol !== '|' ? diffSymbol : i + 1}
                         </LineNo>
                       )}

--- a/src/components/customMdx/subSections.tsx
+++ b/src/components/customMdx/subSections.tsx
@@ -9,13 +9,14 @@ import { withPrefix } from 'gatsby'
 
 interface SubsecProps {
   depth?: number
+  rootPath?: string
 }
 
 const SubsectionWrapper = styled.div`
   margin: 1.5rem 0;
 `
 
-const Subsections = ({ depth }: SubsecProps) => {
+const Subsections = ({ depth, rootPath }: SubsecProps) => {
   const { allMdx }: AllArticles = useAllArticlesQuery()
   const location = useLocation()
   const treeData = calculateTreeData(allMdx.edges, null, null)
@@ -39,7 +40,7 @@ const Subsections = ({ depth }: SubsecProps) => {
     }
   }
 
-  getSubSecs(location.pathname, treeData.items)
+  getSubSecs(rootPath ? rootPath : location.pathname, treeData.items)
 
   const list = (subsecs: any, dep: number) => {
     const subs = subsecs.filter((t: any) => t.label !== 'index' && !t.hidePage)

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -244,7 +244,6 @@ hr {
   padding-left: 20px;
   text-indent: -1em;
   margin-top: 10px;
-  display: flex;
 }
 
 .list li::before {
@@ -264,15 +263,13 @@ hr {
   clear: both;
 }
 
-.list li > * {
+.list li pre:first-child {
+  margin-top: -20px;
   margin-left: 8px;
-  margin-top: 0;
 }
 
-.list li pre {
-  width: 100%;
-  margin: 0;
-  padding-left: 20px;
+.list li pre .line-no {
+  width: 45px;
 }
 
 @media (min-width: 0px) and (max-width: 767px) {

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -16,6 +16,8 @@ const SEO = ({ title, description }: SEOProps) => {
   const {
     siteMetadata: {
       pathPrefix,
+      titlePrefix,
+      titleSuffix,
       siteUrl,
       keywords,
       twitter: { site: tSite, creator: tCreator, image: tUrl },
@@ -42,7 +44,9 @@ const SEO = ({ title, description }: SEOProps) => {
     <Helmet htmlAttributes={{ lang: 'en' }}>
       {/* <meta charSet="utf-8" /> */}
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>{seoTitle}</title>
+      <title>
+        {titlePrefix} {seoTitle} {titleSuffix}{' '}
+      </title>
       <meta name="description" content={seoDescription} />
       {keywords && <meta name="keywords" content={keywords} />}
       {/* Twitter */}
@@ -76,6 +80,8 @@ const query = graphql`
     site {
       siteMetadata {
         pathPrefix
+        titlePrefix
+        titleSuffix
         siteUrl
         twitter {
           site


### PR DESCRIPTION
#542 

Please add the required suffix and prefix in `config.js` under
```
gatsby: {
    pathPrefix: '/docs',
    siteUrl: 'https://www.prisma.io',
    titlePrefix: '',
    titleSuffix: '',
  },

```

#579 

Root path for subsections can be added using:

`<Subsections rootPath="/getting-started/"/>`