### PR TITLE
docs/system-requirements: Add another Typescript error to help fellow googlers

### DIFF
--- a/content/400-reference/100-system-requirements.mdx
+++ b/content/400-reference/100-system-requirements.mdx
@@ -20,6 +20,28 @@ See also: [Supported database versions](database-reference/supported-databases)
 
 ## Troubleshooting
 
+### Unable to build a Next.js project
+
+#### Problem
+
+You see the following error when you run `next build`
+
+```terminal
+./node_modules/.prisma/client/index.d.ts:10:33
+Type error: Type expected.
+   8 | export type PrismaPromise<A> = Promise<A> & {[prisma]: true}
+   9 | type UnwrapTuple<Tuple extends readonly unknown[]> = {
+> 10 |   [K in keyof Tuple]: K extends `${number}` ? Tuple[K] extends PrismaPromise<infer X> ? X : never : never
+     |                                 ^
+  11 | };
+  12 | 
+  13 |
+```
+
+#### Solution
+
+Upgrade your project to TypeScript 4.1.X or later. `npm install -D typescript`.
+
 ### Unable to use `groupBy` preview feature
 
 #### Problem
@@ -45,4 +67,4 @@ server.ts:6:48 - error TS2554: Expected 0 arguments, but got 1.
 
 #### Solution
 
-Upgrade your project to TypeScript 4.1.X or later.
+Upgrade your project to TypeScript 4.1.X or later. `npm install -D typescript`.

--- a/content/400-reference/100-system-requirements.mdx
+++ b/content/400-reference/100-system-requirements.mdx
@@ -24,7 +24,7 @@ See also: [Supported database versions](database-reference/supported-databases)
 
 #### Problem
 
-You see the following error when you run try type-checking a project after you run `prisma generate`.
+You see the following error when you try type-checking a project after you run `prisma generate`.
 
 ```terminal
 ./node_modules/.prisma/client/index.d.ts:10:33

--- a/content/400-reference/100-system-requirements.mdx
+++ b/content/400-reference/100-system-requirements.mdx
@@ -24,7 +24,7 @@ See also: [Supported database versions](database-reference/supported-databases)
 
 #### Problem
 
-You see the following error when you run `next build`
+You see the following error when you run try type-checking a project after you run `prisma generate`.
 
 ```terminal
 ./node_modules/.prisma/client/index.d.ts:10:33

--- a/content/400-reference/100-system-requirements.mdx
+++ b/content/400-reference/100-system-requirements.mdx
@@ -20,7 +20,7 @@ See also: [Supported database versions](database-reference/supported-databases)
 
 ## Troubleshooting
 
-### Unable to build a Next.js project
+### Unable to build a TypeScript project with @prisma/client
 
 #### Problem
 


### PR DESCRIPTION
Adds another error you see in next.js projects if you're using a version of TS that's incompatible.