### PR TITLE
fix(command-reference): Remove duplicated Arguments table

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -650,15 +650,9 @@ npx prisma db push --schema=/tmp/schema.prisma
 
   ```js
   "scripts": {
-   "ts-node": "ts-node --compiler-options '{\\\"module\\\":\\\"commonjs\\\"}'"
+    "ts-node": "ts-node --compiler-options '{\\\"module\\\":\\\"commonjs\\\"}'"
   },
   ```
-
-#### Arguments
-
-| Argument   | Required | Description                                                                                                                                       | Default                                          |
-| :--------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------- |
-| `--schema` | No       | Specifies the path to the desired schema.prisma file to be processed instead of the default path. Both absolute and relative paths are supported. | `./schema.prisma`<br /> `./prisma/schema.prisma` |
 
 #### Options
 


### PR DESCRIPTION
One table is enough.

Fixes: https://github.com/prisma/docs/pull/1965 as well