### PR TITLE
Use Prisma namespace in database access docs

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -171,10 +171,10 @@ const result = await prisma.$queryRaw`SELECT * FROM User WHERE id = ${userId};`
 Prisma Client specifically uses [SQL Template Tag](https://github.com/blakeembrey/sql-template-tag), which exposes a number of helpers. For example, the following query uses `join()` to pass in a list of IDs:
 
 ```ts
-import { join } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 const ids = [1, 3, 5, 10, 20];
-const result = await prisma.$queryRaw`SELECT * FROM User WHERE id IN (${join(
+const result = await prisma.$queryRaw`SELECT * FROM User WHERE id IN (${Prisma.join(
   ids
 )})`;
 ```
@@ -182,11 +182,11 @@ const result = await prisma.$queryRaw`SELECT * FROM User WHERE id IN (${join(
 The following example uses the `empty` and `sql` helpers to change the query depending on whether `userName` is empty:
 
 ```ts
-import { sql, empty } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 const userName = "";
 const result = await prisma.$queryRaw`SELECT * FROM User ${
-  userName ? sql`WHERE name = ${userName}` : empty // Cannot use "" or NULL here!
+  userName ? Prisma.sql`WHERE name = ${userName}` : Prisma.empty // Cannot use "" or NULL here!
 }`;
 ```
 


### PR DESCRIPTION
I'm assuming this is part of the  2.15.0 cleanup: functions such as `sql`, `join` and `empty` are not exported directly from `@prisma/client`, so making necessary changes in the documentation.