### PR TITLE
Fix SQL Server features

### DIFF
--- a/content/03-reference/02-database-connectors/01-database-features.mdx
+++ b/content/03-reference/02-database-connectors/01-database-features.mdx
@@ -90,8 +90,8 @@ Lock option (MySQL):
 | Feature                           | PostgreSQL | SQL Server | MySQL | SQLite | Prisma schema                                                                                  | Prisma Client | Prisma Migrate |
 | :-------------------------------- | :--------- | :--------- |:---- | :----- | :--------------------------------------------------------------------------------------------- | ------------- | -------------- |
 | Autoincrementing IDs              | ✔️         | ✔️ | ✔️ |   | ✔️     | [`autoincrement()`](../tools-and-interfaces/prisma-schema/data-model#defining-a-default-value) | ✔️            | ✔️             |
-| Arrays                            | ✔️         | ✔️ | No    | No     | [`[]`](../tools-and-interfaces/prisma-schema/data-model#type-modifiers)                        | ✔️            | ✔️             |
-| Enums                             | ✔️         | ✔️ | ✔️    | No     | [`enum`](../tools-and-interfaces/prisma-schema/data-model#defining-enums)                      | ✔️            | ✔️             |
+| Arrays                            | ✔️         | No | No    | No     | [`[]`](../tools-and-interfaces/prisma-schema/data-model#type-modifiers)                        | ✔️            | ✔️             |
+| Enums                             | ✔️         | No | ✔️    | No     | [`enum`](../tools-and-interfaces/prisma-schema/data-model#defining-enums)                      | ✔️            | ✔️             |
 | Native database types             | ✔️         | ✔️ | ✔️    | ✔️     | Not yet                                                                                        | ✔️            | Not yet        |
 | SQL Views                         | ✔️         | ✔️ | ✔️    | ✔️     | Not yet                                                                                        | Not yet       | Not yet        |
 | Authorization and user management | ✔️         | ✔️ | ✔️    | No     | Not yet                                                                                        | Not yet       | Not yet        |
@@ -118,20 +118,20 @@ The following functions are implemented by Prisma's query engine:
 
 `uuid()` and `cuid()` are commonly used to set default values for [ID](../tools-and-interfaces/prisma-schema/data-model#defining-an-id-field) fields.
 
-<!-- | Name              | PostgreSQL | MySQL  | SQLite |
-| ----------------- | ---------- | ------ | ------ |
-| `uuid()`          | ✔️\*       | ✔️\*\* | No     |
-| `cuid()`          | No         | No     | No     | 
+<!-- | Name         | PostgreSQL | SQL Server | MySQL  | SQLite |
+| ----------------- | ---------- | ---------- | ------ | ------ |
+| `uuid()`          | ✔️\*        | ✔         | ✔️\*\* | No     |
+| `cuid()`          | No         | No         | No     | No     |
 \*via an [extension](http://www.ossp.org/pkg/lib/uuid/)
 \*\*but usage as default values only in [MySQL 8 and higher](https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html)
 -->
 
 The following functions are available in Prisma and map to underlying database features:
 
-| Name              | PostgreSQL                                                                                                                                 | MySQL                                                                                                                                           | SQLite                          | Description                           |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------- |
-| `autoincrement()` | via the `SERIAL` type                                                                                                                      | via the `AUTO_INCREMENT` keyword                                                                                                                | via the `AUTOINCREMENT` keyword | Generates an autoincrementing integer |
-| `now()`           | [`CURRENT_TIMESTAMP`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT) and aliases like `now()` | [`CURRENT_TIMESTAMP`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_current-timestamp) and aliases like `now()` | `date('now')`                   | Returns the current time              |
+| Name              | PostgreSQL                                                                                                                                 | SQL Server                                                                                                  | MySQL                                                                                                                                           | SQLite                          | Description                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------- |
+| `autoincrement()` | via the `SERIAL` type                                                                                                                      | IDENTITY(1,1)                                                                                               | via the `AUTO_INCREMENT` keyword                                                                                                                | via the `AUTOINCREMENT` keyword | Generates an autoincrementing integer |
+| `now()`           | [`CURRENT_TIMESTAMP`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT) and aliases like `now()` | [GET_DATE](https://docs.microsoft.com/en-us/sql/t-sql/functions/getdate-transact-sql?view=sql-server-ver15) | [`CURRENT_TIMESTAMP`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_current-timestamp) and aliases like `now()` | `date('now')`                   | Returns the current time              |
 
 `autoincrement()` is commonly used to generated autoincrementing [ID](../tools-and-interfaces/prisma-schema/data-model
 ../tools-and-interfaces/prisma-schema/data-model#defining-an-id-field) values. `now()` is commonly used to initialize "createdAt"-fields that store the point in time when a record was created.


### PR DESCRIPTION
- Doesn't have support for arrays or enums
- Uuid supported natively
- `autoincrement` through `SERIAL(1,1)`
- `now` through `GET_DATE`