### PR TITLE
fix(under-the-hood): Move confirmation step away from .env file

### DIFF
--- a/content/02-understand-prisma/05-under-the-hood.mdx
+++ b/content/02-understand-prisma/05-under-the-hood.mdx
@@ -59,37 +59,12 @@ By default, all binaries are automatically downloaded into the `node_modules/@pr
 * Automated download of binaries is not possible.
 * You have created your own engine binary (for testing, or for an OS that is not officially supported).
 
-Use the following environment variables to specify custom locations for your binaries:
+1. Use the following environment variables to specify custom locations for your binaries:
 
-* `PRISMA_QUERY_ENGINE_BINARY` (Query engine)
-* `PRISMA_MIGRATION_ENGINE_BINARY` (Migration engine)
-* `PRISMA_INTROSPECTION_ENGINE_BINARY` (Introspection engine)
-* `PRISMA_FMT_BINARY` (for `npx prisma format`)
-
-
-#### The `prisma/.env` file
-
-To set an environment variable in the `prisma/.env` file:
-
-1. Add the environment variable to the `prisma/.env` file:
-
-   <TabbedContent tabs={[<FileWithIcon text="Unix, MacOS" icon="code"/>  , <FileWithIcon text="Windows" icon="display"/>]}>	
-
-   <tab>
-
-   ```
-   PRISMA_QUERY_ENGINE_BINARY=custom/path/my-query-engine-binary
-   ```
-
-   </tab>
-   <tab>
-
-   ```
-   PRISMA_QUERY_ENGINE_BINARY=c:\custom\path\my-query-engine-binary
-   ```
-
-   </tab>
-   </TabbedContent>
+   * `PRISMA_QUERY_ENGINE_BINARY` (Query engine)
+   * `PRISMA_MIGRATION_ENGINE_BINARY` (Migration engine)
+   * `PRISMA_INTROSPECTION_ENGINE_BINARY` (Introspection engine)
+   * `PRISMA_FMT_BINARY` (for `npx prisma format`)
 
 2. Run the following command to output the paths to all binaries:
 
@@ -124,6 +99,28 @@ To set an environment variable in the `prisma/.env` file:
 
     </tab>
     </TabbedContent>
+    
+#### The `prisma/.env` file
+
+You can also set environment variables in the `prisma/.env` file:
+
+<TabbedContent tabs={[<FileWithIcon text="Unix, MacOS" icon="code"/>  , <FileWithIcon text="Windows" icon="display"/>]}>	
+
+<tab>
+
+```
+PRISMA_QUERY_ENGINE_BINARY=custom/path/my-query-engine-binary
+```
+
+</tab>
+<tab>
+
+```
+PRISMA_QUERY_ENGINE_BINARY=c:\custom\path\my-query-engine-binary
+```
+
+</tab>
+</TabbedContent>
 
 > **Note**: It is possible to [use an `.env` file in a location outside the `prisma` folder](../reference/tools-and-interfaces/prisma-schema#manage-env-files-manually).
 


### PR DESCRIPTION
The `2. Run the following command to output the paths to all binaries` step applies to all ways to set the ENV variables, so this makes sense in this suggested location I think.

(The "The `prisma/.env` file" section could possibly be replaced by a link completely)