### PR TITLE
docs: Fixes typo in Migrate from Sequelize page.

### DIFF
--- a/content/300-guides/400-migrate-to-prisma/02-migrate-from-sequelize.mdx
+++ b/content/300-guides/400-migrate-to-prisma/02-migrate-from-sequelize.mdx
@@ -532,8 +532,8 @@ model PostToCategories {
   updatedAt  DateTime @updatedAt
   categoryId Int
   postId     Int
-  categories Category @relation(fields: [categoryId], references: [id])
-  posts      Post     @relation(fields: [postId], references: [id])
+  category Category @relation(fields: [categoryId], references: [id])
+  post      Post     @relation(fields: [postId], references: [id])
 
   @@id([categoryId, postId])
   @@map("PostCategories")


### PR DESCRIPTION
Closes #1514