### PR TITLE
fix: make search result block completely clickable

### DIFF
--- a/src/components/search/hitComps.tsx
+++ b/src/components/search/hitComps.tsx
@@ -18,6 +18,7 @@ const HitComp = styled.div`
   }
   a {
     color: ${p => p.theme.colors.gray900} !important;
+    display: block;
   }
   h4 {
     font-weight: normal;


### PR DESCRIPTION
It happens often to me that I click on the block but the a link doesn't cover the whole block so I it ends up closing the results instead of going to the link.

This will make the search a better to me & others ❤️ 