### PR TITLE
Add documentation about 2 more available Studio arguments

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -815,11 +815,11 @@ datasource db {
 
 The `studio` command recognizes the following options:
 
-| Option            | Required | Description                                  | Default                 |
-| ----------------- | -------- | -------------------------------------------- | ----------------------- |
-| `-b`, `--browser` | No       | The browser to auto-open Studio in.          | <your-default-browser>  |
-| `-h`, `--help`    | No       | Show all available possible options and exit |                         |
-| `-p`, `--port`    | No       | The port number to start Studio on.          | 5555                    |
+| Option            | Required | Description                         | Default                 |
+| ----------------- | -------- | ----------------------------------- | ----------------------- |
+| `-b`, `--browser` | No       | The browser to auto-open Studio in. | <your-default-browser>  |
+| `-h`, `--help`    | No       | Show all available options and exit |                         |
+| `-p`, `--port`    | No       | The port number to start Studio on. | 5555                    |
 
 #### Examples
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -815,9 +815,11 @@ datasource db {
 
 The `studio` command recognizes the following options:
 
-| Option         | Required | Description                         | Default |
-| -------------- | -------- | ----------------------------------- | ------- |
-| `-p`, `--port` | No       | The port number to start Studio on. | 5555    |
+| Option            | Required | Description                                  | Default                 |
+| ----------------- | -------- | -------------------------------------------- | ----------------------- |
+| `-b`, `--browser` | No       | The browser to auto-open Studio in.          | <your-default-browser>  |
+| `-h`, `--help`    | No       | Show all available possible options and exit |                         |
+| `-p`, `--port`    | No       | The port number to start Studio on.          | 5555                    |
 
 #### Examples
 
@@ -831,4 +833,16 @@ prisma studio
 
 ```terminal
 prisma studio --port 7777
+```
+
+####  Start Studio and open a Firefox tab to it
+
+```terminal
+prisma studio --browser firefox
+```
+
+####  Start Studio without opening a new browser tab to it
+
+```terminal
+prisma studio --browser none
 ```

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -817,7 +817,7 @@ The `studio` command recognizes the following options:
 
 | Option            | Required | Description                         | Default                 |
 | ----------------- | -------- | ----------------------------------- | ----------------------- |
-| `-b`, `--browser` | No       | The browser to auto-open Studio in. | <your-default-browser>  |
+| `-b`, `--browser` | No       | The browser to auto-open Studio in. | `<your-default-browser>`  |
 | `-h`, `--help`    | No       | Show all available options and exit |                         |
 | `-p`, `--port`    | No       | The port number to start Studio on. | 5555                    |
 


### PR DESCRIPTION
Studio accepts `--browser` as well as `--help`, so I thought I'd add docs for it :)

1. I reordered the arguments table to be alphabetical now that there's more than one
2. I also added a few examples for the `--browser` argument (Especially `--browser none`, since some people might find it annoying that Studio auto-opens a browser tab)