### PR TITLE
docs(error-formatting): add examples for all errorFormats

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/02-prisma-client/150-error-formatting.mdx
+++ b/content/03-reference/01-tools-and-interfaces/02-prisma-client/150-error-formatting.mdx
@@ -41,6 +41,17 @@ It can be used like so:
 
 ```ts
 const prisma = new PrismaClient({
+  errorFormat: 'pretty',
+})
+```
+
+```ts
+const prisma = new PrismaClient({
+  errorFormat: 'colorless',
+})
+```
+```ts
+const prisma = new PrismaClient({
   errorFormat: 'minimal',
 })
 ```


### PR DESCRIPTION
This lets me copy/paste any of the possible values instead of having to copy paste the existing one, and then change it to the one I want.