### PR TITLE
Add a note explaining something that confused me in db matrix

### DIFF
--- a/content/400-reference/300-database-reference/01-database-features.mdx
+++ b/content/400-reference/300-database-reference/01-database-features.mdx
@@ -88,7 +88,7 @@ Lock option (MySQL):
 ### Misc
 
 Features are only available if supported by Prisma _and_ the underlying database.
-If the database supports the feature, but the Prisma Client doesn't you should still be able to use [raw database access](../../concepts/components/prisma-schema/raw-database-access) to issue SQL commands.
+If your database supports a feature but Prisma Client does not, consider using [raw database access](../../concepts/components/prisma-schema/raw-database-access) to issue SQL commands.
 
 | Feature                           | PostgreSQL | SQL Server | MySQL | SQLite | Prisma schema                                                                                  | Prisma Client | Prisma Migrate |
 | :-------------------------------- | :--------- | :--------- |:---- | :----- | :--------------------------------------------------------------------------------------------- | ------------- | -------------- |

--- a/content/400-reference/300-database-reference/01-database-features.mdx
+++ b/content/400-reference/300-database-reference/01-database-features.mdx
@@ -87,6 +87,9 @@ Lock option (MySQL):
 
 ### Misc
 
+Note that both the support for the feature from the given database and from Prisma Client is required to use the feature from Prisma. 
+If the database supports the feature, but the Prisma Client doesn't you should still be able to use [raw database access](../../concepts/components/prisma-schema/raw-database-access) to issue SQL commands.
+
 | Feature                           | PostgreSQL | SQL Server | MySQL | SQLite | Prisma schema                                                                                  | Prisma Client | Prisma Migrate |
 | :-------------------------------- | :--------- | :--------- |:---- | :----- | :--------------------------------------------------------------------------------------------- | ------------- | -------------- |
 | Autoincrementing IDs              | ✔️         | ✔️ | ✔️ |   | ✔️     | [`autoincrement()`](../../concepts/components/prisma-schema/data-model#defining-a-default-value) | ✔️            | ✔️             |

--- a/content/400-reference/300-database-reference/01-database-features.mdx
+++ b/content/400-reference/300-database-reference/01-database-features.mdx
@@ -99,7 +99,9 @@ Lock option (MySQL):
 | Authorization and user management | ✔️         | ✔️ | ✔️    | No     | Not yet                                                                                        | Not yet       | Not yet        |
 | JSON support                      | ✔️         | ✔️ | ✔️    | No     | ✔️*                                                                                             | ✔️*            | ✔️*             |
 | Fuzzy/Phrase full text search     | ✔️         | ✔️ | ✔️    | No     | Not yet                                                                                        | Not yet       | Not yet        |
-| Table inheritance                 | ✔️         | ✔️ | No    | No     | Not yet                                                                                        | ✔️            | Not yet        |
+| Table inheritance                 | ✔️         | ✔️ | No    | No     | Not yet                                                                                        | ✔️*            | Not yet        |
+
+\* Only available if natively supported by database.
 
 ## Prisma features
 

--- a/content/400-reference/300-database-reference/01-database-features.mdx
+++ b/content/400-reference/300-database-reference/01-database-features.mdx
@@ -12,7 +12,7 @@ This page gives an overview of the features which are provided by the databases 
 
 This section describes which database features exist on the databases that are currently supported by Prisma. The **Prisma schema** column indicates how a certain feature can be represented in the [Prisma schema](../../concepts/components/prisma-schema) and links to its documentation. Note that database features can be used in **Prisma Client** even though they might not yet be representable in the Prisma schema.
 
-If a feature is not supported natively by the database, it's also not available in Prisma.
+> **Note**: If a feature is not supported natively by the database, it's also not available in Prisma.
 
 ### Constraints
 
@@ -21,7 +21,7 @@ If a feature is not supported natively by the database, it's also not available 
 | `PRIMARY KEY` |     ✔️     |  ✔️    |✔️    |   ✔️   |      [`@id` and `@@id`](../../concepts/components/prisma-schema/data-model#defining-an-id-field)       |      ✔️       |       ✔️       |
 | `FOREIGN KEY` |     ✔️     |  ✔️    |✔️   |   ✔️   |          [Relation fields](../../concepts/components/prisma-schema/relations#relation-fields)          |      ✔️       |       ✔️       |
 | `UNIQUE`      |     ✔️     |  ✔️†    |✔️   |   ✔️   | [`@unique` and `@@unique`](../../concepts/components/prisma-schema/data-model#defining-a-unique-field) |      ✔️       |       ✔️       |
-| `CHECK`       |     ✔️     |  ✔️    |✔\*  |   ✔️   |                                               Not yet                                                |      ✔️       |    Not yet     |
+| `CHECK`       |     ✔️     |  ✔️    |✔️\*  |   ✔️   |                                               Not yet                                                |      ✔️       |    Not yet     |
 | `NOT NULL`    |     ✔️     |  ✔️    |✔️   |   ✔️   |                [`?`](../../concepts/components/prisma-schema/data-model#type-modifiers)                |      ✔️       |       ✔️       |
 | `DEFAULT`     |     ✔️     |  ✔️    |✔️   |   ✔️   |       [`@default`](../../concepts/components/prisma-schema/data-model#defining-a-default-value)        |      ✔️       |       ✔️       |
 
@@ -62,10 +62,12 @@ Algorithm specified via `USING`:
 | ---------------------- | ---------- | ---------- | ----- | ------ | ------------- | ------------- | -------------- |
 | B-tree                 | ✔️         | ✔️    |✔️    | ✔️     | Not yet       | ✔️            | Not yet        |
 | Hash                   | ✔️         | ✔️    |✔️    | ✔️     | Not yet       | ✔️            | Not yet        |
-| GiST                   | ✔️         | ✔️    |No    | No     | Not yet       | ✔️            | Not yet        |
-| GIN                    | ✔️         | ✔️    |No    | No     | Not yet       | ✔️            | Not yet        |
-| BRIN                   | ✔️         | ✔️    |No    | No     | Not yet       | ✔️            | Not yet        |
-| SP-GiST                | ✔️         | ✔️    |No    | No     | Not yet       | ✔️            | Not yet        |
+| GiST                   | ✔️         | ✔️    |No    | No     | Not yet       | ✔️*            | Not yet        |
+| GIN                    | ✔️         | ✔️    |No    | No     | Not yet       | ✔️*            | Not yet        |
+| BRIN                   | ✔️         | ✔️    |No    | No     | Not yet       | ✔️*            | Not yet        |
+| SP-GiST                | ✔️         | ✔️    |No    | No     | Not yet       | ✔️*            | Not yet        |
+
+\* Only available if natively supported by database.
 
 <!-- **MySQL only**
 
@@ -87,18 +89,15 @@ Lock option (MySQL):
 
 ### Misc
 
-Features are only available if supported by Prisma _and_ the underlying database.
-If your database supports a feature but Prisma Client does not, consider using [raw database access](../../concepts/components/prisma-schema/raw-database-access) to issue SQL commands.
-
 | Feature                           | PostgreSQL | SQL Server | MySQL | SQLite | Prisma schema                                                                                  | Prisma Client | Prisma Migrate |
 | :-------------------------------- | :--------- | :--------- |:---- | :----- | :--------------------------------------------------------------------------------------------- | ------------- | -------------- |
 | Autoincrementing IDs              | ✔️         | ✔️ | ✔️ |   | ✔️     | [`autoincrement()`](../../concepts/components/prisma-schema/data-model#defining-a-default-value) | ✔️            | ✔️             |
-| Arrays                            | ✔️         | No | No    | No     | [`[]`](../../concepts/components/prisma-schema/data-model#type-modifiers)                        | ✔️            | ✔️             |
-| Enums                             | ✔️         | No | ✔️    | No     | [`enum`](../../concepts/components/prisma-schema/data-model#defining-enums)                      | ✔️            | ✔️             |
+| Arrays                            | ✔️         | No | No    | No     | [`[]`](../../concepts/components/prisma-schema/data-model#type-modifiers)                        | ✔️*            | ✔️*             |
+| Enums                             | ✔️         | No | ✔️    | No     | [`enum`](../../concepts/components/prisma-schema/data-model#defining-enums)                      | ✔️*            | ✔️*             |
 | Native database types             | ✔️         | ✔️ | ✔️    | ✔️     | Not yet                                                                                        | ✔️            | Not yet        |
 | SQL Views                         | ✔️         | ✔️ | ✔️    | ✔️     | Not yet                                                                                        | Not yet       | Not yet        |
 | Authorization and user management | ✔️         | ✔️ | ✔️    | No     | Not yet                                                                                        | Not yet       | Not yet        |
-| JSON support                      | ✔️         | ✔️ | ✔️    | No     | ✔️                                                                                             | ✔️            | ✔️             |
+| JSON support                      | ✔️         | ✔️ | ✔️    | No     | ✔️*                                                                                             | ✔️*            | ✔️*             |
 | Fuzzy/Phrase full text search     | ✔️         | ✔️ | ✔️    | No     | Not yet                                                                                        | Not yet       | Not yet        |
 | Table inheritance                 | ✔️         | ✔️ | No    | No     | Not yet                                                                                        | ✔️            | Not yet        |
 

--- a/content/400-reference/300-database-reference/01-database-features.mdx
+++ b/content/400-reference/300-database-reference/01-database-features.mdx
@@ -87,7 +87,7 @@ Lock option (MySQL):
 
 ### Misc
 
-Note that both the support for the feature from the given database and from Prisma Client is required to use the feature from Prisma. 
+Features are only available if supported by Prisma _and_ the underlying database.
 If the database supports the feature, but the Prisma Client doesn't you should still be able to use [raw database access](../../concepts/components/prisma-schema/raw-database-access) to issue SQL commands.
 
 | Feature                           | PostgreSQL | SQL Server | MySQL | SQLite | Prisma schema                                                                                  | Prisma Client | Prisma Migrate |


### PR DESCRIPTION
Added note to `Misc` in `Database features matrix` that tries to explain that a green ✔️ checkmark in a row for a given database doesn't mean that Prisma supports the feature, but just that the database supports that feature. I know this is said on the overview at the top of the page:

> This page gives an overview of the features which are provided by the databases that Prisma supports.

but what I did and probably what most people do is skim through and look for the feature they want missing the important detail at the top. As a result I [was confused](https://github.com/prisma/prisma/issues/1684#issuecomment-752239611) as to whether a certain feature was available or not.

This is just a suggestion, feel free to put it differently or close the pull request if you feel it is redundant.