### PR TITLE
Updated page title

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Prisma schema'
-metaTitle: 'Prisma schema (Reference)'
+title: 'Prisma Schema'
+metaTitle: 'Prisma Schema (Reference)'
 metaDescription: 'The Prisma schema is the main configuration file when using Prisma. It is typically called schema.prisma and contains your database connection and data model.'
 ---
 


### PR DESCRIPTION
Page title wasn't consistent with the other page titles. They all have an upper-case as first letter.