### PR TITLE
Consider disabling smooth scrolling

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -5,7 +5,6 @@ html {
   box-sizing: border-box;
   overflow-y: scroll;
   /* Issue 894 */
-  scroll-behavior: smooth;
   font-size: 16px;
 }
 


### PR DESCRIPTION
This PR disables smooth scrolling. I find this quite annoying, especially when you use `cmd+f`.

**Before:** https://cln.sh/4LE2aaySHWeLHGZwdYIM

**After:** https://cln.sh/dRysSWs2k9KpXMWUg5ik

**Note:** There was a comment above that suggested it was related to https://github.com/prisma/docs/issues/894. Not sure how this is related to sticky scrolling, but that might be worth double-checking.

I think this resolves https://github.com/prisma/docs/issues/989