### PR TITLE
fix: DB seed example command

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -592,7 +592,7 @@ npx prisma db push --preview-feature --schema=/tmp/schema.prisma
 #### Examples
 
 ```terminal
-npx prisma db push --preview-feature --force
+npx prisma db seed --preview-feature
 ```
 
 ## Prisma Migrate (Preview)


### PR DESCRIPTION
Fixed wrong example for database seeding command.