### PR TITLE
Fix wording for @@map description

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1599,7 +1599,7 @@ Maps a model name from the Prisma schema to a different table name, or an enum n
 
 | Name   | Type     | Required | Description               | Example                         |
 | :----- | :------- | :------- | :------------------------ | :------------------------------ |
-| `name` | `String` | **Yes**  | The database column name. | `"comments"`, `"someTableName"` |
+| `name` | `String` | **Yes**  | The database table name. | `"comments"`, `"someTableName"` |
 
 The name of the `name` argument on the `@@map` attribute can be omitted
 


### PR DESCRIPTION
I think the description in the table for `@@map` should read `The database table name.` instead of `The database column name.` The way it currently stands makes `@map` and `@@map` appear to do the same thing.