### PR TITLE
VARCHAR type change

### DIFF
--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -225,7 +225,7 @@ CREATE TABLE "public"."User" (
 
 CREATE TABLE "public"."Post" (
   id SERIAL PRIMARY KEY NOT NULL,
-  title TEXT NOT NULL,
+  title VARCHAR(255) NOT NULL,
   "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
   content TEXT,
   published BOOLEAN NOT NULL DEFAULT false,
@@ -860,7 +860,6 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 | [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/master/javascript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
 | [`rest-express`](https://github.com/prisma/prisma-examples/tree/master/javascript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
 | [`grpc`](https://github.com/prisma/prisma-examples/tree/master/javascript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
-
 
 
 

--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -241,6 +241,8 @@ CREATE TABLE "public"."Profile" (
 );
 ```
 
+See [type mapping between PostgreSQL to Prisma schema during introspection](../../reference/database-connectors/postgresql#introspection) for information about what each databas type maps to in the Prisma Schema.
+
 > **Note**: Some fields are written in double-quotes to ensure PostgreSQL uses proper casing. If no double-quotes were used, PostgreSQL would just read everything as _lowercase_ characters.
 
 You can create the tables using any PostgreSQL client of your choice. If you're using `psql`, you can now create the tables using the following command:

--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -220,7 +220,7 @@ In this guide, you'll use plain SQL to create the tables in your database. Creat
 CREATE TABLE "public"."User" (
   id SERIAL PRIMARY KEY NOT NULL,
   name VARCHAR(255),
-  email TEXT UNIQUE NOT NULL
+  email VARCHAR(255) UNIQUE NOT NULL
 );
 
 CREATE TABLE "public"."Post" (
@@ -860,7 +860,6 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 | [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/master/javascript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
 | [`rest-express`](https://github.com/prisma/prisma-examples/tree/master/javascript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
 | [`grpc`](https://github.com/prisma/prisma-examples/tree/master/javascript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
-
 
 
 

--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -219,13 +219,13 @@ In this guide, you'll use plain SQL to create the tables in your database. Creat
 ```sql copy
 CREATE TABLE "public"."User" (
   id SERIAL PRIMARY KEY NOT NULL,
-  name VARCHAR(255),
-  email VARCHAR(255) UNIQUE NOT NULL
+  name TEXT,
+  email TEXT UNIQUE NOT NULL
 );
 
 CREATE TABLE "public"."Post" (
   id SERIAL PRIMARY KEY NOT NULL,
-  title VARCHAR(255) NOT NULL,
+  title TEXT NOT NULL,
   "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
   content TEXT,
   published BOOLEAN NOT NULL DEFAULT false,

--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -241,7 +241,7 @@ CREATE TABLE "public"."Profile" (
 );
 ```
 
-See [type mapping between PostgreSQL to Prisma schema during introspection](../../reference/database-connectors/postgresql#introspection) for information about what each databas type maps to in the Prisma Schema.
+See [type mapping between PostgreSQL to Prisma schema during introspection](../../reference/database-connectors/postgresql#introspection) for information about what each database type maps to in the Prisma Schema.
 
 > **Note**: Some fields are written in double-quotes to ensure PostgreSQL uses proper casing. If no double-quotes were used, PostgreSQL would just read everything as _lowercase_ characters.
 
@@ -862,6 +862,5 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 | [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/master/javascript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
 | [`rest-express`](https://github.com/prisma/prisma-examples/tree/master/javascript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
 | [`grpc`](https://github.com/prisma/prisma-examples/tree/master/javascript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
-
 
 

--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -219,7 +219,7 @@ In this guide, you'll use plain SQL to create the tables in your database. Creat
 ```sql copy
 CREATE TABLE "public"."User" (
   id SERIAL PRIMARY KEY NOT NULL,
-  name TEXT,
+  name VARCHAR(255),
   email TEXT UNIQUE NOT NULL
 );
 
@@ -860,7 +860,6 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 | [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/master/javascript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
 | [`rest-express`](https://github.com/prisma/prisma-examples/tree/master/javascript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
 | [`grpc`](https://github.com/prisma/prisma-examples/tree/master/javascript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
-
 
 
 


### PR DESCRIPTION
According to this section of the guide https://www.prisma.io/docs/reference/database-connectors/postgresql#type-mapping-between-postgresql-to-prisma-schema String is mapped to "TEXT". To be consistent I believe this should be set as TEXT in the CREATE TABLE commands here. Also, If users use VARCHAR(255) they will see trailing white space on their string types. (as seen here https://github.com/prisma/prisma/discussions/3198).