### PR TITLE
Fix typos in "Add Prisma Migrate to an existing project"

### DIFF
--- a/content/300-guides/100-prisma-guides/100-prisma-migrate-guides/100-add-prisma-migrate-to-a-project.mdx
+++ b/content/300-guides/100-prisma-guides/100-prisma-migrate-guides/100-add-prisma-migrate-to-a-project.mdx
@@ -65,10 +65,10 @@ Baselining works by creating the `_prisma_migrations` table (if it does not exis
 To baseline a production database:
 
 1. Make sure you have a working copy of the new migrations directory
-2. Run the following command to baseline  a migration:
+2. Run the following command to baseline a migration:
 
    ```terminal
-   prisma migrate resolve --applied "20201124-create-users"  --preview-feature` to baseline a migration.
+   prisma migrate resolve --applied "20201124-create-users"  --preview-feature
    ```
 
    If you need to baseline multiple migrations (for example, if you generated more migrations after transitioning your development environment), run the `prisma migrate resolve --preview-feature` command for each migration separately.


### PR DESCRIPTION
One of the commands had some extra text!