### PR TITLE
Update vercel deployment guide

### DIFF
--- a/content/300-guides/200-deployment/01-deploying-to-vercel.mdx
+++ b/content/300-guides/200-deployment/01-deploying-to-vercel.mdx
@@ -139,80 +139,26 @@ Prisma will introspect the database defined in the `datasource` block of the Pri
 
 ```prisma
 model Post {
-  post_id   Int     @default(autoincrement()) @id
+  post_id   Int     @id @default(autoincrement())
   title     String
   content   String?
   author_id Int?
-  User      User?   @relation(fields: [author_id], references: [user_id])
+  author    User?   @relation(fields: [author_id], references: [user_id])
 }
 
 model Profile {
-  profile_id Int     @default(autoincrement()) @id
+  profile_id Int     @id @default(autoincrement())
   bio        String?
   user_id    Int
-  User       User    @relation(fields: [user_id], references: [user_id])
+  user       User    @relation(fields: [user_id], references: [user_id])
 }
 
 model User {
-  user_id Int       @default(autoincrement()) @id
-  name    String?
-  email   String    @unique
-  Post    Post[]
-  Profile Profile[]
-}
-```
-
-### Rename the relation fields for easy access
-
-Because both the generated `Post` and `Profile` fields in the `User` model are _virtual_ (i.e. they're _not backed by a foreign key in the database_), you can manually rename them in your Prisma schema. This will only affect the generated client and is typically done so that they have a more meaningful name in the context of the relation.
-
-In the resulting Prisma schema there are two types of relation fields:
-
-- Relation fields: identified by having a Model name as the type, e.g. the `User` field in the `Post` model. Can be renamed to better fit its usage, e.g. `User` -> `author`.
-- [Relation scalar fields](../..//concepts/components/prisma-schema/relations): these are used to store the foreign key, e.g. the `authorId` field in the `Post` model. Cannot be rename as it must match the field in the database.
-
-The names of the relation fields are used in the client to access those relations for example, fetching a specific `Post` and its associated `User` object would as follows with the Prisma schema above:
-
-```js
-const postAuthor = await prisma.post.findUnique({
-  where: { id: 1 },
-  include: { User: true },
-})
-```
-
-If you rename the `User` field in the `Post` model to `author`, you'll be able to access it as follows:
-
-```js
-const postAuthor = await prisma.post.findUnique({
-  where: { id: 1 },
-  include: { author: true },
-})
-```
-
-Based on that logic, rename the relation fields to better adhere to the [naming conventions](../../reference/api-reference/prisma-schema-reference#naming-conventions-1) <span class="api"></span>:
-
-```prisma
-model Post {
-  post_id   Int     @default(autoincrement()) @id
-  content   String?
-  title     String
-  author_id Int?
-  author    User?   @relation(fields: [author_id], references: [user_id]) // renamed from `User` -> `author`
-}
-
-model Profile {
-  bio        String?
-  profile_id Int     @default(autoincrement()) @id
-  user_id    Int
-  user       User    @relation(fields: [user_id], references: [user_id]) // renamed from `User` -> `user`
-}
-
-model User {
-  email     String    @unique
-  name      String?
-  user_id   Int       @default(autoincrement()) @id
-  posts     Post[]    // renamed from `Post` -> `posts`
-  profiles  Profile[] // renamed from `Profile` -> `profiles`
+  user_id  Int       @id @default(autoincrement())
+  name     String?
+  email    String    @unique
+  posts    Post[]
+  profiles Profile[]
 }
 ```
 


### PR DESCRIPTION
This PR removes the section on renaming. Renaming is no longer necessary as Prisma supports re-introspection and the example already has the fields renamed in the [Prisma schema](https://github.com/prisma/prisma-examples/blob/latest/deployment-platforms/vercel/prisma/schema.prisma#L15).