### PR TITLE
fix(data-model): model => data model

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -84,7 +84,7 @@ The corresponding database looks like this:
 
 </details>
 
-The following query uses the Prisma Client generated from this model to create:
+The following query uses the Prisma Client generated from this data model to create:
 
 - A `User` record
 - Two nested `Post` records
@@ -199,8 +199,8 @@ Your data model reflects _your_ application domain. For example:
 
 There are two ways to define a data model:
 
-- **Write the model manually and use Prisma Migrate**: You can write your data model manually and map it to your database using [Prisma Migrate](../prisma-migrate). In this case, the data model is the single source of truth for the models of your application.
-- **Generate the model via introspection**: When you have an existing database or prefer migrating your database schema with SQL, you generate the data model by [introspecting](../introspection) your database. In this case, the database schema is the single source of truth for the models of your application.
+- **Write the data model manually and use Prisma Migrate**: You can write your data model manually and map it to your database using [Prisma Migrate](../prisma-migrate). In this case, the data model is the single source of truth for the models of your application.
+- **Generate the data model via introspection**: When you have an existing database or prefer migrating your database schema with SQL, you generate the data model by [introspecting](../introspection) your database. In this case, the database schema is the single source of truth for the models of your application.
 
 ## Defining models
 


### PR DESCRIPTION
Fix a few location where it used `model` but `data model` was meant - and especially on this page where we explain how the data model consists of models this seemed important :D 