### PR TITLE
fix(docs): user requires REFERENCES grants

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -221,7 +221,7 @@ In order to create and delete the shadow database when using development command
 | Database   | Database user requirements                                                                                                                                                                                            |
 | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SQLite     | No special requirements.                                                                                                                                                                                              |
-| MySQL      | Database user must have `CREATE, ALTER, DROP ON *.*` privileges                                                                                                                                                                       |
+| MySQL      | Database user must have `CREATE, ALTER, DROP, REFERENCES ON *.*` privileges                                                                                                                                                                       |
 | PostgreSQL | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createdatabase.html))                                       |
 | SQL Server | The user must be a site admin or have the `SERVER` securable. See the [official documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine?view=sql-server-ver15). |
 


### PR DESCRIPTION
[The docs](https://www.prisma.io/docs/concepts/components/prisma-migrate#shadow-database-user-permissions) currently state the the mysql user requires `CREATE, ALTER, DROP ON *.*` privileges.

The user requires one more grant, `REFERENCES` - seen in the following error during `prisma migrate dev --preview-feature`

```bash
Error: P3006

Migration `20200202020200_one` failed to apply cleanly to a temporary database. 
Error:
Database error: Error querying the database: Server error: `ERROR 42000 (1142): REFERENCES command denied to user 'prisma'@'172.18.0.1' for table 'SomeTable''
   0: sql_migration_connector::flavour::mysql::sql_schema_from_migration_history
             at migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs:221
   1: sql_migration_connector::sql_database_migration_inferrer::calculate_drift
             at migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs:40
   2: migration_core::api::DevDiagnostic
             at migration-engine/core/src/api.rs:100
```
Granting `prisma` user `REFERENCES` permissions fixed this issue.
<hr />
MySQL: 5.7 <br />
Prisma: 2.15.0 <br />
Node: 12.11.0