### PR TITLE
chore: move shadow db cloud up

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -60,6 +60,21 @@ Assuming Prisma Migrate did not [detect schema drift](#detecting-schema-drift), 
 1. Applies the generated migration to the development database (assuming you have not specified the `--create-only` flag)
 1. Drops the shadow database (cloud-hosted databases cannot be dropped, but are reset at the start of the `migrate dev` command)
 
+## Cloud-hosted shadow databases must be created manually
+
+Some cloud providers do not allow you to drop and create databases with SQL. Some require to create or drop the database via an online interface, and some really limit you to 1 database. If you **develop** in such a cloud-hosted environment, you must:
+
+1. Create a dedicated cloud-hosted shadow database
+2. Add the URL to the [`shadowDatabaseUrl`](../../../reference/api-reference/prisma-schema-reference#datasource) <span class="api"></span> field:
+
+```prisma highlight=4;normal
+datasource db {
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
+}
+```
+
 ## Shadow database user permissions
 
 In order to create and delete the shadow database when using development commands such as `migrate dev` and `migrate reset`, Prisma Migrate currently requires that the database user defined in your `datasource` has permission to **create databases**.
@@ -88,18 +103,3 @@ The resolve this error:
 - If you are developing against a cloud-based database (for example, on Heroku) and are currently **prototyping** such that you don't care about generated migration files and only need to apply your Prisma data model to the database schema, you can run [`prisma db push`](../../../reference/api-reference/command-reference#db) instead of the `prisma migrate dev` command.
 
 > **Important**: The shadow database is _only_ required in a development environment (specifically for the `prisma migrate dev` command) - you **do not** need to make any changes to your production environment.
-
-## Cloud-hosted shadow databases must be created manually
-
-Some cloud providers do not allow you to drop and create databases with SQL. Some require to create or drop the database via an online interface, and some really limit you to 1 database. If you **develop** in such a cloud-hosted environment, you must:
-
-1. Create a dedicated cloud-hosted shadow database
-2. Add the URL to the [`shadowDatabaseUrl`](../../../reference/api-reference/prisma-schema-reference#datasource) <span class="api"></span> field:
-
-```prisma highlight=4;normal
-datasource db {
-  provider          = "postgresql"
-  url               = env("DATABASE_URL")
-  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
-}
-```


### PR DESCRIPTION
Jan found it hard to find at the bottom, moving it up could help a bit

Then We could change the destination of https://pris.ly/d/migrate-shadow to this anchor

https://prisma-company.slack.com/archives/CGMCB82N8/p1621634495046000