### PR TITLE
fix(connection-strings): socket_timeout has no default

### DIFF
--- a/content/200-concepts/200-database-connectors/03-postgresql.mdx
+++ b/content/200-concepts/200-database-connectors/03-postgresql.mdx
@@ -68,13 +68,14 @@ The following arguments can be used
 | `connection_limit` | No       | `num_cpus * 2 + 1`     | Maximum size of the [connection pool](../components/prisma-client/working-with-prismaclient/connection-pool))                             |
 | `connect_timeout`  | No       | `5`                    | Maximum number of seconds to wait for a new connection                                                                                                          |
 | `pool_timeout`     | No       | `10`                    | Maximum number of seconds to wait for a new connection from the pool. If all connections are in use, the database will return a `PoolTimeout` error after waiting for the given time. |
-| `socket_timeout`   | No       | `5`                    | Maximum number of seconds to wait until a single query terminates                                                                                               |
 | `sslmode`          | No       | `prefer`               | Configures whether to use TLS, possible values: `prefer`, `disable`, `require`                                                                                  |
 | `sslcert`          | No       |                        | Path of the server certificate. Certificate paths are [resolved relative to the `./prisma folder`](../components/prisma-schema/data-sources#ssl-certificates). |
 | `sslidentity`      | No       |                        | Path to the PKCS12 certificate                                                                                                                                  |
 | `sslpassword`      | No       |                        | Password that was used to secure the PKCS12 file                                                                                                                |
 | `sslaccept`        | No       | `accept_invalid_certs` | Configures whether to check for missing values in the certificate                                                                                               |
 | `host`             | No       |                        | Points to a directory that contains a socket to be used for the connection                                                                                      |
+| `socket_timeout`   | No       |                        | Maximum number of seconds to wait until a single query terminates                                                                                               |
+
 
 As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds, you can use the following arguments:
 

--- a/content/200-concepts/200-database-connectors/04-mysql.mdx
+++ b/content/200-concepts/200-database-connectors/04-mysql.mdx
@@ -67,13 +67,14 @@ The following arguments can be used
 | `connection_limit` | No       | `num_cpus * 2 + 1`     | Maximum size of the [connection pool](../components/prisma-client/working-with-prismaclient/connection-pool)                                                    |
 | `connect_timeout`  | No       | `5`                    | Maximum number of seconds to wait for a new connection                                                                                                                                |
 | `pool_timeout`     | No       | `10`                     | Maximum number of seconds to wait for a new connection from the pool. If all connections are in use, the database will return a `PoolTimeout` error after waiting for the given time. |
-| `socket_timeout`   | No       | `5`                    | Maximum number of seconds to wait until a single query terminates                                                                                                                     |
 | `sslmode`          | No       | `prefer`               | Configures whether to use TLS, possible values: `prefer`, `disable`, `require`                                                                                                        |
 | `sslcert`          | No       |                        | Path to the server certificate. Certificate paths are [resolved relative to the `./prisma folder`](../components/prisma-schema/data-sources#ssl-certificates)                         |
 | `sslidentity`      | No       |                        | Path to the PKCS12 certificate                                                                                                                                                        |
 | `sslpassword`      | No       |                        | Password that was used to secure the PKCS12 file                                                                                                                                      |
 | `sslaccept`        | No       | `accept_invalid_certs` | Configures whether to check for missing values in the certificate                                                                                                                     |
 | `socket`           | No       |                        | Points to a directory that contains a socket to be used for the connection                                                                                                            |
+| `socket_timeout`   | No       |                        | Number of seconds to wait until a single query terminates                                                                                                                            |
+
 
 As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds, you can use the following arguments:
 


### PR DESCRIPTION
Turns out `socket_timeout` by default set is to `None` (which kinda means `infinity`) so has no default value at all.

closes https://github.com/prisma/prisma/issues/6910