### PR TITLE
Updated the docs with the current prisma-lens

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14737,7 +14737,7 @@ prism-react-renderer@^1.0.1, prism-react-renderer@^1.0.2:
 
 "prisma-lens@git+https://github.com/prisma/lens.git":
   version "1.0.0"
-  resolved "git+https://github.com/prisma/lens.git#23a9ee6a89e3711fa9441c3c1feb99f9b3c6ad04"
+  resolved "git+https://github.com/prisma/lens.git#c524e16ffd9977ba951797e5c4b3cd779d33997f"
   dependencies:
     "@babel/cli" "^7.11.6"
     "@babel/core" "^7.11.6"


### PR DESCRIPTION
To update it with the latest changes for doc, can fix few problems like #1007,

fix of, link broke: https://www.prisma.io/docs/more/faq at vary top navbar as FAQ

Need to generalize it, since prisma-lens is used directly from its repo