### PR TITLE
Fix grammar for prisma dependency note

### DIFF
--- a/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
@@ -19,7 +19,7 @@ Exactly when to run `prisma migrate deploy` depends on your platform. For exampl
 
 Ideally, `migrate deploy` should be part of an automated CI/CD pipeline, and we do not generally recommend [running this command locally to deploy changes to a production database](./deployment-guides/deploying-migrations-from-a-local-environment) (for example, by temporarily changing the `DATABASE_URL` environment variable). It is not generally considered good practice to store the production database URL locally.
 
-Beware that in order to run the `prisma migrate deploy` command, you need access the `prisma` dependency that is typically added to the `devDependencies`. Some platforms like Vercel, prune development dependencies during the build, thereby preventing you from calling the command. This can be worked around by making the `prisma` a production dependency, by moving it to `dependencies` in your `package.json`.
+Beware that in order to run the `prisma migrate deploy` command, you need access to the `prisma` dependency that is typically added to the `devDependencies`. Some platforms like Vercel, prune development dependencies during the build, thereby preventing you from calling the command. This can be worked around by making the `prisma` a production dependency, by moving it to `dependencies` in your `package.json`.
 For more information about the `migrate deploy` command, see:
 
 - [`migrate deploy` reference](../../../reference/api-reference/command-reference#migrate-deploy) <span class="api"></span>


### PR DESCRIPTION
Should have the word "to" to make better grammatical sense.