### PR TITLE
Update AWS serverless programming model link

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/02-prisma-client/190-deployment.mdx
+++ b/content/03-reference/01-tools-and-interfaces/02-prisma-client/190-deployment.mdx
@@ -78,7 +78,7 @@ mysql://USER:PASSWORD@HOST:PORT/DATABASE?connection_limit=1
 
 Serverless environments have the concept of warm starts which means that for subsequent invocations of the same function it may use an already existing container that has the allocated processes, memory, file system (`/tmp` is writable on AWS Lambda), and even DB connection still available.
 
-Typically, any piece of code [outside the handler](https://docs.aws.amazon.com/lambda/latest/dg/programming-model-v2.html) remains initialized. This is a great place for
+Typically, any piece of code [outside the handler](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel) remains initialized. This is a great place for
 `PrismaClient` to call `connect` or at least call `PrismaClient` constructor so that subsequent invocations can share a connection. There are some implications though that are not directly related to Prisma Client JS but any system that would require a DB connection from serverless environment:
 
 | Implication               | Description                                                                                                                                                                                                                                                                                                                           | Potential Solution                                                                                                                                               |


### PR DESCRIPTION
The previous link is redirected to a new route that doesn't immediately talk about the programming model.