### PR TITLE
update mysql datasource to use port 3306

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/01-prisma-schema/02-data-sources.mdx
+++ b/content/03-reference/01-tools-and-interfaces/01-prisma-schema/02-data-sources.mdx
@@ -46,13 +46,13 @@ In this example, the target database is available with the following credentials
 - User: `johndoe`
 - Password: `mypassword`
 - Host: `localhost`
-- Post: `5432`
+- Post: `3306`
 - Database name: `mydb`
 
 ```prisma
 datasource mysql {
   provider = "mysql"
-  url      = "mysql://johndoe:mypassword@localhost:5432/mydb"
+  url      = "mysql://johndoe:mypassword@localhost:3306/mydb"
 }
 ```
 


### PR DESCRIPTION
It must be pretty annoying for the people like me who copy and paste this frequently from the docs. Changed it to use default Mysql port.