### PR TITLE
fix(deployment-guides): Split Serverless and PaaS

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/index.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/index.mdx
@@ -17,14 +17,18 @@ This page outlines the platforms and services Prisma can be deployed to.
 
 The following is an evolving list of serverless and PaaS (platform as a service) platforms that Prisma can be deployed to.
 
+### Serverless Platforms
+
+- [AWS Lambda](deploying-to-aws-lambda)
+- [Serverless Framework, AWS Lambda](deploying-to-aws-lambda)
+- [Netlify](deploying-to-netlify)
+- [Vercel](deploying-to-vercel)
 - [Azure functions](deploying-to-azure-functions)
 - Firebase functions
 - GCP functions
-- [AWS Lambda](deploying-to-aws-lambda)
-- [Netlify CLI](deploying-to-netlify)
-- [Serverless lambda](deploying-to-aws-lambda)
-- [Vercel API](deploying-to-vercel)
-- Vercel node builder
+
+### Paas Platforms
+
 - CodeSandbox
 - [Heroku](deploying-to-heroku)
 - Render


### PR DESCRIPTION
- also renames some to actually use the platform names, vs. the deployment method
- also removes one that is an implementation detail probably