### PR TITLE
Change `orderByRelations` to `orderByRelation`

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -2020,12 +2020,12 @@ const users = await prisma.user.findMany({
 
 #### Sort `Post` by the related `User` record's `name`
 
-Sorting by relation fields is a Preview feature. To enable this feature, add `orderByRelations` to `previewFeatures` in your schema:
+Sorting by relation fields is a Preview feature. To enable this feature, add `orderByRelation` to `previewFeatures` in your schema:
 
 ```prisma highlight=3;normal
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["orderByRelations"]
+  previewFeatures = ["orderByRelation"]
 }
 ```
 
@@ -2043,12 +2043,12 @@ const posts = await prisma.post.findMany({
 
 #### Sort `User` by the `posts` count
 
-Sorting by relation count is a Preview feature. To enable this feature, add `orderByRelations` to `previewFeatures` in your schema:
+Sorting by relation count is a Preview feature. To enable this feature, add `orderByRelation` to `previewFeatures` in your schema:
 
 ```prisma highlight=3;normal
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["orderByRelations"]
+  previewFeatures = ["orderByRelation"]
 }
 ```
 


### PR DESCRIPTION
This change will fix a typo in the `orderBy` documentations.