### PR TITLE
fix: casing in 100-prisma-schema-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1048,12 +1048,12 @@ const user = await prisma.user.create({
 })
 ```
 
-To retrieve a user, use the generated composite ID field (`firstname_lastname`):
+To retrieve a user, use the generated composite ID field (`firstName_lastName`):
 
 ```ts
 const user = await prisma.user.findUnique({
   where: {
-    firstname_lastname: {
+    firstName_lastName: {
       firstName: 'Alice',
       lastName: 'Smith',
     }


### PR DESCRIPTION
Prisma seems to preserve casing when generating composite ID fields.