### PR TITLE
We don't need to use the Routing mode anymore

### DIFF
--- a/content/200-concepts/100-components/07-preview-features/100-sql-server/index.mdx
+++ b/content/200-concepts/100-components/07-preview-features/100-sql-server/index.mdx
@@ -153,7 +153,3 @@ Microsoft SQL Server [only allows one `NULL` value in a column that has a `UNIQU
 The standard way to get around this issue is to create a filtered unique index that excludes `NULL` values. This allows you to insert multiple `NULL` values. If you do not create an index in the database, you will get an error if you try to insert more than one `null` value into a column with Prisma Client.
 
 _However_, creating an index makes it impossible to use `license_number` as a foreign key in the database (or a relation scalar field in corresponding Prisma Schema)
-
-### Azure SQL firewall connection policy must be proxy
-
-Follow issue [#88 on GitHub](https://github.com/prisma/tiberius/issues/88) for more information.


### PR DESCRIPTION
In the next version of Prisma, we support both: routing and redirect for SQL Server firewall on Azure.

Merged in https://github.com/prisma/prisma-engines/pull/1599
Will be fixed in 2.17.0