### PR TITLE
fix(deployment): Fix indentation of connection string examples

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/190-deployment.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/190-deployment.mdx
@@ -62,17 +62,17 @@ If your machine four physical CPUs, your connection pool will contain nine conne
 - **Long running process (PaaS)**: It's recommended to use the default of `num_physical_cpus * 2 + 1`. That number should be multiplied by the number of application instances to ensure it's under the database's limit. For example if your database's connection limit is _10_ and you have _two_ instances of your app, the connection limit should be no more than _5_.
 - **Serverless (FaaS)**: It's recommended to set the connection limit to 1 if you're not using an external connection pooler because each incoming request starts a short-lived Node.js process. This can cause the database connection pool to be quickly exhausted from a short spike in user traffic.
 
-**PostgreSQL**
+  **PostgreSQL**
 
-```
-postgresql://USER:PASSWORD@HOST:PORT/DATABASE?connection_limit=1
-```
+  ```
+  postgresql://USER:PASSWORD@HOST:PORT/DATABASE?connection_limit=1
+  ```
 
-**MySQL**
+  **MySQL**
 
-```
-mysql://USER:PASSWORD@HOST:PORT/DATABASE?connection_limit=1
-```
+  ```
+  mysql://USER:PASSWORD@HOST:PORT/DATABASE?connection_limit=1
+  ```
 
 ### Usage with PgBouncer
 


### PR DESCRIPTION
Currently the 2 examples are on the same level as the headline before the list, but the examples really belong to the second list item only.