### PR TITLE
typography fixes

### DIFF
--- a/src/components/customMdx/switchTech.tsx
+++ b/src/components/customMdx/switchTech.tsx
@@ -15,7 +15,6 @@ export default SwitchTech
 
 const SwitchWrapper = styled.section`
   display: none;
-  margin-top: 2rem;
   position: relative;
   &.show {
     display: block;

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -85,9 +85,10 @@ h2 {
 
 section h3 {
   border-top: 1px solid var(--border-color);
-  padding: 24px 40px 0;
+  padding: 32px 40px 0;
   margin-left: -40px;
   margin-right: -40px;
+  margin-bottom: 0;
 }
 
 section h2,
@@ -141,7 +142,7 @@ img {
 }
 
 p {
-  margin: 1.5rem 0;
+  margin: 1rem 0;
 }
 
 p,
@@ -228,10 +229,12 @@ blockquote p {
 }
 
 hr {
-  border: 0.5px solid var(--border-color);
   margin: 2rem 0;
   margin-left: -40px;
   margin-right: -40px;
+  border: 0;
+  height: 1px;
+  background: var(--border-color);
 }
 
 .list {

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -10,7 +10,7 @@ import { withPrefix } from 'gatsby'
 const List = styled.ul`
   list-style: none;
   padding: 0;
-  margin: 16px 0;
+  margin: 12px 0 24px;
   &.has-border {
     border-left: 2px solid var(--border-color);
     margin-left: -12px;
@@ -45,7 +45,7 @@ const ListItem = styled.li`
       font-size: 14px;
       font-style: normal;
       font-weight: 600;
-      background: var(--code-bgd-color);
+      background: var(--code-inline-bgd-color);
       border-radius: 5px;
       padding: 2px 5px;
       &.small {
@@ -107,7 +107,7 @@ const ListItem = styled.li`
   &.top-level {
     margin-top: 2rem;
     > a {
-      font-size: 1rem;
+      font-size: 1.125rem;
       color: var(--main-font-color) !important;
       font-weight: 600;
       letter-spacing: -0.01em;
@@ -116,14 +116,14 @@ const ListItem = styled.li`
       }
     }
     > ul {
-      margin-top: 24px;
+      margin-top: 12px;
     }
   }
   &.bottom-level {
     margin-left: 20px;
   }
   &.static-link {
-    margin-top: 24px;
+    margin-top: 12px;
   }
   &.static-link > a {
     color: var(--main-font-color) !important;

--- a/src/components/topSection.tsx
+++ b/src/components/topSection.tsx
@@ -9,8 +9,8 @@ import { withPrefix } from 'gatsby'
 const TopSectionWrapper = styled.div`
   position: relative;
   hr.bigger-margin {
-    margin-top: 3.5rem;
-    margin-bottom: 4rem;
+    margin-top: 3rem;
+    margin-bottom: 3.5rem;
   }
   .tech-switch-block {
     position: relative;


### PR DESCRIPTION
- fixed hierarchy in the sidebar to have more discernible blocks instead of blending in
- fixed headings and paragraphs in main body text to flow better
- fixed tech switcher horizontal rule being 2px tall
- fixed #558 