### PR TITLE
Remove db push + migrate side effects section

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -510,19 +510,6 @@ The `db push` command pushes the state of your Prisma schema file to the databas
 - You want to keep track of changes made to the database schema over time. `db push` does not create any artifacts that allow you to keep track of these changes.
 - You want the schema changes to be reversible. You can use `db push` again to revert to the original state, but this might result in data loss and there will be no mechanism for you to orchestrate these changes.
 
-#### <inlinecode>db push</inlinecode> and Migrate (Preview)
-
-If you are already using migrations with Prisma Migrate, `db push` will still work. However, be aware of the following side effects of using both Prisma Migrate and `db push`:
-
-Prisma Migrate introspects the database to anticipate the changes needed to reach the end-state of the migration and Preview these changes as DDL statements in `README.md` files.
-
-If you use `db push` to change the database schema using the Prisma Schema file, and subsequently use `prisma migrate dev --preview-feature` to generate the corresponding migration:
-
-1. Migrate will still work regardless if it is executed on top of the changes from `db push` or not, **but**
-2. the DDL statements in `README.md` will **not** reflect the steps carried out in other environments where `db push` was not used - the statements can be different or entirely missing.
-
-Because this behavior could be confusing to some, if `db push` detect migration files, it will require confirmation to proceed or supplying an `—-ignore-migrations` option.
-
 #### Prerequisites
 
 Before using the `db push` command, you must define a valid [datasource](../../concepts/components/prisma-schema/data-sources) within your `schema.prisma` file.


### PR DESCRIPTION
This is no longer relevant with Migrate Experimental. The flag has also been removed.