### PR TITLE
fix (raw access): use $queryRaw

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/02-prisma-client/090-raw-database-access.mdx
+++ b/content/03-reference/01-tools-and-interfaces/02-prisma-client/090-raw-database-access.mdx
@@ -23,14 +23,14 @@ Use cases for raw SQL include:
 `$queryRaw` returns actual database records. For example, the following `SELECT` query returns all fields for each record in the `User` table:
 
 ```ts no-lines
-const result = await prisma.queryRaw('SELECT * FROM User;')
+const result = await prisma.$queryRaw('SELECT * FROM User;')
 ```
 
 The same method is implemented as a [tagged template](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates), which makes it easier to use [variables](#using-variables) by providing **placeholders**. The following example includes an `${email}` placeholder:
 
 ```ts no-lines
 const email = 'edna@prisma.io'
-const result = await prisma.queryRaw`SELECT * FROM User WHERE email = ${email};`
+const result = await prisma.$queryRaw`SELECT * FROM User WHERE email = ${email};`
 ```
 
 ### Return type
@@ -49,7 +49,7 @@ You can also [type the results of `$queryRaw`](#typing-queryraw-results).
 ### Signature
 
 ```ts no-lines
-queryRaw<T = any>(query: string | TemplateStringsArray, ...values: any[]): Promise<T>;
+$queryRaw<T = any>(query: string | TemplateStringsArray, ...values: any[]): Promise<T>;
 ```
 
 ### Typing `$queryRaw` results
@@ -57,7 +57,7 @@ queryRaw<T = any>(query: string | TemplateStringsArray, ...values: any[]): Promi
 You can adjust the return type of `$queryRaw` with a [TypeScript Generic](https://www.typescriptlang.org/docs/handbook/generics.html). `$queryRaw` has the following signature:
 
 ```ts no-lines
-queryRaw<T = any>(query: string | TemplateStringsArray): Promise<T>;
+$queryRaw<T = any>(query: string | TemplateStringsArray): Promise<T>;
 ```
 
 `Promise<T>` uses [generic type parameter `T`](https://www.typescriptlang.org/docs/handbook/generics.html). You can determine the type of `T` when you invoke the `$queryRaw` command. In the following example, `$queryRaw` returns `User[]`:
@@ -66,7 +66,7 @@ queryRaw<T = any>(query: string | TemplateStringsArray): Promise<T>;
 // import the generated `User` type from the `@prisma/client` module
 import { User } from '@prisma/client'
 
-const result = await prisma.queryRaw<User[]>('SELECT * FROM User;')
+const result = await prisma.$queryRaw<User[]>('SELECT * FROM User;')
 // result is of type: `User[]`
 ```
 
@@ -94,7 +94,7 @@ model Post {
 The following query returns all posts and prints out the value of each post's `published` property:
 
 ```ts
-const result = await prisma.queryRaw<Post[]>`SELECT * FROM Post`
+const result = await prisma.$queryRaw<Post[]>`SELECT * FROM Post`
 
 result.forEach(x => {
   console.log(x.published)
@@ -121,7 +121,7 @@ The same method is implemented as a [tagged template](https://developer.mozilla.
 const emailValidated = true
 const active = true
 
-const result: number = await prisma.executeRaw`UPDATE User SET active = ${active} WHERE emailValidated = ${emailValidated};`
+const result: number = await prisma.$executeRaw`UPDATE User SET active = ${active} WHERE emailValidated = ${emailValidated};`
 ```
 
 Be aware that:
@@ -136,7 +136,7 @@ Be aware that:
 ### Signature
 
 ```ts
-executeRaw<T = any>(query: string | TemplateStringsArray, ...values: any[]): Promise<number>;
+$executeRaw<T = any>(query: string | TemplateStringsArray, ...values: any[]): Promise<number>;
 ```
 
 ## Using variables
@@ -192,7 +192,7 @@ As an alternative to tagged templates, `$queryRaw()` and `$executeRaw()` support
 ```ts
 const userName = 'Sarah'
 const email = 'alice@prisma.io'
-const result = await prisma.queryRaw(
+const result = await prisma.$queryRaw(
   'SELECT * FROM User WHERE (name = ? OR email = ?)', // MySQL variable, represented by ?
   userName,
   email
@@ -204,7 +204,7 @@ The following example uses a PostgreSQL query:
 ```ts
 const userName = 'Sarah'
 const email = 'alice@prisma.io'
-const result = await prisma.queryRaw(
+const result = await prisma.$queryRaw(
   'SELECT * FROM User WHERE (name = $1 OR email = $2)', // PostgreSQL variables, represented by $1 and $2
   userName,
   email
@@ -222,7 +222,7 @@ When you use `ILIKE`, the `%` wildcard character(s) should be included in the va
 ```ts
 const userName = "Sarah";
 const emailFragment = "prisma.io";
-const result = await prisma.queryRaw(
+const result = await prisma.$queryRaw(
   'SELECT * FROM "User" WHERE (name = $1 OR email = $2)', // Using %$2 here would not work
   userName,
   `%${emailFragment}`
@@ -245,7 +245,7 @@ The following example concatanates `query`and `inputString`. Prisma Client ❌ *
 ```ts
 const inputString = '"Sarah" UNION SELECT id, title, content FROM Post' // SQL Injection
 const query = 'SELECT id, name, email FROM User WHERE name = ' + inputString
-const result = await prisma.queryRaw(query)
+const result = await prisma.$queryRaw(query)
 
 console.log(result)
 ```
@@ -256,7 +256,7 @@ The following example uses a template literal inside `$queryRaw()`and returns al
 
 ```ts
 const inputString = '"Sarah" UNION SELECT id, title, content FROM Post' // SQL Injection
-const result = await prisma.queryRaw(`SELECT id, name, email FROM User WHERE name = ${inputString}`)
+const result = await prisma.$queryRaw(`SELECT id, name, email FROM User WHERE name = ${inputString}`)
 
 console.log(result)
 ```
@@ -265,7 +265,7 @@ By contrast, the same query using **tagged templates** escapes `inputString` and
 
 ```ts
 const inputString = '"Sarah" UNION SELECT id, title, content FROM Post'
-const result = await prisma.queryRaw`SELECT id, name, email FROM User WHERE name = ${inputString}`
+const result = await prisma.$queryRaw`SELECT id, name, email FROM User WHERE name = ${inputString}`
 
 console.log(result)
 ```


### PR DESCRIPTION
In the examples for raw DB access, ensure that we're using the renamed functions that start with a `$`