### PR TITLE
fix(500-under-the-hood): Restructure "Using custom engine binaries"

### DIFF
--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -40,7 +40,7 @@ Use the following environment variables to specify custom locations for your bin
 
 #### Setting the environment variable
 
-There are multiple ways to at an environment variables. Here are two ways:
+You can define environment variables globally on your machine or in the `.env` file.
 
 ##### a) The `.env` file
 

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -26,7 +26,7 @@ As an example, Prisma Client connects to the [query engine](../components/prisma
 
 ### Using custom engine binaries
 
-By default, all binaries are automatically downloaded into the `node_modules/prisma` folder when you install or update `prisma`. You might want to use a [custom binary](https://github.com/prisma/prisma-engines) file if:
+By default, all binaries are automatically downloaded into the `node_modules/@prisma/engines` folder when you install or update `prisma`. You might want to use a [custom binary](https://github.com/prisma/prisma-engines) file if:
 
 - Automated download of binaries is not possible.
 - You have created your own engine binary (for testing, or for an OS that is not officially supported).
@@ -38,73 +38,39 @@ Use the following environment variables to specify custom locations for your bin
 - `PRISMA_INTROSPECTION_ENGINE_BINARY` (Introspection engine)
 - `PRISMA_FMT_BINARY` (for `npx prisma format`)
 
-#### The `.env` file
+#### Setting the environment variable
 
-To set an environment variable in the [`.env` file](../concepts/components/prisma-schema#using-env-files):
+There are multiple ways to at an environment variables. Here are two ways:
 
-1. Add the environment variable to the  `.env` file (The Prisma CLI looks for [an .env file in`.env` file in several locations](../concepts/components/prisma-schema#using-env-files)):
+##### a) The `.env` file
 
-   <TabbedContent tabs={[<FileWithIcon text="Unix, MacOS" icon="code"/> , <FileWithIcon text="Windows" icon="display"/>]}>
+Add the environment variable to the  [`.env` file](../concepts/components/prisma-schema#using-env-files) (The Prisma CLI looks for [an .env file in`.env` file in several locations](../concepts/components/prisma-schema#using-env-files)):
 
-   <tab>
+<TabbedContent tabs={[<FileWithIcon text="Unix, MacOS" icon="code"/> , <FileWithIcon text="Windows" icon="display"/>]}>
 
-   ```
-   PRISMA_QUERY_ENGINE_BINARY=custom/my-query-engine-unix
-   ```
+<tab>
 
-   </tab>
-   <tab>
+```
+PRISMA_QUERY_ENGINE_BINARY=custom/my-query-engine-unix
+```
 
-   ```
-   PRISMA_QUERY_ENGINE_BINARY=c:\custom\path\my-query-engine-binary.exe
-   ```
+</tab>
+<tab>
 
-   </tab>
-   </TabbedContent>
+```
+PRISMA_QUERY_ENGINE_BINARY=c:\custom\path\my-query-engine-binary.exe
+```
 
-2. Run the following command to output the paths to all binaries:
-
-   ```terminal
-   npx prisma -v
-   ```
-
-   The output shows that the query engine path comes from the `PRISMA_QUERY_ENGINE_BINARY` environment variable:
-
-   <TabbedContent tabs={[<FileWithIcon text="Unix, macOS" icon="code"/> , <FileWithIcon text="Windows" icon="display"/>]}>
-
-   <tab>
-
-   ```sh highlight=2;normal
-   Current platform     : darwin
-   Query Engine         : query-engine d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /custom/my-query-engine-unix)
-   Migration Engine     : migration-engine-cli d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/migration-engine-windows)
-   Introspection Engine : introspection-core d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/introspection-engine-windows)
-   Format Binary        : prisma-fmt d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/prisma-fmt-windows)
-   ```
-
-    </tab>
-    <tab>
-
-   ```sh highlight=2;normal
-   Current platform     : windows
-   Query Engine         : query-engine d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\custom\my-query-engine-windows.exe)
-   Migration Engine     : migration-engine-cli d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\myproject\node_modules\@prisma\engines\migration-engine-windows.exe)
-   Introspection Engine : introspection-core d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\myproject\node_modules\@prisma\engines\introspection-engine-windows.exe)
-   Format Binary        : prisma-fmt d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\myproject\node_modules\@prisma\engines\prisma-fmt-windows.exe)
-   ```
-
-    </tab>
-    </TabbedContent>
+</tab>
+</TabbedContent>
 
 > **Note**: It is possible to [use an `.env` file in a location outside the `prisma` folder](../components/prisma-schema#manage-env-files-manually).
 
-#### Global environment variable
+##### b) Global environment variable
 
-To set the an environment variable globally (in this example, `PRISMA_QUERY_ENGINE_BINARY`):
+Run the following command to set the environment variable globally (in this example, `PRISMA_QUERY_ENGINE_BINARY`):
 
-1. Run the following command to set the environment variable:
-
-   <TabbedContent tabs={[<FileWithIcon text="Unix, macOS" icon="code"/> , <FileWithIcon text="Windows" icon="display"/>]}>
+<TabbedContent tabs={[<FileWithIcon text="Unix, macOS" icon="code"/> , <FileWithIcon text="Windows" icon="display"/>]}>
 
    <tab>
 
@@ -122,38 +88,41 @@ To set the an environment variable globally (in this example, `PRISMA_QUERY_ENGI
 
    </tab>
 
-   </TabbedContent>
+</TabbedContent>
+   
+#### Confirm the environment variable is picked up 
 
-2. Run the following command to output the paths to all binaries:
+Run the following command to output the paths to all binaries:
 
-   ```terminal
-   npx prisma -v
-   ```
+```terminal
+npx prisma -v
+```
 
-   The output shows that the query engine path comes from the `PRISMA_QUERY_ENGINE_BINARY` environment variable:
+The output shows that the query engine path comes from the `PRISMA_QUERY_ENGINE_BINARY` environment variable:
 
-   <TabbedContent tabs={[<FileWithIcon text="Unix, MacOS" icon="code"/> , <FileWithIcon text="Windows" icon="display"/>]}>
+<TabbedContent tabs={[<FileWithIcon text="Unix, macOS" icon="code"/> , <FileWithIcon text="Windows" icon="display"/>]}>
 
    <tab>
 
    ```sh highlight=2;normal
    Current platform     : darwin
    Query Engine         : query-engine d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /custom/my-query-engine-unix)
-   Migration Engine     : migration-engine-cli d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/migration-engine-windows)
-   Introspection Engine : introspection-core d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/introspection-engine-windows)
-   Format Binary        : prisma-fmt d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/prisma-fmt-windows)
+   Migration Engine     : migration-engine-cli d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/migration-engine-unix)
+   Introspection Engine : introspection-core d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/introspection-engine-unix)
+   Format Binary        : prisma-fmt d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/prisma-fmt-unix)
    ```
 
-    </tab>
-    <tab>
+   </tab>
+   <tab>
 
    ```sh highlight=2;normal
-    Current platform     : windows
-    Query Engine         : query-engine 854c8ba7f0dce66f115af36af24e66989a8c02a1 (at c:\custom\my-query-engine-windows.exe)
-    Migration Engine     : migration-engine-cli 854c8ba7f0dce66f115af36af24e66989a8c02a1 (at node_modules\@prisma\engines\migration-engine-windows.exe)
-    Introspection Engine : introspection-core 854c8ba7f0dce66f115af36af24e66989a8c02a1 (at node_modules\@prisma\engines\introspection-engine-windows.exe)
-    Format Binary        : prisma-fmt 854c8ba7f0dce66f115af36af24e66989a8c02a1 (at node_modules\@prisma\engines\prisma-fmt-windows.exe)
+   Current platform     : windows
+   Query Engine         : query-engine d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\custom\my-query-engine-windows.exe)
+   Migration Engine     : migration-engine-cli d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\myproject\node_modules\@prisma\engines\migration-engine-windows.exe)
+   Introspection Engine : introspection-core d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\myproject\node_modules\@prisma\engines\introspection-engine-windows.exe)
+   Format Binary        : prisma-fmt d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\myproject\node_modules\@prisma\engines\prisma-fmt-windows.exe)
    ```
 
-    </tab>
-    </TabbedContent>
+   </tab>
+
+</TabbedContent>

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -90,7 +90,7 @@ Run the following command to set the environment variable globally (in this exam
 
 </TabbedContent>
    
-#### Confirm the environment variable is picked up 
+#### Test your environment variable
 
 Run the following command to output the paths to all binaries:
 


### PR DESCRIPTION
1. Fixes location of binaries
2. Restructures the instructions to set environment variables to avoid duplication of "check if it worked" step
3. Also fixes small details of the `-v` output