### PR TITLE
Heroku API Doc Minor Improvement

### DIFF
--- a/content/04-guides/02-deployment/00-deploying-to-heroku.md
+++ b/content/04-guides/02-deployment/00-deploying-to-heroku.md
@@ -196,7 +196,7 @@ Connection URL:
    postgresql://__USER__:__PASSWORD__@__HOST__:__PORT__/__DATABASE__
 ```
 
-Copy the connection URL and set it as an environment variable:
+Copy the connection URL and set it as an environment variable (make sure your .env is located in the prisma directory): 
 
 ```no-lines
 export DATABASE_URL="postgresql://__USER__:__PASSWORD__@__HOST__:__PORT__/__DATABASE__"


### PR DESCRIPTION
Made the mistake of creating a `.env` file in the root directory and when I tried to run `npx prisma migrate save --experimental --name "init"` it would result in the following:
```
Error: Get config {"is_panic":false,"message":"error: Environment variable not found: DATABASE_URL.\n  -->  schema.prisma:7\n   | \n 6 |   provider = \"postgresql\"\n 7 |   url      = env(\"DATABASE_URL\")\n   | \n\nValidation Error Count: 1","meta":{"full_error":"error: Environment variable not found: DATABASE_URL.\n  -->  schema.prisma:7\n   | \n 6 |   provider = \"postgresql\"\n 7 |   url      = env(\"DATABASE_URL\")\n   | \n\nValidation Error Count: 1"},"error_code":"P1012"}
```

Look me awhile to figure out that I needed to add the .env file in the prisma directory.

This is probably a noob mistake but I thought I would bring this up.