### PR TITLE
Fix missing brackets in docs for Prisma middleware

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/02-prisma-client/180-middleware.mdx
+++ b/content/03-reference/01-tools-and-interfaces/02-prisma-client/180-middleware.mdx
@@ -16,11 +16,11 @@ const prisma = new PrismaClient()
 |prisma.$use(async (params, next) => {
 |    const result = next(params);
 |    return result;
-|}
+|});
 
 |prisma.$use(async (params, next) => {
 |    return next(params);
-|}
+|});
 
 // Queries here
 ```


### PR DESCRIPTION
Missing brackets in first 2 code examples