### PR TITLE
adds auto-approve option in migrate up

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -684,6 +684,7 @@ Additionally, the following options modify the behavior of the `migrate up` comm
 | `-c`, `--create-db` | No       | Create the database if it does not exist.                                                                                                           |                                             |
 | `-p`, `--preview`   | No       | Preview the migration that would be created without writing any changes to the filesystem.                                                          |                                             |
 | `--schema`          | No       | Specifies the path to the desired `schema.prisma` file to be processed instead of the default path. Both absolute and relative paths are supported. | `./schema.prisma`, `./prisma/schema.prisma` |
+| `--auto-approve`    | No       | Skip interactive approval before migrating.                                                          |                                             |
 
 #### Examples
 


### PR DESCRIPTION
Basically copying the doc for auto-approve from this CLI help:
```
Usage

  $ prisma migrate up [<inc|name|timestamp>] --experimental

Arguments

  [<inc>]   go up by an increment [default: latest]

Options

  --auto-approve    Skip interactive approval before migrating
  -h, --help        Displays this help message
  -p, --preview     Preview the migration changes
  -c, --create-db   Create the database in case it doesn't exist
```