### PR TITLE
Fix: typo

### DIFF
--- a/content/100-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
+++ b/content/100-getting-started/02-setup-prisma/03-start-from-scratch-prisma-migrate.mdx
@@ -366,7 +366,7 @@ npx prisma migrate save --name init --experimental
 npx prisma migrate up --experimental
 ```
 
-The `save` command creates a new directory called `migrations` where it will store your migration history. It does not yet create the any tables in the database. The tables are created when `up` is invoked!
+The `save` command creates a new directory called `migrations` where it will store your migration history. It does not yet create any tables in the database. The tables are created when `up` is invoked!
 
 Great, you now created three tables in your database with Prisma Migrate 🚀
 


### PR DESCRIPTION
Removed "the" under section "Create database tables with Prisma Migrate"