### PR TITLE
fix(introspection): order fields by same order as database

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/04-introspection.mdx
+++ b/content/03-reference/01-tools-and-interfaces/04-introspection.mdx
@@ -210,8 +210,8 @@ model User {
 }
 
 model Post {
-  author Int
   id     Int  @default(autoincrement()) @id
+  author Int
   User   User @relation(fields: [author], references: [id])
 }
 ```
@@ -235,8 +235,8 @@ Prisma generally omits the `name` argument on the [`@relation`](prisma-schema/re
 
 ```prisma
 model Post {
-  author Int
   id     Int  @default(autoincrement()) @id
+  author Int
   User   User @relation(fields: [author], references: [id])
 }
 ```
@@ -260,9 +260,9 @@ In this case, Prisma needs to [disambiguate the relation](prisma-schema/relation
 
 ```prisma
 model Post {
+  id                          Int   @default(autoincrement()) @id
   author                      Int
   favoritedBy                 Int?
-  id                          Int   @default(autoincrement()) @id
   User_Post_authorToUser      User  @relation("Post_authorToUser", fields: [author], references: [id])
   User_Post_favoritedByToUser User? @relation("Post_favoritedByToUser", fields: [favoritedBy], references: [id])
 }


### PR DESCRIPTION
Introspection now orders the fields by the same order as they are defined in the database.