### PR TITLE
Fix :  error showing line numbers on code blocks,  blocks using 'highlights' without line-nos

### DIFF
--- a/src/components/customMdx/code.tsx
+++ b/src/components/customMdx/code.tsx
@@ -131,7 +131,7 @@ const Code = ({ children, className, ...props }: PreCodeProps) => {
                       {!hasTerminalSymbol && !isDiff && !hasNoLine && (
                         <LineNo className="line-no">{i + 1}</LineNo>
                       )}
-                      {isDiff && (
+                      {isDiff && !hasNoLine && (
                         <LineNo className="line-no" style={{ color: lineClass.symbColor }}>
                           {['+', '-','✎'].includes(diffSymbol) ? diffSymbol : i + 1}
                         </LineNo>


### PR DESCRIPTION
Error : showing line numbers on code blocks, using 'highlights' without line-nos

![showing_line_numbers](https://user-images.githubusercontent.com/24385409/92727486-d3a50600-f38c-11ea-97a5-62e925b5cd94.jpg)


check an example on : https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-reference#--modifier