### PR TITLE
Fix: reference for mode

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -3142,13 +3142,14 @@ const result = await prisma.post.count({
 
 #### Examples
 
-##### Get all `Post` records where `content` contains `databases`
+##### Get all `Post` records where `title` contains `prisma`, in a case insensitive way
 
 ```js
 const result = await prisma.post.findMany({
   where: {
-    content: {
-      contains: 'databases',
+    title: {
+      contains: 'prisma',
+      mode: 'insensitive',
     },
   },
 })


### PR DESCRIPTION
Currently the `mode` documentation contains an example for `contains`. This PR adds a basic example that includes `mode: 'insensitive'` 