### PR TITLE
Fix indentation to render a list as a list

### DIFF
--- a/content/200-concepts/100-components/250-preview-features/100-sql-server/001-sql-server-start-from-scratch.mdx
+++ b/content/200-concepts/100-components/250-preview-features/100-sql-server/001-sql-server-start-from-scratch.mdx
@@ -85,8 +85,8 @@ npx prisma
 
 This command created a new directory called `prisma` with the following contents:
 
-    - `schema.prisma`: The Prisma schema with your database connection and the Prisma Client generator
-    - `.env`: A [dotenv](https://github.com/motdotla/dotenv) file for defining environment variables (used for your database connection)
+- `schema.prisma`: The Prisma schema with your database connection and the Prisma Client generator
+- `.env`: A [dotenv](https://github.com/motdotla/dotenv) file for defining environment variables (used for your database connection)
 
 </SwitchTech>
 
@@ -122,8 +122,8 @@ npx prisma
 
 This command created a new directory called `prisma` with the following contents:
 
-    - `schema.prisma`: The Prisma schema with your database connection and the Prisma Client generator
-    - `.env`: A [dotenv](https://github.com/motdotla/dotenv) file for defining environment variables (used for your database connection)
+- `schema.prisma`: The Prisma schema with your database connection and the Prisma Client generator
+- `.env`: A [dotenv](https://github.com/motdotla/dotenv) file for defining environment variables (used for your database connection)
 
 </SwitchTech>
 


### PR DESCRIPTION
Instead of as the markdown for that list in a code block. Expecially since it contains a link to dotenv.

It is the the code block just above "Connect your database": https://www.prisma.io/docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch-typescript/