### PR TITLE
added new env vars page and linked to headers

### DIFF
--- a/content/100-getting-started/02-setup-prisma/02-start-from-scratch.mdx
+++ b/content/100-getting-started/02-setup-prisma/02-start-from-scratch.mdx
@@ -143,10 +143,10 @@ datasource db {
 ```
 
 In this case, the `url` is [set via an environment variable](../../concepts/components/prisma-schema#using-environment-variables) which is defined in `.env`:
-
 ```js file=.env
 DATABASE_URL = 'postgresql://johndoe:randompassword@localhost:5432/mydb?schema=public'
 ```
+
 
 You now need to adjust the connection URL to point to your own database.
 
@@ -841,7 +841,7 @@ const deletedUser = await prisma.user.delete({
 
 ### Explore the data in Prisma Studio
 
-Prisma Studio is a visual editor for the data in your database.  
+Prisma Studio is a visual editor for the data in your database.
 You can run it with two ways:
 
 1. Run `$ npx prisma studio` in your terminal.

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -37,6 +37,7 @@ Use the following environment variables to specify custom locations for your bin
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary) (Migration engine)
 - [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) (Introspection engine)
 - [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) (for `npx prisma format`)
+- [`PRISMA_CLI_BINARY_TARGETS`](../../reference/api-reference/environment-variables-reference/#prisma_cli_binary_targets)
 
 #### Setting the environment variable
 

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -35,7 +35,7 @@ Use the following environment variables to specify custom locations for your bin
 
 - [`PRISMA_QUERY_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_query_engine_binary) <span class="api"></span> (Query engine)
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary)  <span class="api"></span> (Migration engine)
-- [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) (Introspection engine)
+- [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) <span class="api"></span> (Introspection engine)
 - [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) (for `npx prisma format`)
 - [`PRISMA_CLI_BINARY_TARGETS`](../../reference/api-reference/environment-variables-reference/#prisma_cli_binary_targets) <span class="api"></span>
 

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -33,7 +33,7 @@ By default, all binaries are automatically downloaded into the `node_modules/@pr
 
 Use the following environment variables to specify custom locations for your binaries:
 
-- [`PRISMA_QUERY_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_query_engine_binary) (Query engine)
+- [`PRISMA_QUERY_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_query_engine_binary) <span class="api"></span> (Query engine)
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary) (Migration engine)
 - [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) (Introspection engine)
 - [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) (for `npx prisma format`)

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -36,7 +36,7 @@ Use the following environment variables to specify custom locations for your bin
 - [`PRISMA_QUERY_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_query_engine_binary) <span class="api"></span> (Query engine)
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary)  <span class="api"></span> (Migration engine)
 - [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) <span class="api"></span> (Introspection engine)
-- [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) (for `npx prisma format`)
+- [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) <span class="api"></span> (for `npx prisma format`)
 - [`PRISMA_CLI_BINARY_TARGETS`](../../reference/api-reference/environment-variables-reference/#prisma_cli_binary_targets) <span class="api"></span>
 
 #### Setting the environment variable

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -37,7 +37,7 @@ Use the following environment variables to specify custom locations for your bin
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary) (Migration engine)
 - [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) (Introspection engine)
 - [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) (for `npx prisma format`)
-- [`PRISMA_CLI_BINARY_TARGETS`](../../reference/api-reference/environment-variables-reference/#prisma_cli_binary_targets)
+- [`PRISMA_CLI_BINARY_TARGETS`](../../reference/api-reference/environment-variables-reference/#prisma_cli_binary_targets) <span class="api"></span>
 
 #### Setting the environment variable
 

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -33,10 +33,10 @@ By default, all binaries are automatically downloaded into the `node_modules/@pr
 
 Use the following environment variables to specify custom locations for your binaries:
 
-- `PRISMA_QUERY_ENGINE_BINARY` (Query engine)
-- `PRISMA_MIGRATION_ENGINE_BINARY` (Migration engine)
-- `PRISMA_INTROSPECTION_ENGINE_BINARY` (Introspection engine)
-- `PRISMA_FMT_BINARY` (for `npx prisma format`)
+- [`PRISMA_QUERY_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_query_engine_binary) (Query engine)
+- [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary) (Migration engine)
+- [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) (Introspection engine)
+- [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) (for `npx prisma format`)
 
 #### Setting the environment variable
 
@@ -89,7 +89,7 @@ Run the following command to set the environment variable globally (in this exam
    </tab>
 
 </TabbedContent>
-   
+
 #### Test your environment variable
 
 Run the following command to output the paths to all binaries:

--- a/content/200-concepts/050-overview/500-under-the-hood.mdx
+++ b/content/200-concepts/050-overview/500-under-the-hood.mdx
@@ -34,7 +34,7 @@ By default, all binaries are automatically downloaded into the `node_modules/@pr
 Use the following environment variables to specify custom locations for your binaries:
 
 - [`PRISMA_QUERY_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_query_engine_binary) <span class="api"></span> (Query engine)
-- [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary) (Migration engine)
+- [`PRISMA_MIGRATION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary)  <span class="api"></span> (Migration engine)
 - [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) (Introspection engine)
 - [`PRISMA_FMT_BINARY`](../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) (for `npx prisma format`)
 - [`PRISMA_CLI_BINARY_TARGETS`](../../reference/api-reference/environment-variables-reference/#prisma_cli_binary_targets) <span class="api"></span>

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/150-error-formatting.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/150-error-formatting.mdx
@@ -27,7 +27,7 @@ In order to configure these different error formatting levels, there are two opt
 
 ## Formatting via environment variables
 
-- `NO_COLOR`: If this env var is provided, colors are stripped from the error message. Therefore you end up with a **colorless error**. The `NO_COLOR` environment variable is a standard described [here](https://no-color.org/).
+- [`NO_COLOR`](../../../../reference/api-reference/environment-variables-reference/#no_color): If this env var is provided, colors are stripped from the error message. Therefore you end up with a **colorless error**. The `NO_COLOR` environment variable is a standard described [here](https://no-color.org/).
 - `NODE_ENV=production`: If the env var `NODE_ENV` is set to `production`, only the **minimal error** will be printed. This allows for easier digestion of logs in production environments.
 
 ### Formatting via the `PrismaClient` constructor

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/150-error-formatting.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/150-error-formatting.mdx
@@ -27,7 +27,7 @@ In order to configure these different error formatting levels, there are two opt
 
 ## Formatting via environment variables
 
-- [`NO_COLOR`](../../../../reference/api-reference/environment-variables-reference/#no_color): If this env var is provided, colors are stripped from the error message. Therefore you end up with a **colorless error**. The `NO_COLOR` environment variable is a standard described [here](https://no-color.org/).
+- [`NO_COLOR`](../../../../reference/api-reference/environment-variables-reference/#no_color): If this env var is provided, colors are stripped from the error messages. Therefore you end up with a **colorless error**. The `NO_COLOR` environment variable is a standard described [here](https://no-color.org/).
 - `NODE_ENV=production`: If the env var `NODE_ENV` is set to `production`, only the **minimal error** will be printed. This allows for easier digestion of logs in production environments.
 
 ### Formatting via the `PrismaClient` constructor

--- a/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
@@ -6,7 +6,7 @@ metaDescription: 'This page explains how to enable debugging output for Prisma C
 
 ## Overview
 
-You can enable debugging output in Prisma Client via the `DEBUG` environment variable. It accepts two namespaces to print debugging output:
+You can enable debugging output in Prisma Client via the [`DEBUG`](../../../reference/api-reference/environment-variables-reference/#debug) environment variable. It accepts two namespaces to print debugging output:
 
 - `engine`: Prints relevant debug messages happening in a Prisma [engine](https://github.com/prisma/prisma-engines/)
 - `prisma-client`: Prints relevant debug messages happening in the Prisma Client runtime

--- a/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
@@ -8,8 +8,9 @@ metaDescription: 'This page explains how to enable debugging output for Prisma C
 
 You can enable debugging output in Prisma Client via the [`DEBUG`](../../../reference/api-reference/environment-variables-reference/#debug) environment variable. It accepts two namespaces to print debugging output:
 
-- `engine`: Prints relevant debug messages happening in a Prisma [engine](https://github.com/prisma/prisma-engines/)
-- `prisma-client`: Prints relevant debug messages happening in the Prisma Client runtime
+- `prisma:engine`: Prints relevant debug messages happening in a Prisma [engine](https://github.com/prisma/prisma-engines/)
+- `prisma:client`: Prints relevant debug messages happening in the Prisma Client runtime
+- `prisma*`: Prints all debug messages from Prisma Client or CLI
 
 ## Setting the `DEBUG` environment variable
 

--- a/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
@@ -16,14 +16,14 @@ You can enable debugging output in Prisma Client via the [`DEBUG`](../../../refe
 Here are examples for setting these debugging options in bash:
 
 ```terminal
-# enable only `engine`-level debugging output
+# enable only `prisma:engine`-level debugging output
 export DEBUG="engine"
 
-# enable only `prisma-client`-level debugging output
-export DEBUG="prisma-client"
+# enable only `prisma:client`-level debugging output
+export DEBUG="prisma:client"
 
 # enable both `prisma-client`- and `engine`-level debugging output
-export DEBUG="prisma-client,engine"
+export DEBUG="prisma:client,prisma:engine"
 ```
 
 If you want to enable all debugging options, you can also set `DEBUG` to `*`:

--- a/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
+++ b/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
@@ -110,7 +110,7 @@ To activate the proxy, provide the environment variables `HTTP_PROXY` and/or `HT
 
 The following environment variables can be provided:
 
-- [`HTTP_PROXY`](../../../reference/api-reference/environment-variables-reference/#http_proxy) or `http_proxy`: Proxy URL for http traffic, for example `http://localhost:8080`
+- [`HTTP_PROXY`](../../../reference/api-reference/environment-variables-reference/#http_proxy) <span class="api"></span> or `http_proxy`: Proxy URL for http traffic, for example `http://localhost:8080`
 - [`HTTPS_PROXY`](../../../reference/api-reference/environment-variables-reference/#https_proxy) or `https_proxy`: Proxy URL for https traffic, for example `https://localhost:8080`
 
 > To get a local proxy, you can also use the [`proxy`](https://www.npmjs.com/package/proxy) module.

--- a/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
+++ b/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
@@ -110,7 +110,7 @@ To activate the proxy, provide the environment variables `HTTP_PROXY` and/or `HT
 
 The following environment variables can be provided:
 
-- `HTTP_PROXY` or `http_proxy`: Proxy URL for http traffic, for example `http://localhost:8080`
-- `HTTPS_PROXY` or `https_proxy`: Proxy URL for https traffic, for example `https://localhost:8080`
+- [`HTTP_PROXY`](../../../reference/api-reference/environment-variables-reference/#http_proxy) or `http_proxy`: Proxy URL for http traffic, for example `http://localhost:8080`
+- [`HTTPS_PROXY`](../../../reference/api-reference/environment-variables-reference/#https_proxy) or `https_proxy`: Proxy URL for https traffic, for example `https://localhost:8080`
 
 > To get a local proxy, you can also use the [`proxy`](https://www.npmjs.com/package/proxy) module.

--- a/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
+++ b/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
@@ -111,6 +111,6 @@ To activate the proxy, provide the environment variables `HTTP_PROXY` and/or `HT
 The following environment variables can be provided:
 
 - [`HTTP_PROXY`](../../../reference/api-reference/environment-variables-reference/#http_proxy) <span class="api"></span> or `http_proxy`: Proxy URL for http traffic, for example `http://localhost:8080`
-- [`HTTPS_PROXY`](../../../reference/api-reference/environment-variables-reference/#https_proxy) or `https_proxy`: Proxy URL for https traffic, for example `https://localhost:8080`
+- [`HTTPS_PROXY`](../../../reference/api-reference/environment-variables-reference/#https_proxy)  <span class="api"></span> or `https_proxy`: Proxy URL for https traffic, for example `https://localhost:8080`
 
 > To get a local proxy, you can also use the [`proxy`](https://www.npmjs.com/package/proxy) module.

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma Client API'
+title: 'Prisma Client API reference'
 metaTitle: 'Prisma Client API (Reference)'
 metaDescription: 'API reference documentation for Prisma Client.'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma Client API Reference'
+title: 'Prisma Client API'
 metaTitle: 'Prisma Client API (Reference)'
 metaDescription: 'API reference documentation for Prisma Client.'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/075-error-reference.mdx
+++ b/content/400-reference/200-api-reference/075-error-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma Client error reference'
+title: 'Prisma Client error'
 metaTitle: 'Prisma Client error reference (Reference)'
 metaDescription: 'Prisma Client errors'
 ---

--- a/content/400-reference/200-api-reference/075-error-reference.mdx
+++ b/content/400-reference/200-api-reference/075-error-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma Client error'
+title: 'Errors'
 metaTitle: 'Prisma Client error reference (Reference)'
 metaDescription: 'Prisma Client errors'
 ---

--- a/content/400-reference/200-api-reference/075-error-reference.mdx
+++ b/content/400-reference/200-api-reference/075-error-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Errors'
+title: 'Errors reference'
 metaTitle: 'Prisma Client error reference (Reference)'
 metaDescription: 'Prisma Client errors'
 ---

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma schema'
+title: 'Prisma schema reference'
 metaTitle: 'Prisma schema API (Reference)'
 metaDescription: 'API reference documentation for the Prisma Schema Language (PSL).'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -104,7 +104,7 @@ datasource db {
 }
 ```
 
-When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the [DATABASE_URL](./environment-variables-reference/#database-url) environment variable is set.
+When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set.
 
 One way to do so is by creating a [`.env`](https://github.com/motdotla/dotenv) file with the following contents. Note that the file must be in the same directory as your `schema.prisma` file to automatically picked up the Prisma CLI.
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma schema API reference'
+title: 'Prisma schema API'
 metaTitle: 'Prisma schema API (Reference)'
 metaDescription: 'API reference documentation for the Prisma Schema Language (PSL).'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -104,7 +104,7 @@ datasource db {
 }
 ```
 
-When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set.
+When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the [DATABASE_URL](./environment-variables-reference/#database-url) environment variable is set.
 
 One way to do so is by creating a [`.env`](https://github.com/motdotla/dotenv) file with the following contents. Note that the file must be in the same directory as your `schema.prisma` file to automatically picked up the Prisma CLI.
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma schema API'
+title: 'Prisma schema'
 metaTitle: 'Prisma schema API (Reference)'
 metaDescription: 'API reference documentation for the Prisma Schema Language (PSL).'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'CLI command'
+title: 'Prisma CLI'
 metaTitle: 'Prisma CLI Command Reference'
 metaDescription: 'This page gives an overview of all available Prisma CLI commands, explains their options and shows numerous usage examples.'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'CLI command reference'
+title: 'CLI command'
 metaTitle: 'Prisma CLI Command Reference'
 metaDescription: 'This page gives an overview of all available Prisma CLI commands, explains their options and shows numerous usage examples.'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Prisma CLI'
+title: 'Prisma CLI reference'
 metaTitle: 'Prisma CLI Command Reference'
 metaDescription: 'This page gives an overview of all available Prisma CLI commands, explains their options and shows numerous usage examples.'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Environment variables reference'
+title: 'Environment variables'
 metaTitle: 'Prisma environment variables reference'
 metaDescription: 'This page gives an overview of all environment variables avalaible for use.'
 tocDepth: 2

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -1,0 +1,187 @@
+---
+title: 'Environment variables reference'
+metaTitle: 'Prisma environment variables reference'
+metaDescription: 'This page gives an overview of all environment variables avalaible for use.'
+tocDepth: 2
+---
+
+## Overview
+
+This document describes different environment variables and their use cases.
+
+### DATABASE_URL
+
+`DATABASE_URL` is used to connect to your database. The url format can differ depending on the database it is connecting to.
+Prisma currently supports 4 types of database connectors, of which 3 use the `DATABASE_URL` environment variable. (SQLite sources a file path)
+
+- PostgreSQL
+- MySQL
+- SQLite
+- SQLServer
+
+Example using a PostgreSQL connector:
+
+```js file=.env
+DATABASE_URL = 'postgresql://USER:PASSWORD@HOST:PORT/DATABASE'
+```
+
+See [Connection URLs](../database-reference/connection-urls) for a breakdown of each database connector.
+
+### DEBUG
+
+`DEBUG` is used to enable debugging output in the `Prisma Client`.
+
+Example setting `Prisma Client` level debugging output:
+
+```terminal
+# enable only `prisma-client`-level debugging output
+export DEBUG="prisma-client"
+```
+
+See [Debugging](../../concepts/components/prisma-client/debugging) for more information.
+
+### NO_COLOR
+
+`NO_COLOR` strips colors from error messages. It's a truthy value.
+
+```js
+if (process.env.NO_COLOR) {
+  // Do Something
+}
+```
+
+### APPDATA
+
+`APPDATA` is used for accessing the windows root cache directory.
+
+```js
+if (process.env.APPDATA) {
+    return path.join(process.env.APPDATA, 'Prisma')
+}
+```
+
+### INIT_CWD
+
+`INIT_CWD` is the directory where `npm run` was executed. `Prisma` uses it to check for the `schema.prisma` file.
+
+```js
+if (process.env.INIT_CWD) {
+    // Do something
+}
+```
+
+### NO_PROXY
+
+`NO_PROXY` is a comma seperated list if hostnames, IP addresses or IP ranges that do not require a proxy.
+
+```terminal
+NO_PROXY=myhostname.com,10.11.12.0/16,172.30.0.0/16
+```
+
+### HTTP_PROXY
+
+`HTTP_PROXY` is set with the hostname or IP address of a proxy server.
+
+```terminal
+HTTP_PROXY=http://proxy.example.com
+```
+
+### HTTPS_PROXY
+
+`HTTPS_PROXY` is set with the hostname or IP address of a proxy server.
+
+```terminal
+HTTPS_PROXY=http://proxy.example.com
+```
+
+### PRISMA_HIDE_UPDATE_MESSAGE
+
+`PRISMA_HIDE_UPDATE_MESSAGE` is used to when checking if a `Prisma` update is cached. It's a truthy value.
+
+```js
+const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
+```
+
+### PRISMA_GENERATE_SKIP_AUTOINSTALL
+
+`PRISMA_GENERATE_SKIP_AUTOINSTALL` is used to when checking if the `prisma generate` command does an auto install.
+
+```js
+if (!process.env.PRISMA_GENERATE_SKIP_AUTOINSTALL) {
+    // Do Something
+}
+```
+
+### SKIP_GENERATE
+
+`SKIP_GENERATE` is used to determine if the `Prisma Client` generation should be skipped.
+
+```js
+if (!process.env.SKIP_GENERATE) {
+    // Do Something
+}
+```
+
+### BROWSER
+
+`BROWSER` is for the `Prisma Studio` to determine which broswer it should open in. It's also used as a flag when starting the studio from the CLI.
+
+```js
+BROWSER=firefox prisma studio --port 5555
+```
+
+```terminal
+prisma studio --browser firefox
+```
+
+See [Studio](./command-reference/#studio) documentation for more information.
+
+### PRISMA_BINARIES_MIRROR
+
+`PRISMA_BINARIES_MIRROR` is used to create a mirror of the `Prisma` CDN so the cli/client will download from the users custom endpoint.
+
+```js
+  const baseUrl = process.env.PRISMA_BINARIES_MIRROR || 'https://binaries.prisma.sh'
+```
+
+### PRISMA_MIGRATION_ENGINE_BINARY
+
+`PRISMA_MIGRATION_ENGINE_BINARY` is used to set a custom location for your own migration engine binary.
+
+```js
+PRISMA_MIGRATION_ENGINE_BINARY=custom/my-migration-engine-unix
+```
+
+### PRISMA_QUERY_ENGINE_BINARY
+
+`PRISMA_QUERY_ENGINE_BINARY` is used to set a custom location for your own query engine binary.
+
+```js
+PRISMA_QUERY_ENGINE_BINARY=custom/my-query-engine-unix
+```
+
+### PRISMA_INTROSPECTION_ENGINE_BINARY
+
+`PRISMA_INTROSPECTION_ENGINE_BINARY` is used to set a custom location for your own introspection engine binary.
+
+```js
+PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
+```
+
+### PRISMA_FMT_BINARY
+
+`PRISMA_FMT_BINARY` is used to set a custom location for your own format engine binary.
+
+```js
+PRISMA_FMT_BINARY=custom/my-custom-format-engine-unix
+```
+
+### QUERY_ENGINE_BINARY_PATH
+
+When connecting to the database the `QUERY_ENGINE_BINARY_PATH` is used to set a custom path to the binary.
+
+```js
+QUERY_ENGINE_BINARY_PATH=custom/my-custom-query-path-unix
+```
+
+See [Prisma Engines](../../concepts/overview/under-the-hood/#prisma-engines) for more information about binaries.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -92,7 +92,7 @@ HTTP_PROXY=http://proxy.example.com
 `HTTPS_PROXY` is set with the hostname or IP address of a proxy server.
 
 ```terminal
-HTTPS_PROXY=http://proxy.example.com
+HTTPS_PROXY=https://proxy.example.com
 ```
 
 ## Binary environment variables

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -9,8 +9,6 @@ tocDepth: 2
 
 This document describes different environment variables and their use cases.
 
-See [Connection URLs](../database-reference/connection-urls) for a breakdown of each database connector.
-
 ### DEBUG
 
 `DEBUG` is used to enable debugging output in the Prisma Client.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -1,19 +1,20 @@
 ---
-title: 'Environment variables'
+title: 'Environment variables reference'
 metaTitle: 'Prisma environment variables reference'
 metaDescription: 'This page gives an overview of all environment variables avalaible for use.'
 tocDepth: 2
 ---
 
-## Overview
+<TopBlock>
 
 This document describes different environment variables and their use cases.
 
----
+</TopBlock>
+
 
 ## Prisma Client
 
-### DEBUG
+### <inlinecode>DEBUG</inlinecode>
 
 `DEBUG` is used to enable debugging output in the Prisma Client.
 
@@ -26,17 +27,15 @@ export DEBUG="prisma-client"
 
 See [Debugging](../../concepts/components/prisma-client/debugging) for more information.
 
-### NO_COLOR
+### <inlinecode>NO_COLOR</inlinecode>
 
 `NO_COLOR` if [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) will activate the `colorless` setting for error formatting and strip colors from error messages.
 
 See [Formatting via environment variables](../../concepts/components/prisma-client/working-with-prismaclient/error-formatting#formatting-via-environment-variables) for more information.
 
----
-
 ## Prisma Studio
 
-### BROWSER
+### <inlinecode>BROWSER</inlinecode>
 
 `BROWSER` is for Prisma Studio to force which browser it should be open in, if not set it will open in the default browser. It's also used as a flag when starting the studio from the CLI.
 
@@ -50,11 +49,9 @@ prisma studio --browser firefox
 
 See [Studio](./command-reference/#studio) documentation for more information.
 
----
-
 ## Prisma CLI
 
-### PRISMA_HIDE_UPDATE_MESSAGE
+### <inlinecode>PRISMA_HIDE_UPDATE_MESSAGE</inlinecode>
 
 `PRISMA_HIDE_UPDATE_MESSAGE` is used to hide the update notification message that is shown when a newer Prisma CLI version is available. It's a truthy value.
 
@@ -62,21 +59,19 @@ See [Studio](./command-reference/#studio) documentation for more information.
 const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
 ```
 
-### PRISMA_GENERATE_SKIP_AUTOINSTALL
+### <inlinecode>PRISMA_GENERATE_SKIP_AUTOINSTALL</inlinecode>
 
 `PRISMA_GENERATE_SKIP_AUTOINSTALL` can be set to a truthy value to skip the auto-install of `prisma` CLI and `@prisma/client` dependencies (if they are missing) when using the `prisma generate` command.
 
-### SKIP_GENERATE
+### <inlinecode>SKIP_GENERATE</inlinecode>
 
 `SKIP_GENERATE` can be set to a truthy value to skip running `prisma generate` on npm's postinstall lifecycle hook.
-
----
 
 ## Proxy environment variables
 
 The Prisma CLI supports custom HTTP proxies. These can be helpful to use when working behind a corperate firewall. See [Using a HTTP proxy for the CLI](../../concepts/components/prisma-cli/installation/#using-a-http-proxy-for-the-cli) for more information.
 
-### NO_PROXY
+### <inlinecode>NO_PROXY</inlinecode>
 
 `NO_PROXY` is a comma-seperated list of hostnames, IP addresses or IP ranges that do not require a proxy.
 
@@ -84,7 +79,7 @@ The Prisma CLI supports custom HTTP proxies. These can be helpful to use when wo
 NO_PROXY=myhostname.com,10.11.12.0/16,172.30.0.0/16
 ```
 
-### HTTP_PROXY
+### <inlinecode>HTTP_PROXY</inlinecode>
 
 `HTTP_PROXY` is set with the hostname or IP address of a proxy server.
 
@@ -92,7 +87,7 @@ NO_PROXY=myhostname.com,10.11.12.0/16,172.30.0.0/16
 HTTP_PROXY=http://proxy.example.com
 ```
 
-### HTTPS_PROXY
+### <inlinecode>HTTPS_PROXY</inlinecode>
 
 `HTTPS_PROXY` is set with the hostname or IP address of a proxy server.
 
@@ -100,17 +95,15 @@ HTTP_PROXY=http://proxy.example.com
 HTTPS_PROXY=http://proxy.example.com
 ```
 
----
-
 ## Binary environment variables
 
 By default all binaries are downloaded when you install Prisma. There are however situations where you may wish to use a custom binary. See [Prisma Engines](../../concepts/overview/under-the-hood/#prisma-engines) for more information.
 
-### PRISMA_BINARIES_MIRROR
+### <inlinecode>PRISMA_BINARIES_MIRROR</inlinecode>
 
 `PRISMA_BINARIES_MIRROR` can be used to specify a custom CDN endpoint (or any server) to download the engines binaries for the CLI/Client. The default value is `https://binaries.prisma.sh`.
 
-### PRISMA_MIGRATION_ENGINE_BINARY
+### <inlinecode>PRISMA_MIGRATION_ENGINE_BINARY</inlinecode>
 
 `PRISMA_MIGRATION_ENGINE_BINARY` is used to set a custom location for your own migration engine binary.
 
@@ -118,7 +111,7 @@ By default all binaries are downloaded when you install Prisma. There are howeve
 PRISMA_MIGRATION_ENGINE_BINARY=custom/my-migration-engine-unix
 ```
 
-### PRISMA_QUERY_ENGINE_BINARY
+### <inlinecode>PRISMA_QUERY_ENGINE_BINARY</inlinecode>
 
 `PRISMA_QUERY_ENGINE_BINARY` is used to set a custom location for your own query engine binary.
 
@@ -126,7 +119,7 @@ PRISMA_MIGRATION_ENGINE_BINARY=custom/my-migration-engine-unix
 PRISMA_QUERY_ENGINE_BINARY=custom/my-query-engine-unix
 ```
 
-### PRISMA_INTROSPECTION_ENGINE_BINARY
+### <inlinecode>PRISMA_INTROSPECTION_ENGINE_BINARY</inlinecode>
 
 `PRISMA_INTROSPECTION_ENGINE_BINARY` is used to set a custom location for your own introspection engine binary.
 
@@ -134,7 +127,7 @@ PRISMA_QUERY_ENGINE_BINARY=custom/my-query-engine-unix
 PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
 ```
 
-### PRISMA_FMT_BINARY
+### <inlinecode>PRISMA_FMT_BINARY</inlinecode>
 
 `PRISMA_FMT_BINARY` is used to set a custom location for your own format engine binary.
 
@@ -142,7 +135,7 @@ PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
 PRISMA_FMT_BINARY=custom/my-custom-format-engine-unix
 ```
 
-### PRISMA_CLI_BINARY_TARGETS
+### <inlinecode>PRISMA_CLI_BINARY_TARGETS</inlinecode>
 
 `PRISMA_CLI_BINARY_TARGETS` is used to run the CLI on AWS Lambda, must be provided during `npm install`
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -9,6 +9,10 @@ tocDepth: 2
 
 This document describes different environment variables and their use cases.
 
+---
+
+## Prisma Client
+
 ### DEBUG
 
 `DEBUG` is used to enable debugging output in the Prisma Client.
@@ -28,6 +32,10 @@ See [Debugging](../../concepts/components/prisma-client/debugging) for more info
 
 See [Formatting via environment variables](../../concepts/components/prisma-client/working-with-prismaclient/error-formatting#formatting-via-environment-variables) for more information.
 
+---
+
+## Prisma Studio
+
 ### BROWSER
 
 `BROWSER` is for Prisma Studio to force which browser it should be open in, if not set it will open in the default browser. It's also used as a flag when starting the studio from the CLI.
@@ -41,6 +49,10 @@ prisma studio --browser firefox
 ```
 
 See [Studio](./command-reference/#studio) documentation for more information.
+
+---
+
+## Prisma CLI
 
 ### PRISMA_HIDE_UPDATE_MESSAGE
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -63,10 +63,6 @@ const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
 
 `PRISMA_GENERATE_SKIP_AUTOINSTALL` can be set to a truthy value to skip the auto-install of `prisma` CLI and `@prisma/client` dependencies (if they are missing), if the `prisma-client-js` generator is defined in the Prisma Schema, when using the `prisma generate` command.
 
-### <inlinecode>SKIP_GENERATE</inlinecode>
-
-`SKIP_GENERATE` can be set to a truthy value to skip running `prisma generate` on npm's postinstall lifecycle hook.
-
 ## Proxy environment variables
 
 The Prisma CLI supports custom HTTP(S) proxies to download the Prisma engines. These can be helpful to use when working behind a corporate firewall. See [Using a HTTP proxy for the CLI](../../concepts/components/prisma-cli/installation/#using-a-http-proxy-for-the-cli) for more information.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -28,6 +28,42 @@ See [Debugging](../../concepts/components/prisma-client/debugging) for more info
 
 See [Formatting via environment variables](../../concepts/components/prisma-client/working-with-prismaclient/error-formatting#formatting-via-environment-variables) for more information.
 
+### BROWSER
+
+`BROWSER` is for Prisma Studio to force which browser it should be open in, if not set it will open in the default browser. It's also used as a flag when starting the studio from the CLI.
+
+```js
+BROWSER=firefox prisma studio --port 5555
+```
+
+```terminal
+prisma studio --browser firefox
+```
+
+See [Studio](./command-reference/#studio) documentation for more information.
+
+### PRISMA_HIDE_UPDATE_MESSAGE
+
+`PRISMA_HIDE_UPDATE_MESSAGE` is used to hide the update notification message that is shown when a newer Prisma CLI version is available. It's a truthy value.
+
+```js
+const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
+```
+
+### PRISMA_GENERATE_SKIP_AUTOINSTALL
+
+`PRISMA_GENERATE_SKIP_AUTOINSTALL` can be set to a truthy value to skip the auto-install of `prisma` CLI and `@prisma/client` dependencies (if they are missing) when using the `prisma generate` command.
+
+### SKIP_GENERATE
+
+`SKIP_GENERATE` can be set to a truthy value to skip running `prisma generate` on npm's postinstall lifecycle hook.
+
+---
+
+## Proxy environment variables
+
+The Prisma CLI supports custom HTTP proxies. These can be helpful to use when working behind a corperate firewall. See [Using a HTTP proxy for the CLI](../../concepts/components/prisma-cli/installation/#using-a-http-proxy-for-the-cli) for more information.
+
 ### NO_PROXY
 
 `NO_PROXY` is a comma-seperated list of hostnames, IP addresses or IP ranges that do not require a proxy.
@@ -52,39 +88,15 @@ HTTP_PROXY=http://proxy.example.com
 HTTPS_PROXY=http://proxy.example.com
 ```
 
-### PRISMA_HIDE_UPDATE_MESSAGE
+---
 
-`PRISMA_HIDE_UPDATE_MESSAGE` is used to when checking if a Prisma update is cached. It's a truthy value.
+## Binary environment variables
 
-```js
-const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
-```
-
-### PRISMA_GENERATE_SKIP_AUTOINSTALL
-
-`PRISMA_GENERATE_SKIP_AUTOINSTALL` can be set to a truthy value to skip the auto-install of `prisma` CLI and `@prisma/client` dependencies (if they are missing) when using the `prisma generate` command.
-
-### SKIP_GENERATE
-
-`SKIP_GENERATE` can be set to a truthy value to skip running `prisma generate` on npm's postinstall lifecycle hook.
-
-### BROWSER
-
-`BROWSER` is for Prisma Studio to force which browser it should be open in, if not set it will open in the default browser. It's also used as a flag when starting the studio from the CLI.
-
-```js
-BROWSER=firefox prisma studio --port 5555
-```
-
-```terminal
-prisma studio --browser firefox
-```
-
-See [Studio](./command-reference/#studio) documentation for more information.
+By default all binaries are downloaded when you install Prisma. There are however situations where you may wish to use a custom binary. See [Prisma Engines](../../concepts/overview/under-the-hood/#prisma-engines) for more information.
 
 ### PRISMA_BINARIES_MIRROR
 
-`PRISMA_BINARIES_MIRROR` can be used to specify a custom CDN endpoint to download the engines binaries for the CLI/Client. The default value is `https://binaries.prisma.sh`.
+`PRISMA_BINARIES_MIRROR` can be used to specify a custom CDN endpoint (or any server) to download the engines binaries for the CLI/Client. The default value is `https://binaries.prisma.sh`.
 
 ### PRISMA_MIGRATION_ENGINE_BINARY
 
@@ -118,16 +130,10 @@ PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
 PRISMA_FMT_BINARY=custom/my-custom-format-engine-unix
 ```
 
-### QUERY_ENGINE_BINARY_PATH
-
-When connecting to the database the `QUERY_ENGINE_BINARY_PATH` is used to set a custom path to the binary.
-
-```js
-QUERY_ENGINE_BINARY_PATH=custom/my-custom-query-path-unix
-```
-
 ### PRISMA_CLI_BINARY_TARGETS
 
-`PRISMA_CLI_BINARY_TARGETS`
+`PRISMA_CLI_BINARY_TARGETS` is used to run the CLI on AWS Lambda, must be provided during `npm install`
 
-See [Prisma Engines](../../concepts/overview/under-the-hood/#prisma-engines) for more information about binaries.
+```terminal
+PRISMA_CLI_BINARY_TARGETS=LOCAL_PLATFORM,rhel-openssl-1.0.x npm install
+```

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -69,7 +69,7 @@ const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
 
 ## Proxy environment variables
 
-The Prisma CLI supports custom HTTP proxies. These can be helpful to use when working behind a corperate firewall. See [Using a HTTP proxy for the CLI](../../concepts/components/prisma-cli/installation/#using-a-http-proxy-for-the-cli) for more information.
+The Prisma CLI supports custom HTTP(S) proxies to download the Prisma engines. These can be helpful to use when working behind a corporate firewall. See [Using a HTTP proxy for the CLI](../../concepts/components/prisma-cli/installation/#using-a-http-proxy-for-the-cli) for more information.
 
 ### <inlinecode>NO_PROXY</inlinecode>
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -97,7 +97,7 @@ HTTPS_PROXY=http://proxy.example.com
 
 ## Binary environment variables
 
-By default all binaries are downloaded when you install Prisma. There are however situations where you may wish to use a custom binary. See [Prisma Engines](../../concepts/overview/under-the-hood/#prisma-engines) for more information.
+By default all binaries are downloaded when you install Prisma CLI. There are however situations where you may wish to use a custom binary. See [Prisma Engines](../../concepts/overview/under-the-hood/#prisma-engines) for more information.
 
 ### <inlinecode>PRISMA_BINARIES_MIRROR</inlinecode>
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -73,7 +73,7 @@ The Prisma CLI supports custom HTTP proxies. These can be helpful to use when wo
 
 ### <inlinecode>NO_PROXY</inlinecode>
 
-`NO_PROXY` is a comma-seperated list of hostnames, IP addresses or IP ranges that do not require a proxy.
+`NO_PROXY` is a comma-separated list of hostnames or IP addresses that do not require a proxy.
 
 ```terminal
 NO_PROXY=myhostname.com,10.11.12.0/16,172.30.0.0/16

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -61,7 +61,7 @@ const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
 
 ### <inlinecode>PRISMA_GENERATE_SKIP_AUTOINSTALL</inlinecode>
 
-`PRISMA_GENERATE_SKIP_AUTOINSTALL` can be set to a truthy value to skip the auto-install of `prisma` CLI and `@prisma/client` dependencies (if they are missing) when using the `prisma generate` command.
+`PRISMA_GENERATE_SKIP_AUTOINSTALL` can be set to a truthy value to skip the auto-install of `prisma` CLI and `@prisma/client` dependencies (if they are missing), if the `prisma-client-js` generator is defined in the Prisma Schema, when using the `prisma generate` command.
 
 ### <inlinecode>SKIP_GENERATE</inlinecode>
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -21,8 +21,8 @@ This document describes different environment variables and their use cases.
 Example setting Prisma Client level debugging output:
 
 ```terminal
-# enable only `prisma-client`-level debugging output
-export DEBUG="prisma-client"
+# enable only `prisma:client`-level debugging output
+export DEBUG="prisma:client"
 ```
 
 See [Debugging](../../concepts/components/prisma-client/debugging) for more information.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -9,29 +9,13 @@ tocDepth: 2
 
 This document describes different environment variables and their use cases.
 
-### DATABASE_URL
-
-`DATABASE_URL` is used to connect to your database. The url format can differ depending on the database it is connecting to.
-Prisma currently supports 4 types of database connectors, of which 3 use the `DATABASE_URL` environment variable. (SQLite sources a file path)
-
-- PostgreSQL
-- MySQL
-- SQLite
-- SQLServer
-
-Example using a PostgreSQL connector:
-
-```js file=.env
-DATABASE_URL = 'postgresql://USER:PASSWORD@HOST:PORT/DATABASE'
-```
-
 See [Connection URLs](../database-reference/connection-urls) for a breakdown of each database connector.
 
 ### DEBUG
 
-`DEBUG` is used to enable debugging output in the `Prisma Client`.
+`DEBUG` is used to enable debugging output in the Prisma Client.
 
-Example setting `Prisma Client` level debugging output:
+Example setting Prisma Client level debugging output:
 
 ```terminal
 # enable only `prisma-client`-level debugging output
@@ -42,37 +26,13 @@ See [Debugging](../../concepts/components/prisma-client/debugging) for more info
 
 ### NO_COLOR
 
-`NO_COLOR` strips colors from error messages. It's a truthy value.
+`NO_COLOR` if [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) will activate the `colorless` setting for error formatting and strip colors from error messages.
 
-```js
-if (process.env.NO_COLOR) {
-  // Do Something
-}
-```
-
-### APPDATA
-
-`APPDATA` is used for accessing the windows root cache directory.
-
-```js
-if (process.env.APPDATA) {
-    return path.join(process.env.APPDATA, 'Prisma')
-}
-```
-
-### INIT_CWD
-
-`INIT_CWD` is the directory where `npm run` was executed. `Prisma` uses it to check for the `schema.prisma` file.
-
-```js
-if (process.env.INIT_CWD) {
-    // Do something
-}
-```
+See [Formatting via environment variables](../../concepts/components/prisma-client/working-with-prismaclient/error-formatting#formatting-via-environment-variables) for more information.
 
 ### NO_PROXY
 
-`NO_PROXY` is a comma seperated list if hostnames, IP addresses or IP ranges that do not require a proxy.
+`NO_PROXY` is a comma-seperated list of hostnames, IP addresses or IP ranges that do not require a proxy.
 
 ```terminal
 NO_PROXY=myhostname.com,10.11.12.0/16,172.30.0.0/16
@@ -96,7 +56,7 @@ HTTPS_PROXY=http://proxy.example.com
 
 ### PRISMA_HIDE_UPDATE_MESSAGE
 
-`PRISMA_HIDE_UPDATE_MESSAGE` is used to when checking if a `Prisma` update is cached. It's a truthy value.
+`PRISMA_HIDE_UPDATE_MESSAGE` is used to when checking if a Prisma update is cached. It's a truthy value.
 
 ```js
 const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
@@ -104,27 +64,15 @@ const shouldHide = process.env.PRISMA_HIDE_UPDATE_MESSAGE
 
 ### PRISMA_GENERATE_SKIP_AUTOINSTALL
 
-`PRISMA_GENERATE_SKIP_AUTOINSTALL` is used to when checking if the `prisma generate` command does an auto install.
-
-```js
-if (!process.env.PRISMA_GENERATE_SKIP_AUTOINSTALL) {
-    // Do Something
-}
-```
+`PRISMA_GENERATE_SKIP_AUTOINSTALL` can be set to a truthy value to skip the auto-install of `prisma` CLI and `@prisma/client` dependencies (if they are missing) when using the `prisma generate` command.
 
 ### SKIP_GENERATE
 
-`SKIP_GENERATE` is used to determine if the `Prisma Client` generation should be skipped.
-
-```js
-if (!process.env.SKIP_GENERATE) {
-    // Do Something
-}
-```
+`SKIP_GENERATE` can be set to a truthy value to skip running `prisma generate` on npm's postinstall lifecycle hook.
 
 ### BROWSER
 
-`BROWSER` is for the `Prisma Studio` to determine which broswer it should open in. It's also used as a flag when starting the studio from the CLI.
+`BROWSER` is for Prisma Studio to force which browser it should be open in, if not set it will open in the default browser. It's also used as a flag when starting the studio from the CLI.
 
 ```js
 BROWSER=firefox prisma studio --port 5555
@@ -138,11 +86,7 @@ See [Studio](./command-reference/#studio) documentation for more information.
 
 ### PRISMA_BINARIES_MIRROR
 
-`PRISMA_BINARIES_MIRROR` is used to create a mirror of the `Prisma` CDN so the cli/client will download from the users custom endpoint.
-
-```js
-  const baseUrl = process.env.PRISMA_BINARIES_MIRROR || 'https://binaries.prisma.sh'
-```
+`PRISMA_BINARIES_MIRROR` can be used to specify a custom CDN endpoint to download the engines binaries for the CLI/Client. The default value is `https://binaries.prisma.sh`.
 
 ### PRISMA_MIGRATION_ENGINE_BINARY
 
@@ -183,5 +127,9 @@ When connecting to the database the `QUERY_ENGINE_BINARY_PATH` is used to set a 
 ```js
 QUERY_ENGINE_BINARY_PATH=custom/my-custom-query-path-unix
 ```
+
+### PRISMA_CLI_BINARY_TARGETS
+
+`PRISMA_CLI_BINARY_TARGETS`
 
 See [Prisma Engines](../../concepts/overview/under-the-hood/#prisma-engines) for more information about binaries.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -137,8 +137,10 @@ PRISMA_FMT_BINARY=custom/my-custom-format-engine-unix
 
 ### <inlinecode>PRISMA_CLI_BINARY_TARGETS</inlinecode>
 
-`PRISMA_CLI_BINARY_TARGETS` is used to run the CLI on AWS Lambda, must be provided during `npm install`
+`PRISMA_CLI_BINARY_TARGETS` can be used to specify one or more binary targets that the CLI will download, it must be provided during `npm install`.
+
+For example:
+If you are on macOS, the binary target is `darwin` & AWS Lambda target is `rhel-openssl-1.0.x`
 
 ```terminal
-PRISMA_CLI_BINARY_TARGETS=LOCAL_PLATFORM,rhel-openssl-1.0.x npm install
-```
+PRISMA_CLI_BINARY_TARGETS=darwin,rhel-openssl-1.0.x npm install


### PR DESCRIPTION
Ive added a new page on the same level as the CLI API info. Ive also linked throughout the docs back to the env vars defined in this page.

Some of these env vars may not be public facing, if so i'll can just remove them. On the same note, there could be some that i have missed which a kind soul would have to tell me about and i can add them 😄

Also, im unsure of some of my descriptions, they might be totally wrong and need amending.

First PR.... GET IN! 

Fixes: 
- #447 
- #1152 