### PR TITLE
Docs: Fix reflink pointing to non existing page.

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/100-operating-against-partial-structures-of-model-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/100-operating-against-partial-structures-of-model-types.mdx
@@ -68,7 +68,7 @@ type UserPersonalData = {
 }
 ```
 
-While this is certainly feasible, this approach increases the maintenance burden upon changes to the Prisma schema as you need to manually maintain the types. A cleaner solution to this is to use the `UserGetPayload` type that is generated and exposed by Prisma Client under the `Prisma` namespace in combination with the [`validator`](./advanced-type-safety/#what-is-the-prisma-validator):
+While this is certainly feasible, this approach increases the maintenance burden upon changes to the Prisma schema as you need to manually maintain the types. A cleaner solution to this is to use the `UserGetPayload` type that is generated and exposed by Prisma Client under the `Prisma` namespace in combination with the [`validator`](./advanced-type-safety/prisma-validator):
 
 ```ts
 import { Prisma } from '@prisma/client'


### PR DESCRIPTION
Currently the **validator** word takes to a non existing page on the docs while it should take to the dedicated page for prisma Validators. Changed the reflink to take to the right location.