### PR TITLE
Fix example to be valid sql statement

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/050-prisma-migrate-flows.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/050-prisma-migrate-flows.mdx
@@ -42,9 +42,9 @@ You can choose to change the behavior of a migration **when you create it**. For
 2. Edit the generated `20201208100950_fullname_field/migration.sql` file:
 
    ```sql
-   ALTER TABLE "User" DROP COLUMN "name",
+   - ALTER TABLE "User" DROP COLUMN "name",
    - ADD COLUMN     "fullname" TEXT,
-   + RENAME "name" TO  "fullname"
+   + ALTER TABLE "User" RENAME "name" TO  "fullname";
    ```
 
 3. Migrate:


### PR DESCRIPTION
The example diff resulted in `ALTER TABLE "User" DROP COLUMN "name", RENAME "name" TO "fullname",`.

Changed the diff to result in a valid rename statement.