### PR TITLE
findOne updated to findUnique on Soft Delete Middleware Example Docs

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/180-middleware/100-soft-delete-middleware.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/180-middleware/100-soft-delete-middleware.mdx
@@ -307,9 +307,9 @@ async function mainAsync() {
 
   prisma.$use(async (params, next) => {
     if (params.model == "Post") {
-      if (params.action == "findOne") {
+      if (params.action == "findUnique") {
         // Change to findFirst - you cannot filter
-        // by anything except ID / unique with findOne
+        // by anything except ID / unique with findUnique
         params.action = "findFirst";
         // Add 'deleted' filter
         // ID filter maintained
@@ -334,7 +334,7 @@ async function mainAsync() {
     if (params.model == "Post") {
       if (params.action == "update") {
         // Change to updateMany - you cannot filter
-        // by anything except ID / unique with findOne
+        // by anything except ID / unique with findUnique
         params.action = "updateMany";
         // Add 'deleted' filter
         // ID filter maintained
@@ -482,7 +482,7 @@ async function mainAsync() {
   );
   console.log();
   console.log(
-    "findOne: " +
+    "findUnique: " +
       (getOnePost?.id != undefined
         ? "\u001b[1;32m" + "Posts returned!" + "\u001b[0m"
         : "\u001b[1;31m" +
@@ -554,7 +554,7 @@ Posts created with IDs: 680,681,682
 Deleted post (delete) with ID: 680
 Deleted posts (deleteMany) with IDs: 681,682
 
-findOne: Post not returned!(Value is: [])
+findUnique: Post not returned!(Value is: [])
 findMany: Posts not returned!
 findMany ( delete: true ): Posts returned!
 


### PR DESCRIPTION
Looks like the docs are using an old method findOne that is no longer supported by prisma client.