### PR TITLE
fix(generating-prisma-client): more intuitive paths for output

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/010-generating-prisma-client.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/010-generating-prisma-client.mdx
@@ -98,7 +98,7 @@ If you do not specify a custom `output` in the `generator` block, Prisma Client 
 
 ### Using a custom `output` path
 
-You can also specify a custom `output` path on the `generator` configuration, for example (assuming your `schema.prisma` os located in the default `prisma` subfolder):
+You can also specify a custom `output` path on the `generator` configuration, for example (assuming your `schema.prisma` file is located at the default `prisma` subfolder):
 
 ```prisma
 generator client {
@@ -152,4 +152,3 @@ By generating Prisma Client into `node_modules`, the query engine is kept out of
 ## Generating Prisma Client in the `postinstall` hook of `@prisma/client`
 
 The `@prisma/client` package defines its own `postinstall` hook that's being executed whenever the package is being installed. This hook invokes the `prisma generate` command which in turn generates the Prisma Client code into the default location `node_modules/.prisma/client`. Notice that this requires the `prisma` to be available, either as local dependency or as a global installation (it is recommended to always install the `prisma` package as a development dependency, using `npm install prisma --save-dev`, to avoid versioning conflicts though).
-

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/010-generating-prisma-client.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/010-generating-prisma-client.mdx
@@ -98,12 +98,12 @@ If you do not specify a custom `output` in the `generator` block, Prisma Client 
 
 ### Using a custom `output` path
 
-You can also specify a custom `output` path on the `generator` configuration, for example:
+You can also specify a custom `output` path on the `generator` configuration, for example (assuming your `schema.prisma` os located in the default `prisma` subfolder):
 
 ```prisma
 generator client {
   provider = "prisma-client-js"
-  output   = "./src/generated/client"
+  output   = "../src/generated/client"
 }
 ```
 
@@ -116,7 +116,7 @@ After running `prisma generate` for that schema file, the Prisma Client package 
 To import the `PrismaClient` from a custom location:
 
 ```ts
-import { PrismaClient } from '../prisma/src/generated/client'
+import { PrismaClient } from './src/generated/client'
 ```
 
 ### Why is Prisma Client generated into `node_modules/.prisma/client` by default?

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/010-generating-prisma-client.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/010-generating-prisma-client.mdx
@@ -113,10 +113,10 @@ After running `prisma generate` for that schema file, the Prisma Client package 
 ./src/generated/client
 ```
 
-To import the `PrismaClient` from a custom location:
+To import the `PrismaClient` from a custom location (for example, from a file named `./src/script.ts`):
 
 ```ts
-import { PrismaClient } from './src/generated/client'
+import { PrismaClient } from './generated/client'
 ```
 
 ### Why is Prisma Client generated into `node_modules/.prisma/client` by default?


### PR DESCRIPTION
Currently the example is a bit weird, as you generate into a `src` folder inside `prisma`. Usually you would want to have that `src` folder one level up from your `prisma` folder.