### PR TITLE
fix: Small spelling mistake

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -279,7 +279,7 @@ In a development environment, Prisma Migrate sometimes prompts you to reset the 
 - You call `prisma migrate reset --preview-feature` explicitly
 - You call `prisma migrate dev --preview-feature` and Prisma Migrate detects drift in the database or a migration history conflict
 
-The `prisma migrate dev --preview-feature` and `prisma migrate reset --preview-feature` commands are designed to be used **in development only**, and should not affect poduction data.
+The `prisma migrate dev --preview-feature` and `prisma migrate reset --preview-feature` commands are designed to be used **in development only**, and should not affect production data.
 
 ### Native types preview not yet supported
 


### PR DESCRIPTION
Found a very small spelling mistake in migration docs 👍🏻 