### PR TITLE
Update 08-working-with-json.mdx

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/02-prisma-client/08-working-with-json.mdx
+++ b/content/03-reference/01-tools-and-interfaces/02-prisma-client/08-working-with-json.mdx
@@ -122,8 +122,6 @@ const createUser = await prisma.user.create({
 });
 ```
 
-The `Json` field also accepts   
-
 > **Note**: Javascript objects (for example, `{ pets: "none"}`) are automatically converted to JSON.
 
 ### Filter on a `Json` field

--- a/content/03-reference/01-tools-and-interfaces/02-prisma-client/08-working-with-json.mdx
+++ b/content/03-reference/01-tools-and-interfaces/02-prisma-client/08-working-with-json.mdx
@@ -158,7 +158,7 @@ var json = { pets: [{ name: "Sob the dog" }, { name: "Claudine the cat" }] };
 const get = await prisma.user.findMany({
   where: {
     extendedProfile: {
-      equals: json,
+      not: json,
     },
   },
 });


### PR DESCRIPTION
Small typo fix.

Besides that question
In the example:
> The following example returns all users where the `extendedProfile` field does **not** match `json`: 

```
const get = await prisma.user.findMany({
  where: {
    extendedProfile: {
      equals: json,
    },
  },
}
```


Did you intend on using `equals` or `not`?