### PR TITLE
Fix typo in Section 6 of "Deploying to Heroku"

### DIFF
--- a/content/300-guides/200-deployment/00-deploying-to-heroku.md
+++ b/content/300-guides/200-deployment/00-deploying-to-heroku.md
@@ -183,7 +183,7 @@ Created postgresql-parallel-73780 as DATABASE_URL
 
 ## 6. Set the DATABASE_URL environment variable locally
 
-In the previous step you created the database and saw how Heroku defines `DATABASE_URL` for the application when running on Heroku. In this step, you will to set the `DATABASE_URL` environment variable locally so that you can run the database migration from locally using Prisma.
+In the previous step you created the database and saw how Heroku defines `DATABASE_URL` for the application when running on Heroku. In this step, you will set the `DATABASE_URL` environment variable locally so that you can run the database migration from locally using Prisma.
 
 Get the connection URL with the Heroku CLI:
 


### PR DESCRIPTION
Fix "you will ~~to~~ set the DATABASE_URL environment variable locally"