### PR TITLE
Fix incorrect optional  "?" syntax

### DIFF
--- a/content/03-reference/01-tools-and-interfaces/01-prisma-schema/04-data-model.mdx
+++ b/content/03-reference/01-tools-and-interfaces/01-prisma-schema/04-data-model.mdx
@@ -354,7 +354,7 @@ model Post {
 model Comment {
   id      Int    @id @default(autoincrement())
   title   String
-|  content? String
+|  content String?
 }
 
 model Tag {


### PR DESCRIPTION
While I was reading the documentation, I found a typo in the doc.

The question mark should be placed after the type, not the field name.