### PR TITLE
Fix broken links

### DIFF
--- a/content/05-more/02-style-guide/01-mdx-examples.mdx
+++ b/content/05-more/02-style-guide/01-mdx-examples.mdx
@@ -300,14 +300,14 @@ Here's more!
 
 Example:
 
-<ButtonLink color="dark" type="primary" href="/to/path">	
+<ButtonLink color="dark" type="primary" href="https://www.prisma.io/docs">
   Button text	
 </ButtonLink>
 
 Code:
 
 ```
-<ButtonLink color="dark" type="primary" href="/to/path">	
+<ButtonLink color="dark" type="primary" href="https://www.prisma.io/docs">
   Button text	
 </ButtonLink>
 ```

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -145,7 +145,7 @@ Prisma has a large and supportive [community](https://prisma.io/community) of en
 
 You can ask questions and initiate [discussions](https://github.com/prisma/prisma/discussions/) about Prisma-related topics in the `prisma` repository on GitHub.
 
-<ButtonLink color="dark" type="primary" href="https://github.com/prisma/prisma/discussions/new">
+<ButtonLink color="dark" type="primary" href="https://github.com/prisma/prisma/discussions">
   Ask a question
 </ButtonLink>
 <br />


### PR DESCRIPTION
Fix links that are broken by adding an actual URL.

In  the case of the new discussion button, it shows up as a 404 if you are not logged into GitHub.