### PR TITLE
feat: code highlighting redefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jquery": "^3.5.1",
     "lodash": "^4.17.15",
     "netlify-lambda": "^2.0.1",
+    "parse-numeric-range": "^1.2.0",
     "polished": "^3.5.1",
     "prism-react-renderer": "^1.0.2",
     "prisma-lens": "git+https://github.com/prisma/lens.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13958,6 +13958,11 @@ parse-numeric-range@^0.0.2:
   resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-0.0.2.tgz#b4f09d413c7adbcd987f6e9233c7b4b210c938e4"
   integrity sha1-tPCdQTx6282Yf26SM8e0shDJOOQ=
 
+parse-numeric-range@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-1.2.0.tgz#aa70b00f29624ed13e9f943e9461b306e386b0fa"
+  integrity sha512-1q2tXpAOplPxcl8vrIGPWz1dJxxfmdRkCFcpxxMBerDnGuuHalOWF/xj9L8Nn5XoTUoB/6F0CeQBp2fMgkOYFg==
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"


### PR DESCRIPTION
#654 

Usage: 

```
```js file=schema.js highlight=15;normal|4,7-11;edit|5,13;add|1,2;delete
async function main() {
  const allUsers = await prisma.user.findMany();
  console.log(allUsers);
}
......
``````


You can also use `+`, `-`, `|` etc. as usual too.

TODO:

- [ ] Change all the code block highlighting to use the new structure