### PR TITLE
docs: quick start update findMany needs argument of empty object

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -259,7 +259,7 @@ Inside the `main` function, add the following query to read all `User` records f
 
 ```js copy file=script.ts
 async function main() {
-  const allUsers = await prisma.user.findMany()
+  const allUsers = await prisma.user.findMany({})
   console.log(allUsers)
 }
 ```
@@ -270,7 +270,7 @@ async function main() {
 
 ```js copy file=script.js
 async function main() {
-  const allUsers = await prisma.user.findMany()
+  const allUsers = await prisma.user.findMany({})
   console.log(allUsers)
 }
 ```


### PR DESCRIPTION
```
> dev
> ts-node ./script.ts

{
  then: [Function: then],
  requestTransaction: [Function: requestTransaction],
  catch: [Function: catch],
  finally: [Function: finally],
  posts: [Function (anonymous)]
} allUsers
```
- const allUsers = await prisma.user.findMany();


```
> dev
> ts-node ./script.ts

[
  { id: 1, email: 'sarah@prisma.io', name: 'Sarah' },
  { id: 2, email: 'maria@prisma.io', name: 'Maria' }
] allUsers
➜  starter npm run dev
```
- const allUsers = await prisma.user.findMany({});

using node v.14.16.0