### PR TITLE
Data model docs minor inconsistency

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -259,8 +259,8 @@ The following table describes `User` model's fields from the sample schema:
 | `email`     | `String`   | Scalar             | -             | `@unique`                             |
 | `name`      | `String`   | Scalar             | `?`           | -                                     |
 | `role`      | `Role`     | Scalar (`enum`)    | -             | `@default(USER)`                      |
-| `posts`     | `Post`     | Relation (Prisma-level field) | `?`           | -                                     |
-| `profile`   | `Profile`  | Relation (Prisma-level field) | `[]`          | -                                     |
+| `posts`     | `Post`     | Relation (Prisma-level field) | `[]`           | -                                     |
+| `profile`   | `Profile`  | Relation (Prisma-level field) | `?`          | -                                     |
 
 </details>
 


### PR DESCRIPTION
In User model's fields from the sample schema post is array and profile is optional in this table this is swapped around