### PR TITLE
fix: Small typo in exit hook section

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/100-connection-management.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/100-connection-management.mdx
@@ -102,7 +102,7 @@ If your machine has four physical CPUs, your connection pool will contain nine c
 
 ## Exit hooks
 
-The `beforeExit` hook runs _before_ Prisma ends its child processes and allows you to issue queries beore the client disconnects - for example, as part of a graceful shutdown of a service:
+The `beforeExit` hook runs _before_ Prisma ends its child processes and allows you to issue queries before the client disconnects - for example, as part of a graceful shutdown of a service:
 
 ```ts
 const prisma = new PrismaClient();


### PR DESCRIPTION
Makes a change in the **Exit Hooks** section fixing a typo (`beore` -> `before`)