### PR TITLE
fix: Broken link on docs page

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/index.mdx
@@ -26,7 +26,7 @@ The setup instructions [below](#set-up) provide a high-level overview of the ste
 <ButtonLink
   color="dark"
   type="primary"
-  href="../../../getting-started/setup-prisma/add-to-existing-project"
+  href="../../../getting-started/setup-prisma/add-to-existing-project-typescript-postgres"
 >
   Add Prisma to an existing project
 </ButtonLink>


### PR DESCRIPTION
On this page, https://www.prisma.io/docs/concepts/components/prisma-client "Add to existing project" redirects to 404 page. (client-side routing issue)