### PR TITLE
Updates schema to match example project.

### DIFF
--- a/content/04-guides/02-deployment/01-deploying-to-vercel.mdx
+++ b/content/04-guides/02-deployment/01-deploying-to-vercel.mdx
@@ -137,26 +137,28 @@ Prisma will introspect the database defined in the `datasource` block of the Pri
 
 ```prisma
 model Post {
-  author_id Int?
-  content   String?
-  post_id   Int     @default(autoincrement()) @id
+  id        Int      @default(autoincrement()) @id
   title     String
-  User      User?   @relation(fields: [author_id], references: [user_id])
+  createdAt DateTime @default(now())
+  content   String?
+  published Boolean  @default(false)
+  authorId  Int
+  User      User     @relation(fields: [authorId], references: [id])
 }
 
 model Profile {
-  bio        String?
-  profile_id Int     @default(autoincrement()) @id
-  user_id    Int
-  User       User    @relation(fields: [user_id], references: [user_id])
+  id     Int     @default(autoincrement()) @id
+  bio    String?
+  userId Int     @unique
+  User   User    @relation(fields: [userId], references: [id])
 }
 
 model User {
-  email   String    @unique
+  id      Int      @default(autoincrement()) @id
   name    String?
-  user_id Int       @default(autoincrement()) @id
+  email   String   @unique
   Post    Post[]
-  Profile Profile[]
+  Profile Profile?
 }
 ```
 
@@ -191,26 +193,28 @@ Based on that logic, rename the relation fields to better adhere to the [naming 
 
 ```prisma
 model Post {
-  post_id   Int     @default(autoincrement()) @id
-  author_id Int?
-  content   String?
+  id        Int      @default(autoincrement()) @id
   title     String
-  author      User?   @relation(fields: [author_id], references: [user_id]) // renamed from `User` -> `author`
+  createdAt DateTime @default(now())
+  content   String?
+  published Boolean  @default(false)
+  authorId  Int
+  author    User     @relation(fields: [authorId], references: [id])
 }
 
 model Profile {
-  bio        String?
-  profile_id Int     @default(autoincrement()) @id
-  user_id    Int
-  user       User    @relation(fields: [user_id], references: [user_id]) // renamed from `User` -> `user`
+  id     Int     @default(autoincrement()) @id
+  bio    String?
+  userId Int     @unique
+  author User    @relation(fields: [userId], references: [id])
 }
 
 model User {
-  email   String    @unique
+  id      Int      @default(autoincrement()) @id
   name    String?
-  user_id Int       @default(autoincrement()) @id
-  posts    Post[] // renamed from `Post` -> `posts`
-  profiles Profile[] // renamed from `User` -> `profiles`
+  email   String   @unique
+  post    Post[]
+  profile Profile?
 }
 ```
 


### PR DESCRIPTION
Pasting in the code in the **Rename the relation fields for easy access** currently breaks the tutorial. The schema in the example project appears to have changed since this article was originally written. This PR updates the code to its current schema and applies the changes described in **Rename the relation fields for easy access** to this new schema.