### PR TITLE
Deploying to AWS Lambda: Add note about Package Pattern to exclude binaries

### DIFF
--- a/content/300-guides/200-deployment/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/400-deploying-to-aws-lambda.mdx
@@ -309,12 +309,11 @@ curl -v https://UNIQUE_IDENTIFIER.execute-api.us-east-1.amazonaws.com/dev/seed
 
 ## Notes
 
-### serverless.yaml
+### `serverless.yml`
 
-The `serverless.yml` configuration file is where the endpoint and function configuration lives.
-You can update this file to add or change endpoints. For more AWS specific configuration, check out the AWS provider configuration in the [Serverless Framework Docs](https://serverless.com/framework/docs/providers/aws/guide/functions/).
+The `serverless.yml` configuration file is where the endpoint and function configuration lives. You can update this file to add or change endpoints. For more AWS specific configuration, check out the AWS provider configuration in the [Serverless Framework Docs](https://serverless.com/framework/docs/providers/aws/guide/functions/).
 
-### Binary targets in schema.prisma
+### Binary targets in `schema.prisma`
 
 The Prisma schema contains the following in the generator block:
 
@@ -323,6 +322,10 @@ binaryTargets = ["native", "rhel-openssl-1.0.x"]
 ```
 
 This is necessary as the local runtime is different to the Lambda runtime. Adding the `binaryTarget` will ensure that the compatible Prisma Engine binary is available.
+
+### Package Pattern in `serverless.yml`
+
+The Serverless configuration file includes a package pattern that excludes all Prisma Engine binaries but the one relevant for the Lambda runtime, so only 1 binary will be included when Serverless packages your app for upload. This ensures the packaged archive is as small as possible. 
 
 ## Summary
 

--- a/content/300-guides/200-deployment/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/400-deploying-to-aws-lambda.mdx
@@ -325,7 +325,16 @@ This is necessary as the local runtime is different to the Lambda runtime. Addin
 
 ### Package Pattern in `serverless.yml`
 
-The Serverless configuration file includes a package pattern that excludes all Prisma Engine binaries but the one relevant for the Lambda runtime, so only 1 binary will be included when Serverless packages your app for upload. This ensures the packaged archive is as small as possible. 
+The Serverless configuration file includes a package pattern that excludes all Prisma Engine binaries but the one relevant for the Lambda runtime, so only 1 binary will be included when Serverless packages your app for upload:
+
+```
+package:
+  patterns:
+    - '!node_modules/.prisma/client/query-engine-*'
+    - 'node_modules/.prisma/client/query-engine-rhel-*'
+```
+
+This ensures the packaged archive is as small as possible. 
 
 ## Summary
 


### PR DESCRIPTION
To avoid problems like https://github.com/prisma/prisma/issues/6644, we want to filter out all binaries but the required on during the packaging step of Serverless Framework.

Preview: https://deploy-preview-1578--prisma2-docs.netlify.app/docs/guides/deployment/deploying-to-aws-lambda#notes

Related PR in examples that this article depends on: https://github.com/prisma/prisma-examples/pull/2769
Related PR adding this to e2e tests as well: https://github.com/prisma/e2e-tests/pull/1637