### PR TITLE
fix(mongodb): remove comment anchor

### DIFF
--- a/content/200-concepts/200-database-connectors/07-mongodb.mdx
+++ b/content/200-concepts/200-database-connectors/07-mongodb.mdx
@@ -14,6 +14,6 @@ MongoDB support is in [Early Access](../../about/releases#early-access).
 
 If you're interested in beta testing the MongoDB connector for Prisma, please fill out this <a href="https://prisma103696.typeform.com/to/FriDuIeM">2-minute form</a>, and we'll reach out with details.
 
-You can also follow our progress in [issue #1277 on GitHub](https://github.com/prisma/prisma/issues/1277#issuecomment-624532966).
+You can also follow our progress in [issue #1277 on GitHub](https://github.com/prisma/prisma/issues/1277).
 
 </TopBlock>


### PR DESCRIPTION
Random comment in the middle of a loooong thread now - better link to just the issue