### PR TITLE
Update 06-upgrading-prisma-binding-to-sdl-first.mdx

### DIFF
--- a/content/300-guides/300-upgrade-guides/01-upgrade-from-prisma-1/06-upgrading-prisma-binding-to-sdl-first.mdx
+++ b/content/300-guides/300-upgrade-guides/01-upgrade-from-prisma-1/06-upgrading-prisma-binding-to-sdl-first.mdx
@@ -1103,7 +1103,7 @@ const resolvers = {
     users: (_, args, context, info) => {
       // this doesn't work yet
       const { where, orderBy, skip, first, last, after, before } = args
-      return context.prismaClient.user.findMany({
+      return context.prisma.user.findMany({
         where,
         orderBy,
         skip,
@@ -1185,7 +1185,7 @@ const resolvers = {
           : Boolean(before)
           ? prisma2Before
           : prisma2After
-      return context.prismaClient.user.findMany({
+      return context.prisma.user.findMany({
         where: prisma2Where,
         orderBy: prisma2OrderBy,
         skip: prisma2Skip,


### PR DESCRIPTION
changed prismaClient to prisma, since it configures the server to use it like that:
```js line-number
const { PrismaClient } = require('@prisma/client')

// ...

const server = new GraphQLServer({
  typeDefs: 'src/schema.graphql',
  resolvers,
  context: req => ({
    ...req,
-    prisma: new Prisma({   // this line here is prisma
-      typeDefs: 'src/generated/prisma.graphql',
-      endpoint: 'http://localhost:4466',
-    }),
+    prisma: new PrismaClient()
  }),
})
```