### PR TITLE
Fix: TopBlock doesn't render Markdown links #1046

### DIFF
--- a/content/300-guides/04-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/04-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Learn how to migrate from TypeORM to Prisma'
 ---
 
 <TopBlock>
+ 
 This guide describes how to migrate from TypeORM to Prisma. It uses an extended version of the [TypeORM Express example](https://github.com/typeorm/typescript-express-example/) as a [sample project](https://github.com/prisma/migrate-from-typeorm-to-prisma) to demonstrate the migration steps. You can find the example used for this guide on [GitHub](https://github.com/prisma/migrate-from-typeorm-to-prisma). 
 
 This migration guide uses PostgreSQL as as an example database, but it equally applies to any other relational database that's [supported by Prisma](../../reference/database-reference/supported-databases).

--- a/content/300-guides/04-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/04-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -9,6 +9,7 @@ metaDescription: 'Learn how to migrate from TypeORM to Prisma'
 This guide describes how to migrate from TypeORM to Prisma. It uses an extended version of the [TypeORM Express example](https://github.com/typeorm/typescript-express-example/) as a [sample project](https://github.com/prisma/migrate-from-typeorm-to-prisma) to demonstrate the migration steps. You can find the example used for this guide on [GitHub](https://github.com/prisma/migrate-from-typeorm-to-prisma). 
 
 This migration guide uses PostgreSQL as as an example database, but it equally applies to any other relational database that's [supported by Prisma](../../reference/database-reference/supported-databases).
+
 </TopBlock>
 
 ## Overview of the migration process


### PR DESCRIPTION
TopBlock doesn't render Markdown links #1046

It just needs **a newLine between** the newBlock and the content to work fine, **if found elsewhere, just add a newline**