### PR TITLE
(typo fix) Update 020-configuring-the-prisma-client-api.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/020-configuring-the-prisma-client-api.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/020-configuring-the-prisma-client-api.mdx
@@ -269,7 +269,7 @@ CREATE TABLE "Post" (
 );
 ```
 
-Prism's introspection will output the following Prisma schema:
+Prisma's introspection will output the following Prisma schema:
 
 ```prisma
 model Post {


### PR DESCRIPTION
appended an "a" to the end of "Prism" to correct spelling of "Prisma" and minimize reader confusion around the correct terminology.