### PR TITLE
Fix broken quickstart link

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/index.mdx
@@ -6,9 +6,9 @@ metaDescription: 'Prisma Client is an auto-generated, type-safe query builder ge
 
 <TopBlock>
 
-Prisma Client is an auto-generated and type-safe query builder that's _tailored_ to your data. The easiest way to get started with Prisma Client is by following the **[Quickstart](../../../getting-started/quickstart)**.
+Prisma Client is an auto-generated and type-safe query builder that's _tailored_ to your data. The easiest way to get started with Prisma Client is by following the **[Quickstart](../../../getting-started/quickstart-typescript)**.
 
-<ButtonLink color="dark" type="primary" href="../../../getting-started/quickstart">
+<ButtonLink color="dark" type="primary" href="../../../getting-started/quickstart-typescript">
   Quickstart (5 min)
 </ButtonLink>
 


### PR DESCRIPTION
Changes
- `https://www.prisma.io/docs/getting-started/quickstart/`
to
- `https://www.prisma.io/docs/getting-started/quickstart-typescript/`