### PR TITLE
Rename experimentalFeatures to previewFeatures

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-relation-queries.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-relation-queries.mdx
@@ -260,7 +260,7 @@ const user = await prisma.profile.create({
 >  ```prisma
 >  generator client {
 >    provider             = "prisma-client-js"
->    experimentalFeatures = ["connectOrCreate"]
+>    previewFeatures      = ["connectOrCreate"]
 >  }
 >  ```
 
@@ -319,7 +319,7 @@ The following example:
 >  ```prisma
 >  generator client {
 >    provider             = "prisma-client-js"
->    experimentalFeatures = ["connectOrCreate"]
+>    previewFeatures      = ["connectOrCreate"]
 >  }
 >  ```
 
@@ -525,7 +525,7 @@ const user = await prisma.post.create({
 >  ```prisma
 >  generator client {
 >    provider             = "prisma-client-js"
->    experimentalFeatures = ["connectOrCreate"]
+>    previewFeatures      = ["connectOrCreate"]
 >  }
 >  ```
 
@@ -583,7 +583,7 @@ const user = await prisma.user.update({
 >  ```prisma
 >  generator client {
 >    provider             = "prisma-client-js"
->    experimentalFeatures = ["connectOrCreate"]
+>    previewFeatures      = ["connectOrCreate"]
 >  }
 >  ```
 


### PR DESCRIPTION
This fixes the naming that is used in the latest version of prisma