### PR TITLE
fix \$transaction

### DIFF
--- a/content/300-guides/100-prisma-guides/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-prisma-guides/100-prisma-client-transactions-guide.mdx
@@ -371,7 +371,7 @@ You an use the [`$transaction` API to perform a cascading delete](#are-cascading
 
 Yes - for example, you can include multiple `deleteMany` operations inside a `$transaction`.
 
-### <inlinecode>\$transaction</inlinecode> API
+### `$transaction` API
 
 The `$transaction` API is generic solution to independent writes that allows you to run multiple operations as a single, atomic operation - if any operation fails, Prisma rolls back the entire transaction. As the Prisma Client evolves, use cases for the `$transaction` API will increasingly be replaced by more specialized bulk operations (such as `createMany`) and nested writes.
 


### PR DESCRIPTION
Prettier automatically escapes `$` to `\$`, so I think this will continue to be a problem. Any reason we go with `<inlinecode>$transaction</inlinecode>` and not backticks?

https://www.prisma.io/docs/guides/prisma-guides/prisma-client-transactions-guide#transaction-api

<img width="952" alt="CleanShot 2021-02-16 at 13 22 38@2x" src="https://user-images.githubusercontent.com/170299/108062471-1ebcf680-705a-11eb-9031-81a9949bcec4.png">
