### PR TITLE
Fix typo in CRUD section of the documentation

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -248,7 +248,7 @@ const user = await prisma.user.findUnique({
 
 The following examples demonstrate how to retrieve records by a compound ID or unique identifier, defined by [`@@id`](../../../reference/api-reference/prisma-schema-reference#id-2) <span class="api"></span> or [`@@unique`](../../../reference/api-reference/prisma-schema-reference#unique-2) <span class="api"></span>.
 
-The following Prisma model defines an compound ID:
+The following Prisma model defines a compound ID:
 
 ```prisma highlight=6;normal
 model TimePeriod {


### PR DESCRIPTION
~an compound id~ => a compound id