### PR TITLE
fix(prisma-schema): comment indentation

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -286,7 +286,7 @@ There are two types of comments that are supported in the schema file:
 Here are some different examples:
 
 ```prisma
-  /// This comment will get attached to the `User` node in the AST
+/// This comment will get attached to the `User` node in the AST
 model User {
   /// This comment will get attached to the `id` node in the AST
   id      Int    @default(autoincrement())
@@ -294,13 +294,13 @@ model User {
   weight  Float /// This comment gets attached to the `weight` node
 }
 
-  // This comment is just for you. It will not
-  // show up in the AST.
+// This comment is just for you. It will not
+// show up in the AST.
 
-  /// This is a free-floating comment that will show up
-  /// in the AST as a `Comment` node, but is not attached
-  /// to any other node. We can use these for documentation
-  /// in the same way that godoc.org works.
+/// This is a free-floating comment that will show up
+/// in the AST as a `Comment` node, but is not attached
+/// to any other node. We can use these for documentation
+/// in the same way that godoc.org works.
 
 model Customer {}
 ```


### PR DESCRIPTION
I think this was wrong before.