### PR TITLE
Use consistent path separators

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -126,12 +126,12 @@ The Prisma CLI looks for the Prisma schema file in the following locations, in t
 The Prisma CLI outputs the path of the schema file that will be used. The following example shows the terminal output for `prisma introspect`:
 
 ```no-lines
-Environment variables loaded from prisma\.env
-|Prisma Schema loaded from prisma\schema.prisma
+Environment variables loaded from prisma/.env
+|Prisma Schema loaded from prisma/schema.prisma
 
-Introspecting based on datasource defined in prisma\schema.prisma …
+Introspecting based on datasource defined in prisma/schema.prisma …
 
-✔ Introspected 4 models and wrote them into prisma\schema.prisma in 239ms
+✔ Introspected 4 models and wrote them into prisma/schema.prisma in 239ms
 
 Run prisma generate to generate Prisma Client.
 ```


### PR DESCRIPTION
Most of the to path separators are slashes, but a few were backslashes. They are now slashes to match the others.

In its former form, the page was a bit confusing to a new reader (me). When I got to the first backslash form, a reference to prisma\.env, since I wasn't expecting a backslash path separator, I thought at first it was some sort of escape. Consistency avoids this kind of confusion.