### PR TITLE
Fixed typo 

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1202,7 +1202,7 @@ model User {
 }
 ```
 
-##### Map an enum named `ADMIN` to a database enu named `admin`
+##### Map an enum named `ADMIN` to a database enum named `admin`
 
 ```prisma
 enum Role {


### PR DESCRIPTION
I noticed a typo in Prisma schema API docs, here's the PR to fix it