### PR TITLE
Add bottom padding to TOCList

### DIFF
--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -15,7 +15,7 @@ const ChapterTitle = styled.div`
 `
 
 const TOCList = styled.ul`
-  padding: 0;
+  padding: 0 0 1em;
   list-style-type: none;
   margin: 0;
   li {


### PR DESCRIPTION
- Change the bottom padding of `TOCList` component. 

**Before:**
![Screen Shot 2021-03-03 at 10 04 25 AM](https://user-images.githubusercontent.com/46835608/109753234-e98ed780-7c07-11eb-9820-0ceaeae671e4.png)

**After:**
![Screen Shot 2021-03-03 at 10 03 48 AM](https://user-images.githubusercontent.com/46835608/109753211-de3bac00-7c07-11eb-9d54-5420e2b1edbd.png)

Notice the difference in the spacing in the bottom right corner.

It's a really small thing that bothered me for no reason, so just thought of fixing it.