### PR TITLE
fix(prisma-engines): Add information to "Using custom engine binaries"

### DIFF
--- a/content/200-concepts/100-components/08-prisma-engines/index.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/index.mdx
@@ -26,7 +26,7 @@ As an example, Prisma Client connects to the [query engine](../../components/pri
 
 ### Using custom engine binaries
 
-By default, all binaries are automatically downloaded into the `node_modules/@prisma/engines` folder when you install or update `prisma`. You might want to use a [custom binary](https://github.com/prisma/prisma-engines) file if:
+By default, all binaries are automatically downloaded into the `node_modules/@prisma/engines` folder when you install or update `prisma`, the Prisma CLI package. (The [query engine](../../components/prisma-engines/query-engine) is also copied to the generated Prisma Client when you generate.) You might want to use a [custom binary](https://github.com/prisma/prisma-engines) file if:
 
 - Automated download of binaries is not possible.
 - You have created your own engine binary (for testing, or for an OS that is not officially supported).


### PR DESCRIPTION
The information about QE was missing.