### PR TITLE
fix(prisma-schema): Remove "In this section"

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -313,7 +313,3 @@ Similar to tools like [gofmt](https://golang.org/cmd/gofmt/) and [prettier](http
 Like `gofmt` and unlike `prettier`, there are no options for configuration here. **There is exactly one way to format a prisma file**.
 
 Learn more about the formatting rules in the [spec](https://github.com/prisma/specs/tree/master/schema#formatting-rules).
-
-## In this section
-
-<Subsections />


### PR DESCRIPTION
... which is covered in the introduction section already as all subpages are linked to.