### PR TITLE
fix: typo

### DIFF
--- a/content/400-reference/300-database-reference/02-connection-urls.mdx
+++ b/content/400-reference/300-database-reference/02-connection-urls.mdx
@@ -46,7 +46,7 @@ datasource db {
 ```prisma
 datasource db {
   provider = "sqlserver"
-  url      = "sqlserver://localhost:1433;initial catalog=sample;user=sa;password=mypassword;
+  url      = "sqlserver://localhost:1433;initial catalog=sample;user=sa;password=mypassword;"
 }
 ```
 


### PR DESCRIPTION
Missing closing " at the end of the URL string