### PR TITLE
Correct Prisma Float type mapping for PostgreSQL

### DIFF
--- a/content/03-reference/02-database-connectors/03-postgresql.mdx
+++ b/content/03-reference/02-database-connectors/03-postgresql.mdx
@@ -129,7 +129,7 @@ The PostgreSQL connector maps the [scalar types](../tools-and-interfaces/prisma-
 | `String`   | `text`      |
 | `Boolean`  | `boolean`   |
 | `Int`      | `integer`   |
-| `Float`    | `real`      |
+| `Float`    | `decimal(65,30)`      |
 | `Datetime` | `timestamp` |
 | `Json`     | `jsonb`     |
 


### PR DESCRIPTION
Corrects the type mapping documentation regarding Prisma's Float. 

In reality, Prisma Migrate maps a Prisma **Float** to a PostgreSQL **decimal(65,30)**. This is also what the docs say in the [Prisma Schema API Reference](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-reference/#float).