### PR TITLE
Change SQL examples in concepts, relations

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
@@ -501,8 +501,9 @@ CREATE TABLE "User" (
 );
 CREATE TABLE "Profile" (
     id SERIAL PRIMARY KEY,
-    "userFirstName" TEXT NOT NULL UNIQUE,
-    "userLastName" TEXT NOT NULL UNIQUE,
+    "userFirstName" TEXT NOT NULL,
+    "userLastName" TEXT NOT NULL,
+    UNIQUE ("userFirstName", "userLastName")
     FOREIGN KEY ("userFirstName", "userLastName") REFERENCES "User"("firstName", "lastName")
 );
 ```
@@ -652,8 +653,8 @@ CREATE TABLE "User" (
 );
 CREATE TABLE "Post" (
     id SERIAL PRIMARY KEY,
-    "authorFirstName" TEXT NOT NULL UNIQUE,
-    "authorLastName" TEXT NOT NULL UNIQUE,
+    "authorFirstName" TEXT NOT NULL,
+    "authorLastName" TEXT NOT NULL,
     FOREIGN KEY ("authorFirstName", "authorLastName") REFERENCES "User"("firstName", "lastName")
 );
 ```
@@ -1209,7 +1210,6 @@ model Category {
   posts         Post[]      @relation("CategoryPostRelation")
 }
 ```
-
 
 <!--
 


### PR DESCRIPTION
Hey!
While I was reading docs I noticed that in the first SQL example, a group should be `UNIQUE`, instead of the fields itself. In the second SQL example, I think that if that's the 1-N relation, the fields can't be unique either. Correct me if I am wrong :D. Have a nice day!