### PR TITLE
Update 150-introspection.mdx to remove `authorId` having a default value of `false`

### DIFF
--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/150-introspection.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/150-introspection.mdx
@@ -59,7 +59,7 @@ CREATE TABLE "public"."Profile" (
 | `title`     | `VARCHAR(255)` | No          | No          | **✔️**   | -                  |
 | `content`   | `TEXT`         | No          | No          | No       | -                  |
 | `published` | `BOOLEAN`      | No          | No          | **✔️**   | `false`            |
-| `authorId`  | `INTEGER`      | No          | **✔️**      | **✔️**   | `false`            |
+| `authorId`  | `INTEGER`      | No          | **✔️**      | **✔️**   | -            |
 
 **Profile**
 


### PR DESCRIPTION
Resolves the documentation at https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/introspection-typescript-postgres which shows a visual representation of the Post table having an `authorId` default value of `false`. 