### PR TITLE
fix(connection-url): Add pgbouncer to PostgreSQL arguments with link to explanation

### DIFF
--- a/content/200-concepts/200-database-connectors/03-postgresql.mdx
+++ b/content/200-concepts/200-database-connectors/03-postgresql.mdx
@@ -75,7 +75,7 @@ The following arguments can be used
 | `sslaccept`        | No       | `accept_invalid_certs` | Configures whether to check for missing values in the certificate                                                                                               |
 | `host`             | No       |                        | Points to a directory that contains a socket to be used for the connection                                                                                      |
 | `socket_timeout`   | No       |                        | Maximum number of seconds to wait until a single query terminates                                                                                               |
-
+| `pgbouncer`        | No       | `false`                | Configure the Engine to [enable PgBouncer compatibility mode](../../guides/performance-and-optimization/connection-management/configure-pg-bouncer/)        |
 
 As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds, you can use the following arguments:
 


### PR DESCRIPTION
Was missing until now.