### PR TITLE
Update 100-prisma-schema-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -373,6 +373,7 @@ model Model {
 | `text`               | `@db.Text`                     |
 | `ntext`              | `@db.NText`                    |
 | `xml`                | `@db.Xml`                      |
+| `uniqueidentifier`   | `@db.UniqueIdentifier`         |
 
 #### SQLite
 
@@ -751,6 +752,7 @@ Not supported
 | `binary`              | `@db.Binary`                   |
 | `varbinary`           | `@db.VarBinary`                |  |
 | `image`               | `@db.Image`                    |
+| `bit`                 | `@db.Bit`                      |
 
 #### SQLite
 


### PR DESCRIPTION
Added two missing sqlserver types, 
MySQL Serial was a false alarm,
Missing MySQL Unsigned types are already in a separate PR afaik 
```
            UnsignedInt => ScalarType::Int,
            UnsignedSmallInt => ScalarType::Int,
            UnsignedTinyInt => ScalarType::Int,
            UnsignedMediumInt => ScalarType::Int,
            UnsignedBigInt => ScalarType::BigInt,
```