### PR TITLE
Fix: Icon for "edit" line higlhight are not rendered #740

### DIFF
--- a/src/components/customMdx/code.tsx
+++ b/src/components/customMdx/code.tsx
@@ -127,7 +127,7 @@ const Code = ({ children, className, ...props }: PreCodeProps) => {
                       )}
                       {isDiff && (
                         <LineNo className="line-no" style={{ color: lineClass.symbColor }}>
-                          {['+', '-'].includes(diffSymbol) ? diffSymbol : i + 1}
+                          {['+', '-','✎'].includes(diffSymbol) ? diffSymbol : i + 1}
                         </LineNo>
                       )}
                       <LineContent className={`${tokenCopyClass}`}>


### PR DESCRIPTION
Show '✎' icon on render  #740