### PR TITLE
Fix minor typo

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/000-generating-prisma-client.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-generating-prisma-client.mdx
@@ -29,7 +29,7 @@ Generating Prisma Client requires three steps:
 
 **Important**: You need to re-run the `prisma generate` command after every change that's made to your Prisma schema to update the generated Prisma Client code.
 
-Here is a graphical illustration of the typicaly workflow for the Prisma Client generation:
+Here is a graphical illustration of the typical workflow for the Prisma Client generation:
 
 ![Graphical illustration of the typical workflow for the Prisma Client generation](https://i.imgur.com/aRJmVFY.png)
 


### PR DESCRIPTION
Hello, was reading docs and noticed a _tiny_ misspelling, so here's a PR to fix `typicaly` -> `typical`.