### PR TITLE
fix(prisma-engines): Remove invalid linked env var

### DIFF
--- a/content/200-concepts/100-components/08-prisma-engines/index.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/index.mdx
@@ -37,7 +37,6 @@ Use the following environment variables to specify custom locations for your bin
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](../../../../reference/api-reference/environment-variables-reference/#prisma_migration_engine_binary)  <span class="api"></span> (Migration engine)
 - [`PRISMA_INTROSPECTION_ENGINE_BINARY`](../../../../reference/api-reference/environment-variables-reference/#prisma_introspection_engine_binary) <span class="api"></span> (Introspection engine)
 - [`PRISMA_FMT_BINARY`](../../../../reference/api-reference/environment-variables-reference/#prisma_fmt_binary) <span class="api"></span> (for `npx prisma format`)
-- [`PRISMA_CLI_BINARY_TARGETS`](../../../../reference/api-reference/environment-variables-reference/#prisma_cli_binary_targets) <span class="api"></span>
 
 #### Setting the environment variable
 


### PR DESCRIPTION
This env var is something different, not to specify custom engine files.