### PR TITLE
[Fix] correct field name with migration

### DIFF
--- a/content/200-concepts/050-overview/300-prisma-in-your-stack/03-is-prisma-an-orm.mdx
+++ b/content/200-concepts/050-overview/300-prisma-in-your-stack/03-is-prisma-an-orm.mdx
@@ -114,7 +114,7 @@ export class UserRefactoring1604448000 implements MigrationInterface {
 }
 ```
 
-Once a migration is carried out and the database schema has been altered, the entity and mapper classes must also be updated to account for the new `lastName` column.
+Once a migration is carried out and the database schema has been altered, the entity and mapper classes must also be updated to account for the new `salutation` column.
 
 With TypeORM that means adding a `salutation` property to the `User` entity class:
 


### PR DESCRIPTION
Newly added column is `salutation` not `lastName` 😅 