### PR TITLE
docs: fix link to `rest-nextjs-api-routes` example

### DIFF
--- a/content/01-getting-started/01-quickstart.mdx
+++ b/content/01-getting-started/01-quickstart.mdx
@@ -760,13 +760,13 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 
 <tab>
 
-| Demo                                                                                                               | Stack        | Description                                                                                         |
-| :----------------------------------------------------------------------------------------------------------------- | :----------- | --------------------------------------------------------------------------------------------------- |
-| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs)                     | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
-| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)               | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
-| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
-| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
-| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
+| Demo                                                                                                                | Stack        | Description                                                                                         |
+| :------------------------------------------------------------------------------------------------------------------ | :----------- | --------------------------------------------------------------------------------------------------- |
+| [`rest-nextjs-api-routes`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-api-routes) | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
+| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)                 | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
+| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server)   | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
+| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                     | Backend only | Simple REST API with Express.JS                                                                     |
+| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                     | Backend only | Simple gRPC API                                                                                     |
 
 </tab>
 

--- a/content/01-getting-started/02-setup-prisma/01-add-to-existing-project.mdx
+++ b/content/01-getting-started/02-setup-prisma/01-add-to-existing-project.mdx
@@ -808,13 +808,13 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 
 <tab>
 
-| Demo                                                                                                               | Stack        | Description                                                                                         |
-| :----------------------------------------------------------------------------------------------------------------- | :----------- | --------------------------------------------------------------------------------------------------- |
-| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs)                     | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
-| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)               | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
-| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
-| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
-| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
+| Demo                                                                                                                | Stack        | Description                                                                                         |
+| :------------------------------------------------------------------------------------------------------------------ | :----------- | --------------------------------------------------------------------------------------------------- |
+| [`rest-nextjs-api-routes`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-api-routes) | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
+| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)                 | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
+| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server)   | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
+| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                     | Backend only | Simple REST API with Express.JS                                                                     |
+| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                     | Backend only | Simple gRPC API                                                                                     |
 
 </tab>
 

--- a/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
+++ b/content/01-getting-started/02-setup-prisma/02-start-from-scratch-sql.mdx
@@ -923,13 +923,13 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 
 <tab>
 
-| Demo                                                                                                               | Stack        | Description                                                                                         |
-| :----------------------------------------------------------------------------------------------------------------- | :----------- | --------------------------------------------------------------------------------------------------- |
-| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs)                     | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
-| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)               | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
-| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
-| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
-| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
+| Demo                                                                                                                | Stack        | Description                                                                                         |
+| :------------------------------------------------------------------------------------------------------------------ | :----------- | --------------------------------------------------------------------------------------------------- |
+| [`rest-nextjs-api-routes`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-api-routes) | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
+| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)                 | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
+| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server)   | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
+| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                     | Backend only | Simple REST API with Express.JS                                                                     |
+| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                     | Backend only | Simple gRPC API                                                                                     |
 
 </tab>
 

--- a/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
+++ b/content/01-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
@@ -833,13 +833,13 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 
 <tab>
 
-| Demo                                                                                                               | Stack        | Description                                                                                         |
-| :----------------------------------------------------------------------------------------------------------------- | :----------- | --------------------------------------------------------------------------------------------------- |
-| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs)                     | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
-| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)               | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
-| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server) | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
-| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                   | Backend only | Simple REST API with Express.JS                                                                     |
-| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                   | Backend only | Simple gRPC API                                                                                     |
+| Demo                                                                                                                | Stack        | Description                                                                                         |
+| :------------------------------------------------------------------------------------------------------------------ | :----------- | --------------------------------------------------------------------------------------------------- |
+| [`rest-nextjs-api-routes`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-api-routes) | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
+| [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)                 | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
+| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server)   | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
+| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                     | Backend only | Simple REST API with Express.JS                                                                     |
+| [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                     | Backend only | Simple gRPC API                                                                                     |
 
 </tab>
 

--- a/content/02-understand-prisma/03-prisma-in-your-stack/01-rest.md
+++ b/content/02-understand-prisma/03-prisma-in-your-stack/01-rest.md
@@ -141,9 +141,9 @@ app.delete(`/post/:id`, async (req, res) => {
 
 You can find several ready-to-run examples that show how to implement a REST API with Prisma Client in the [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository.
 
-| Example                                                                                         | Language   | Stack        | Description                                                       |
-| :---------------------------------------------------------------------------------------------- | :--------- | ------------ | ----------------------------------------------------------------- |
-| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs)   | TypeScript | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API |
-| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express) | TypeScript | Backend only | Simple REST API with Express                                      |
-| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-nextjs)   | JavaScript | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API |
-| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express) | JavaScript | Backend only | Simple REST API with Express                                      |
+| Example                                                                                                             | Language   | Stack        | Description                                                       |
+| :------------------------------------------------------------------------------------------------------------------ | :--------- | ------------ | ----------------------------------------------------------------- |
+| [`rest-nextjs-api-routes`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-api-routes) | TypeScript | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API |
+| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                     | TypeScript | Backend only | Simple REST API with Express                                      |
+| [`rest-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-nextjs)                       | JavaScript | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API |
+| [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express)                     | JavaScript | Backend only | Simple REST API with Express                                      |


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-examples/issues/2183

Would be nice to have an `hacktoberfest` t-shirt thanks to this 😎 