### PR TITLE
Add missing `profileId` field in example code (Doc)

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/01-prisma-schema/06-relations.mdx
+++ b/content/03-reference/01-tools-and-interfaces/01-prisma-schema/06-relations.mdx
@@ -620,8 +620,9 @@ model Profile {
 
 ```prisma
 model User {
-  id        Int       @id @default(autoincrement())
-  profile   Profile?  @relation(fields: [profileId], references: [id]) // references `id` of `Profile`
+  id         Int       @id @default(autoincrement())
+  profile    Profile?  @relation(fields: [profileId], references: [id]) // references `id` of `Profile`
+  profileId  Int?      // relation scalar field (used in the `@relation` attribute above)
 }
 
 model Profile {


### PR DESCRIPTION
The code example in `One-to-one relations` below: 
```
model User {
  id        Int       @id @default(autoincrement())
  profile   Profile?  @relation(fields: [profileId], references: [id]) // references `id` of `Profile`
}

model Profile {
  id   Int    @id @default(autoincrement())
  user User?
}
```
produces `Error validating` below:

```
Error validating: The argument fields must refer only to existing fields. The following fields do not exist in this model: profileId
```