### PR TITLE
Updated old internal links with new internal links

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -18,7 +18,7 @@ techMetaDescriptions: [
 
 <SwitchTech technologies={['typescript']}>
 
-In this page, you will learn how to send queries to a **SQLite database** in a plain **TypeScript** script using Prisma Client. Our other guides cover how to set up Prisma with [your own database](setup-prisma/add-to-existing-project) or [in a new project from scratch](setup-prisma/start-from-scratch).
+In this page, you will learn how to send queries to a **SQLite database** in a plain **TypeScript** script using Prisma Client. Our other guides cover how to set up Prisma with [your own database](setup-prisma/add-to-existing-project-typescript-postgres) or [in a new project from scratch](setup-prisma/start-from-scratch-typescript-postgres).
 
 > TypeScript will be added as a local dependency to the project, no need to install it.
 
@@ -26,7 +26,7 @@ In this page, you will learn how to send queries to a **SQLite database** in a p
 
 <SwitchTech technologies={['node']}>
 
-In this page, you will learn how to send queries to a **SQLite database** in a plain **Node.js** script using Prisma Client. Our other guides cover how to [set up Prisma with your own database](setup-prisma/add-to-existing-project) or [set up a new project from scratch](setup-prisma/start-from-scratch).
+In this page, you will learn how to send queries to a **SQLite database** in a plain **Node.js** script using Prisma Client. Our other guides cover how to [set up Prisma with your own database](setup-prisma/add-to-existing-project-typescript-postgres) or [set up a new project from scratch](setup-prisma/start-from-scratch-typescript-postgres).
 
 > You'll need [**Node.js**](https://nodejs.org/en/) (version 10 or higher) installed on your machine.
 


### PR DESCRIPTION
Updated old internal links with new internal links. Old internal links caused 404-error for client side navigation (but worked because of redirects when hard refresh). Updated to the new correct links to fix issue.