### PR TITLE
Wrong native type in SQL Server boolean example.

### DIFF
--- a/content/200-concepts/100-components/07-preview-features/200-native-types/100-native-types-mappings.mdx
+++ b/content/200-concepts/100-components/07-preview-features/200-native-types/100-native-types-mappings.mdx
@@ -152,11 +152,11 @@ The following table lists the SQL Server native database types that map to Prism
 
 | Native database types | Native database type attribute | Notes |
 | :-------------------- | :----------------------------- | ----- |
-| `bit`                 | `@db.Bit(x)`                      | `@db.Bit(1)` maps to `Boolean`      |
+| `bit`                 | `@db.Bit`                      | `@db.Bit` maps to `Boolean`      |
 
 ```prisma
 model Sample {
-  bit       Boolean    @db.Bit(5)
+  bit       Boolean    @db.Bit
 }
 ```
 


### PR DESCRIPTION
`BIT(n)` doesn't exist in SQL Server.