### PR TITLE
fix(native types mapping): removed line first, added second

### DIFF
--- a/content/200-concepts/100-components/07-preview-features/200-native-types/100-native-types-mappings.mdx
+++ b/content/200-concepts/100-components/07-preview-features/200-native-types/100-native-types-mappings.mdx
@@ -607,10 +607,10 @@ circle     Unsupported("circle")?   @default(dbgenerated("'<(10,4),11>'::circle"
 
 You can also use `dbgenerated()` to set the default value for supported types. For example, you can generate UUIDs at database level rather than rely on Prisma's `uuid()`:
 
-```prisma highlight=2;add|3;delete
+```prisma highlight=3;add|2;delete
 model User {
-  id   String  @id @db.Uuid @default(dbgenerated("gen_random_uuid()"))
   id   String  @id @db.Uuid @default(uuid())
+  id   String  @id @db.Uuid @default(dbgenerated("gen_random_uuid()"))
   test String?
 }
 ```


### PR DESCRIPTION
Diffs usually show removed line first, then added one (I think?)