### PR TITLE
Fix typo errors in concepts/datamodels that caused misrendering.

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -248,7 +248,7 @@ With this model definition, Prisma automatically maps the `Comment` model to the
 The properties of a model are called _fields_, which consist of:
 
 - A **[field name](../../../reference/api-reference/prisma-schema-reference#model-fields)** <span class="api"></span>
-- A **field type]**
+- A **[field type](../../../reference/api-reference/prisma-schema-reference#model-fields)** <span class="api"></span>
 - Optional **[type modifiers](#type-modifiers)**
 - Optional **[attributes](#defining-attributes)**, including [native database type attributes](#native-types-mapping)
 

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -386,7 +386,7 @@ When you introspect a database, unsupported types are added as [`Unsupported`](.
 ```prisma
 location    Unsupported("polygon")?
 ```
-The `Unsupported` attribute allows you to define fields in the Prisma schema for database types that are not yet supported by Prisma. For example, MySQL's `POLOYGON` type is not currently supported by Prisma, but can now be added to the Prisma schema using the `Unsupported("polygon")` type.
+The `Unsupported` attribute allows you to define fields in the Prisma schema for database types that are not yet supported by Prisma. For example, MySQL's `POLYGON` type is not currently supported by Prisma, but can now be added to the Prisma schema using the `Unsupported("polygon")` type.
 
 `Unsupported` fields are not available in the generated Prisma Client API, but can still use `queryRaw` to query these fields.
 


### PR DESCRIPTION
The following edits pertain to this #1396 issue:
- Edited a spelling mistake in the naming of MySQL's type `POLYGON` that is not supported by Prisma.
- Added proper markdown link syntax to the `field type` bullet point in the "Defining Fields" section.