### PR TITLE
fix typo: productiviy to productivity

### DIFF
--- a/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
+++ b/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
@@ -107,7 +107,7 @@ Prisma has a lively [community](https://www.prisma.io/community) with more than 
 
 ### ... you need _full_ control over all database queries
 
-Prisma is an abstraction. As such, an inherent tradeoff of Prisma is a reduced amount of control in exchange for higher productiviy. This means, the [Prisma Client API](../components/prisma-client) might have less capabilities in some scenarios than you get with plain SQL. 
+Prisma is an abstraction. As such, an inherent tradeoff of Prisma is a reduced amount of control in exchange for higher productivity. This means, the [Prisma Client API](../components/prisma-client) might have less capabilities in some scenarios than you get with plain SQL. 
 
 While Prisma does allow you to [send plain SQL queries](../components/prisma-client/raw-database-access) to your database, there might still be cases where this is not enough (e.g. when you absolutely need a [long-running transaction](https://github.com/prisma/prisma/issues?q=is%3Aissue+is%3Aopen+transactions) or when you need special control over the database connection).
 


### PR DESCRIPTION
Greetings.

This PR fixes a typo of **productiviy** → **productivity** which can be found at [`https://www.prisma.io/docs/concepts/overview/should-you-use-prisma#-you-need-full-control-over-all-database-queries`](https://www.prisma.io/docs/concepts/overview/should-you-use-prisma#-you-need-full-control-over-all-database-queries) ([Source](https://github.com/prisma/docs/blob/master/content/200-concepts/050-overview/250-should-you-use-prisma.mdx)).