### PR TITLE
Fixed logic error in generated types example

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -145,8 +145,7 @@ async function main() {
         },
       },
     }
-  }
-  {
+  } else {
     user = {
       email: 'elsa@prisma.io',
       name: 'Elsa Prisma',


### PR DESCRIPTION
[This page of the docs](https://www.prisma.io/docs/concepts/components/prisma-client/crud) is demonstrating record creation with generated types, but it looks like there was an "else" keyword forgotten for the case when posts shouldn't be included. I believe this should fix it.