### PR TITLE
fix(supported-databases): Explicit mention of non support of Data API

### DIFF
--- a/content/400-reference/300-database-reference/03-supported-databases.mdx
+++ b/content/400-reference/300-database-reference/03-supported-databases.mdx
@@ -8,22 +8,24 @@ metaDescription: 'This page lists all the databases and their versions that are 
 
 Prisma currently supports the following databases:
 
-| Database              | Version |
-| --------------------- | ------- |
-| PostgreSQL            | 9       |
-| PostgreSQL            | 10      |
-| PostgreSQL            | 11      |
-| PostgreSQL            | 12      |
-| PostgreSQL            | 13      |
-| MySQL                 | 5.6     |
-| MySQL                 | 5.7     |
-| MySQL                 | 8       |
-| MariaDB               | 10      |
-| SQLite                | \*      |
-| AWS Aurora            | \*      |
-| AWS Aurora Serverless | \*      |
+| Database                     | Version |
+| ---------------------------- | ------- |
+| PostgreSQL                   | 9       |
+| PostgreSQL                   | 10      |
+| PostgreSQL                   | 11      |
+| PostgreSQL                   | 12      |
+| PostgreSQL                   | 13      |
+| MySQL                        | 5.6     |
+| MySQL                        | 5.7     |
+| MySQL                        | 8       |
+| MariaDB                      | 10      |
+| SQLite                       | \*      |
+| AWS Aurora                   | \*      |
+| AWS Aurora Serverless &sup1; | \*      |
 
 Note that a fixed version of SQLite is shipped with every Prisma release.
+
+&sup1; This does not include support for [Data API for Aurora Serverless](https://github.com/prisma/prisma/issues/1964).
 
 </TopBlock>
 

--- a/content/400-reference/300-database-reference/03-supported-databases.mdx
+++ b/content/400-reference/300-database-reference/03-supported-databases.mdx
@@ -25,7 +25,11 @@ Prisma currently supports the following databases:
 
 Note that a fixed version of SQLite is shipped with every Prisma release.
 
+<FootNote>
+  
 &sup1; This does not include support for [Data API for Aurora Serverless](https://github.com/prisma/prisma/issues/1964).
+
+</FootNote>
 
 </TopBlock>
 

--- a/content/400-reference/300-database-reference/03-supported-databases.mdx
+++ b/content/400-reference/300-database-reference/03-supported-databases.mdx
@@ -27,7 +27,7 @@ Note that a fixed version of SQLite is shipped with every Prisma release.
 
 <FootNote>
   
-&sup1; This does not include support for [Data API for Aurora Serverless](https://github.com/prisma/prisma/issues/1964).
+ &sup1; This does not include support for [Data API for Aurora Serverless](https://github.com/prisma/prisma/issues/1964).
 
 </FootNote>
 


### PR DESCRIPTION
We got feedback https://twitter.com/mpv/status/1385592683100573696 that this currently was misleading and not clear - so mention this explicitly that not yet supported, with link to issue about this.

![image](https://user-images.githubusercontent.com/183673/115907131-bc70df80-a468-11eb-93ea-79ad998c6b26.png)

Could possibly look and sound better - feel free to edit as usual.

https://deploy-preview-1610--prisma2-docs.netlify.app/docs/reference/database-reference/supported-databases