### PR TITLE
Fix "existing project" 404ing quickstart link

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -637,7 +637,7 @@ The following guide explains how you can set up a new project from scratch using
 
 When adding Prisma to an already existing npm project, you can obtain your initial data model through [introspection](../concepts/components/introspection).
 
-<ButtonLink color="dark" type="primary" href="./setup-prisma/add-to-existing-project">
+<ButtonLink color="dark" type="primary" href="./setup-prisma/add-to-existing-project-typescript-postgres">
     Add Prisma to existing project
 </ButtonLink>
 


### PR DESCRIPTION
Fixes a 404 on the quickstart guide.

See: https://www.prisma.io/docs/getting-started/quickstart-typescript#set-up-prisma-with-your-own-database and click "Add Prisma to Existing Project".

This fix simply points it to the Typescript/Postgres version of the doc by default, and then people can change the defaults if they wish. Probably in an ideal world the old 404ing link would be redirected to the new one long term - but this is a very quick on-github edit.

