### PR TITLE
Fixed incorrectly marked example in postgres docs

### DIFF
--- a/content/03-reference/02-database-connectors/03-postgresql.mdx
+++ b/content/03-reference/02-database-connectors/03-postgresql.mdx
@@ -200,7 +200,7 @@ model Device {
 }
 ```
 
-Fields with types that **do not yet have a match in the Prisma schema (and are not yet supported)** will be also be added as comments to the Prisma schema as comments using the PostgreSQL type, e.g. `macaddr` would be added to a model as follows:
+Fields with types that **do not yet have a match in the Prisma schema (and are not yet supported)** will be also be added as comments to the Prisma schema as comments using the PostgreSQL type, e.g. `xml` would be added to a model as follows:
 
 ```prisma
 model Device {


### PR DESCRIPTION
The last example is for xml not macaddr