### PR TITLE
Expand on how the schema file is resolved

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -115,7 +115,7 @@ enum Role {
 
 The default name for the schema file is `schema.prisma`. When your schema file is named like this, the Prisma CLI will detect it automatically in the directory where you invoke the CLI command (or any of its subdirectories).
 
-If the file is named differently, you can provide the `--schema` argument to the Prisma CLI with the path to the schema file, e.g.:
+For other ways to supply a schema file, see "Schema File Resolution" section of the [generate command reference](../../../400-reference/200-api-reference/200-command-reference).
 
 ```
 prisma generate --schema ./database/myschema.prisma

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -352,7 +352,7 @@ The `generate` command is most often used to generate Prisma Client with the `pr
 
 1. Searches the current directory and parent directories to find the applicable `npm` project. It will create a `package.json` file in the current directory if it cannot find one.
 2. Installs the `@prisma/client` into the `npm` project if it is not already present.
-3. Inspects the current directory to find a Prisma schema file to process. It will then generate a customized [Prisma Client](https://github.com/prisma/prisma-client-js) for your project.
+3. Inspects the current directory to find a Prisma schema file to process. It will then generate a customized [Prisma Client](https://github.com/prisma/prisma-client-js) for your project. See "Schema File Resolution" section below for how a schema file is identified.
 
 #### Prerequisites
 
@@ -377,6 +377,16 @@ generator client {
 | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | --- |
 | `--schema`    | No       | Specifies the path to the desired `schema.prisma` file to be processed instead of the default path. Both absolute and relative paths are supported.                                          | `./schema.prisma`, `./prisma/schema.prisma` |     |
 | `--generator` | No       | Specifies which generator to use to generate assets. This option may be provided multiple times to include multiple generators. By default, all generators in the target schema will be run. |                                             |
+
+#### Schema File Resolution
+
+The CLI will try the following strategies to identify a schema file and use the first one that is successful:
+
+1. If a `--schema` argument is provided to the `generate` command, that path is expected to resolve to a schema file
+2. If present, the `prisma.schema` key of `package.json` will be interpreted as a path relative to the current working directory, and the file at that path will be used as the schema file
+3. The paths `./schema.prisma` and `./prisma/schema.prisma` are examined in that order and if a file exists, it is used as the schema file
+4. If yarn is used, steps 2 and 3 are applied for each workspace
+
 
 #### Examples
 


### PR DESCRIPTION
Previously only the `--schema` flag to generate was called out in the docs as a way to specify a schema file other than `./schema.prisma`. Looking at the code there are two other options. This PR documents all four options.