### PR TITLE
Fix: Remove preview flag option from `db push`

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -599,7 +599,6 @@ datasource db {
 
 | Options              | Required | Description                                                                                                                |
 | :------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------- |
-| `--preview-feature`  | Yes      | Enables use of Preview feature commands                                                                                    |
 | `--skip-generate`    | No       | Skip generation of artifacts such as Prisma Client                                                                         |
 | `--force-reset`      | No       | Resets the database and then updates the schema - useful if you need to start from scratch due to unexecutable migrations. |
 | `--accept-data-loss` | No       | Ignore data loss warnings. This option is required if as a result of making the schema changes, data may be lost.          |


### PR DESCRIPTION
Removed `--preview-feature` as required flag for `db push command 