### PR TITLE
Fix logical error

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
@@ -108,7 +108,7 @@ const getUser: User | null = await prisma.user.findUnique({
 
 ```js
 {
-  id: 1,
+  id: 22,
   name: "Alice",
   email: "alice@prisma.io",
   profileViews: 0,


### PR DESCRIPTION
The below query is for id="22" and in output it showing '1'

https://www.prisma.io/docs/concepts/components/prisma-client/select-fields

![loGicalError](https://user-images.githubusercontent.com/24385409/116141247-0fab9200-a6f6-11eb-9663-9b5e17f5756e.JPG)
