### PR TITLE
Fixed: typo

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -217,7 +217,7 @@ You can set the `DATABASE_URL` in your `.env` file:
 DATABASE_URL=postgresql://test:test@localhost:5432/test?schema=public
 ```
 
-When you run a command that needs access the database defined via the `datasource` block (for example, `prisma introspect`), the Prisma CLI automatically loads the `DATABASE_URL` environment variables from the `.env` file and makes it available to the CLI.
+When you run a command that needs access to the database defined via the `datasource` block (for example, `prisma introspect`), the Prisma CLI automatically loads the `DATABASE_URL` environment variables from the `.env` file and makes it available to the CLI.
 
 ### Using environment variables in your code
 


### PR DESCRIPTION
Added missing "to" under "Using .env files" section