### PR TITLE
Add mention of yarn 1.19.2 or more recent required 

### DIFF
--- a/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
+++ b/content/200-concepts/100-components/05-prisma-cli/01-installation.mdx
@@ -36,7 +36,7 @@ Here's an example for invoking the `generate` command:
 npx prisma generate
 ```
 
-### Yarn
+### Yarn (1.19.2+)
 
 Install with [Yarn](https://yarnpkg.com/):
 


### PR DESCRIPTION
Not sure it's the best way to surface it.

Context:
 * Because Yarn used to remove all dot folders inside node_modules before.
 * We use node_modules/.prisma/client directory as default location for generated Prisma Client.
 * Changelog https://github.com/yarnpkg/yarn/blob/HEAD/CHANGELOG.md#1192