### PR TITLE
fix(relations): better formatting for initial example

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
@@ -9,17 +9,18 @@ tocDepth: 3
 
 A relation is a _connection_ between two models in the Prisma schema. For example, there is a one-to-many relation between `User` and `Post` because one user can have many blog posts. The following Prisma schema defines a one-to-many relation between the `User` and `Post` models. The fields involved in defining the relation are highlighted:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma 
 model User {
-  id      Int      @id @default(autoincrement())
-|  posts   Post[]
+  id     Int     @id @default(autoincrement())
+|  posts  Post[]
 }
 
 model Post {
-  id         Int         @id @default(autoincrement())
-|  author     User        @relation(fields: [authorId], references: [id])
-|  authorId   Int         // relation scalar field  (used in the `@relation` attribute above)
+  id        Int   @id @default(autoincrement())
+|  author    User  @relation(fields: [authorId], references: [id])
+|  authorId  Int  // relation scalar field  (used in the `@relation` attribute above)
 }
+
 ```
 
 At a Prisma level, the `User` / `Post` relation is made up of:

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
@@ -9,7 +9,7 @@ tocDepth: 3
 
 A relation is a _connection_ between two models in the Prisma schema. For example, there is a one-to-many relation between `User` and `Post` because one user can have many blog posts. The following Prisma schema defines a one-to-many relation between the `User` and `Post` models. The fields involved in defining the relation are highlighted:
 
-```prisma line-number file=schema.prisma 
+```prisma line-number file=schema.prisma
 model User {
   id     Int     @id @default(autoincrement())
 |  posts  Post[]
@@ -20,7 +20,6 @@ model Post {
 |  author    User  @relation(fields: [authorId], references: [id])
 |  authorId  Int  // relation scalar field  (used in the `@relation` attribute above)
 }
-
 ```
 
 At a Prisma level, the `User` / `Post` relation is made up of:

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations.mdx
@@ -18,7 +18,7 @@ model User {
 model Post {
   id        Int   @id @default(autoincrement())
 |  author    User  @relation(fields: [authorId], references: [id])
-|  authorId  Int  // relation scalar field  (used in the `@relation` attribute above)
+|  authorId  Int   // relation scalar field  (used in the `@relation` attribute above)
 }
 ```
 


### PR DESCRIPTION
Had a looot of space between terms in the schema. 
Made it less, but still double the amount (2 spaces instead of 1) than what automatic formatting would do.