### PR TITLE
Use correct casing in GitHub

### DIFF
--- a/config.js
+++ b/config.js
@@ -86,7 +86,7 @@ const config = {
     community: [
       { name: 'Meet the community', link: 'https://www.prisma.io/community' },
       { name: 'Slack', link: 'https://slack.prisma.io/' },
-      { name: 'Github', link: 'https://github.com/prisma' },
+      { name: 'GitHub', link: 'https://github.com/prisma' },
       { name: 'Discussions', link: 'https://github.com/prisma/prisma/discussions' },
       { name: 'GraphQL Meetup', link: 'https://www.meetup.com/graphql-berlin/' },
       { name: 'TypeScript Meetup', link: 'https://www.meetup.com/TypeScript-Berlin/' },

--- a/content/04-guides/02-deployment/04-deploying-to-netlify.mdx
+++ b/content/04-guides/02-deployment/04-deploying-to-netlify.mdx
@@ -19,15 +19,15 @@ The application has the following components:
 
 The focus of this guide is showing how Prisma integrates with Netlify. The starting point will the [Prisma Netlify example](https://github.com/prisma/deployment-example-netlify) which has a couple of REST endpoints preconfigured as serverless functions and a static HTML page.
 
-With Netlify, the fundamental building block is a [**Site**](https://docs.netlify.com/configure-builds/get-started/). Sites are typically connected to a Git repository and have a publicly accessible URL that looks like `https://site-name.netlify.com`. In this guide, you will connect a Github repository to a Netlify site.
+With Netlify, the fundamental building block is a [**Site**](https://docs.netlify.com/configure-builds/get-started/). Sites are typically connected to a Git repository and have a publicly accessible URL that looks like `https://site-name.netlify.com`. In this guide, you will connect a GitHub repository to a Netlify site.
 
 > Throughout the guide you'll find various **checkpoints** that enable you to validate whether you performed the steps correctly.
 
 ## Prerequisites
 
-- Github account
+- GitHub account
 - Hosted PostgreSQL database and a URL from which it can be accessed, e.g. `postgresql://username:password@your_postgres_db.cloud.com/db_identifier` (you can use Heroku, which offers a [free plan](https://dev.to/prisma/how-to-setup-a-free-postgresql-database-on-heroku-1dc1)).
-- [Netlify](https://app.netlify.com/signup) account connected to your Github account (Netlify will need access to the repository you will create as part of this guide).
+- [Netlify](https://app.netlify.com/signup) account connected to your GitHub account (Netlify will need access to the repository you will create as part of this guide).
 - [Netlify CLI](https://docs.netlify.com/cli/get-started/) installed.
 - Node.js installed.
 - PostgreSQL CLI `psql` installed.

--- a/src/components/pageBottom.tsx
+++ b/src/components/pageBottom.tsx
@@ -158,7 +158,7 @@ const PageBottom = ({ editDocsPath }: any) => {
                   Tell us why on GitHub!
                 </P>
                 <Button target="_blank" href={gitIssueUrl} type="primary" color="dark">
-                  Tell us On Github
+                  Tell us On GitHub
                 </Button>
               </>
             ) : (
@@ -177,7 +177,7 @@ const PageBottom = ({ editDocsPath }: any) => {
       )}
       {editDocsPath && (
         <Link className="edit-git" to={`${editDocsPath}`}>
-          Edit this page on Github
+          Edit this page on GitHub
         </Link>
       )}
     </PageBottomWrapper>


### PR DESCRIPTION
See https://www.prisma.io/docs/more/style-guide#capitalize-and-spell-out-proper-nouns

There were some references in the code (JSX) that used `Github` but I wasn't sure if that should be updated as well because e.g. `YouTube` was spelt as `Youtube`. I'm happy to change those occurrences though.

If this PR is accepted, would you mind adding a `hacktoberfest-accepted` label?