### PR TITLE
Update Supported Databases to include Yugabyte

### DIFF
--- a/content/05-more/03-supported-databases.mdx
+++ b/content/05-more/03-supported-databases.mdx
@@ -21,5 +21,6 @@ Prisma currently supports the following databases:
 | SQLite                | \*      |
 | AWS Aurora            | \*      |
 | AWS Aurora Serverless | \*      |
+| YugabyteDB            | 2.1     |
 
 Note that a fixed version of SQLite is shipped with every Prisma release.


### PR DESCRIPTION
Yugabyte YSQL is wire-compatible with Postgres. There is no additional setup required to integrate with Prisma (other than changing the .env file to reflect the appropriate database connection URL - which is necessary for Postgres in the first place). 
For an example app using Yugabyte & Prisma, view https://github.com/vvkgopalan/yugabyte-prisma2-examples/