### PR TITLE
refactor: Replace diff tokens with `highlight` annotation.

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/100-connect-your-database.mdx
@@ -70,9 +70,9 @@ datasource db {
 
 Note that the default schema created by `prisma init` uses PostgreSQL, so you first need to switch the `provider` to `mysql`:
 
-```prisma file=prisma/schema.prisma
+```prisma file=prisma/schema.prisma highlight=2;edit
 datasource db {
-✎  provider = "mysql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 ```

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/250-querying-the-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/250-querying-the-database.mdx
@@ -71,11 +71,11 @@ Inside the `main` function, add the following query to read all `User` records f
 
 <SwitchTech technologies={['typescript', '*']}>
 
-```ts file=index.ts
+```ts file=index.ts highlight=3,4;add
 async function main() {
    // ... you will write your Prisma Client queries here
-+  const allUsers = await prisma.user.findMany()
-+  console.log(allUsers)
+  const allUsers = await prisma.user.findMany();
+  console.log(allUsers);
 }
 ```
 
@@ -83,11 +83,11 @@ async function main() {
 
 <SwitchTech technologies={['node', '*']}>
 
-```js file=index.js
+```js file=index.js highlight=2;delete|3,4;add
 async function main() {
--  // ... you will write your Prisma Client queries here
-+  const allUsers = await prisma.user.findMany()
-+  console.log(allUsers)
+  // ... you will write your Prisma Client queries here
+  const allUsers = await prisma.user.findMany()
+  console.log(allUsers)
 }
 ```
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/100-connect-your-database.mdx
@@ -64,9 +64,9 @@ datasource db {
 
 Note that the default schema created by `prisma init` uses PostgreSQL, so you first need to switch the `provider` to `mysql`:
 
-```prisma file=prisma/schema.prisma
+```prisma file=prisma/schema.prisma highlight=2;edit
 datasource db {
-✎  provider = "mysql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 ```

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/150-introspection.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/150-introspection.mdx
@@ -59,7 +59,7 @@ CREATE TABLE "public"."Profile" (
 | `title`     | `VARCHAR(255)` | No          | No          | **✔️**   | -                  |
 | `content`   | `TEXT`         | No          | No          | No       | -                  |
 | `published` | `BOOLEAN`      | No          | No          | **✔️**   | `false`            |
-| `authorId`  | `INTEGER`      | No          | **✔️**      | **✔️**   | -            |
+| `authorId`  | `INTEGER`      | No          | **✔️**      | **✔️**   | -                  |
 
 **Profile**
 
@@ -190,21 +190,21 @@ These changes are relevant for the generated Prisma Client API where using lower
 
 Because [relation fields](../../../../concepts/components/prisma-schema/relations#relation-fields) are _virtual_ (i.e. they _do not directly manifest in the database_), you can manually rename them in your Prisma schema without touching the database:
 
-```prisma file=prisma/schema.prisma
+```prisma file=prisma/schema.prisma highlight=7,14,22,23;edit
 model Post {
   id        Int      @default(autoincrement()) @id
   title     String   @db.VarChar(255)
   createdAt DateTime @default(now()) @db.Timestamp(6)
   content   String?
   published Boolean  @default(false)
-✎  author    User     @relation(fields: [authorId], references: [id])
+  author    User     @relation(fields: [authorId], references: [id])
   authorId  Int
 }
 
 model Profile {
   id     Int     @default(autoincrement()) @id
   bio    String?
-✎  user   User    @relation(fields: [userId], references: [id])
+  user   User    @relation(fields: [userId], references: [id])
   userId Int     @unique
 }
 
@@ -212,8 +212,8 @@ model User {
   id      Int      @default(autoincrement()) @id
   email   String   @unique @db.VarChar(255)
   name    String?  @db.VarChar(255)
-✎  posts   Post[]
-✎  profile Profile?
+  posts   Post[]
+  profile Profile?
 }
 ```
 

--- a/content/200-concepts/050-overview/300-prisma-in-your-stack/03-is-prisma-an-orm.mdx
+++ b/content/200-concepts/050-overview/300-prisma-in-your-stack/03-is-prisma-an-orm.mdx
@@ -118,7 +118,7 @@ Once a migration is carried out and the database schema has been altered, the en
 
 With TypeORM that means adding a `salutation` property to the `User` entity class:
 
-```ts
+```ts  highlight=17,18;normal
 import {Entity, PrimaryGeneratedColumn, Column} from "typeorm";
 
 @Entity()
@@ -135,8 +135,8 @@ export class User {
   @Column({ unique: true })
   email: string
 
-|  @Column()
-|  salutation: string
+  @Column()
+  salutation: string
 }
 ```
 

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -738,13 +738,13 @@ To resolve this error, you can:
 
 - Make the relation optional:
 
-  ```prisma
+  ```prisma highlight=3,4;add|5,6;delete
   model Post {
   id         Int        @id @default(autoincrement())
-  + author     User?       @relation(fields: [authorId], references: [id])
-  + authorId   Int?
-  - author     User       @relation(fields: [authorId], references: [id])
-  - authorId   Int
+  author     User?       @relation(fields: [authorId], references: [id])
+  authorId   Int?
+  author     User       @relation(fields: [authorId], references: [id])
+  authorId   Int
   }
   ```
 

--- a/content/200-concepts/100-components/250-preview-features/100-sql-server/001-sql-server-start-from-scratch.mdx
+++ b/content/200-concepts/100-components/250-preview-features/100-sql-server/001-sql-server-start-from-scratch.mdx
@@ -404,21 +404,21 @@ Field names affect the shape of the Prisma Client - for example, a property name
 
 1. Change the field names as shown:
 
-   ```prisma file=prisma/schema.prisma
+   ```prisma file=prisma/schema.prisma highlight=7,14,22,23;edit
    model Post {
      id        Int      @default(autoincrement()) @id
      createdAt DateTime @default(now())
      title     String
      content   String?
      published Boolean  @default(false)
-   ✎  author    User     @relation(fields: [authorId], references: [id])
+     author    User     @relation(fields: [authorId], references: [id])
      authorId  Int
    }
 
    model Profile {
      id     Int     @default(autoincrement()) @id
      bio    String?
-   ✎  user   User    @relation(fields: [userId], references: [id])
+     user   User    @relation(fields: [userId], references: [id])
      userId Int     @unique
    }
 
@@ -426,8 +426,8 @@ Field names affect the shape of the Prisma Client - for example, a property name
      id      Int      @default(autoincrement()) @id
      email   String   @unique
      name    String?
-   ✎  posts   Post[]
-   ✎  profile Profile?
+     posts   Post[]
+     profile Profile?
    }
    ```
 

--- a/content/300-guides/050-database/900-advanced-database-tasks/08-sql-views.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/08-sql-views.mdx
@@ -455,7 +455,7 @@ You must manually add views to the Prisma schema.
 
    <SwitchTech technologies={['*', 'mysql']}>
 
-   ```prisma file=schema.prisma
+   ```prisma file=schema.prisma highlight=22,23,24,25,26,27;add
    datasource db {
      provider = "mysql"
      url      = env("DATABASE_URL")
@@ -477,19 +477,19 @@ You must manually add views to the Prisma schema.
      Post  Post[]
    }
 
-   + model Draft {
-   +   title     String
-   +   id        Int     @unique
-   +   email     String
-   +   published Boolean
-   +  }
+   model Draft {
+     title     String
+     id        Int     @unique
+     email     String
+     published Boolean
+   }
    ```
 
     </SwitchTech>
 
    <SwitchTech technologies={['*', 'postgres']}>
 
-   ```prisma file=schema.prisma
+   ```prisma file=schema.prisma highlight=22,23,24,25,26,27;add
    datasource db {
      provider = "postgresql"
      url      = env("DATABASE_URL")
@@ -511,12 +511,12 @@ You must manually add views to the Prisma schema.
      Post  Post[]
    }
 
-   + model Draft {
-   +   title     String
-   +   id        Int     @unique
-   +   email     String
-   +   published Boolean
-   +  }
+   model Draft {
+     title     String
+     id        Int     @unique
+     email     String
+     published Boolean
+   }
    ```
 
     </SwitchTech>

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/02-schema-incompatibilities.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/02-schema-incompatibilities.mdx
@@ -96,10 +96,10 @@ model Post {
 
 You can add the `@default` attribute to the Prisma model:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=3;add
 model Post {
   id        String
-+  published Boolean @default(false)
+  published Boolean @default(false)
 }
 ```
 
@@ -143,9 +143,9 @@ Because there's no indication of the CUID behavior in the database, Prisma's int
 
 As a workaround, you can manually add the `@default(cuid())` attribute to the Prisma model:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=2;add
 model Post {
-+  id String @id @default(cuid())
+  id String @id @default(cuid())
 }
 ```
 
@@ -163,10 +163,10 @@ Prisma 1 auto-generates values for `DateTime` fields when they're annotated with
 
 #### Prisma 1 datamodel
 
-```graphql line-number
+```graphql line-number highlight=3;normal
 type Post {
   id: ID! @id
-|  createdAt: DateTime! @createdAt
+  createdAt: DateTime! @createdAt
 }
 ```
 
@@ -264,10 +264,10 @@ model Post {
 
 As a workaround, you can manually add the `@updatedAt` attribute to the Prisma model:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=3;add
 model Post {
   id        String   @id
-+  updatedAt DateTime @updatedAt
+  updatedAt DateTime @updatedAt
 }
 ```
 
@@ -358,10 +358,10 @@ ALTER TABLE `Profile`
 
 After this adjustment, you can re-introspect your database and the 1-1 relation will be properly recognized:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=3;normal
 model User {
   id      String   @id
-|  Profile Profile?
+  Profile Profile?
 }
 
 model Profile {
@@ -375,10 +375,10 @@ model Profile {
 
 You can remove the `[]` type modifier attribute from the relation field in the Prisma schema:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=3;add
 model User {
   id      String  @id
-+  Profile Profile
+  Profile Profile
 }
 
 model Profile {
@@ -506,16 +506,16 @@ As a workaround, you can migrate the data into a structure that's compatible wit
 
 After that you can introspect your database and the relation will now be recognized as 1-n:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=3,8,9;normal
 model User {
   id   String @id
-|  Post Post[]
+  Post Post[]
 }
 
 model Post {
   id       String @id
-|  User     User   @relation(fields: [authorId], references: [id])
-|  authorId String
+  User     User   @relation(fields: [authorId], references: [id])
+  authorId String
 }
 ```
 
@@ -576,10 +576,10 @@ ALTER TABLE User MODIFY COLUMN role ENUM('ADMIN', 'CUSTOMER') DEFAULT 'CUSTOMER'
 
 After this adjustment, you can re-introspect your database and the field will now be recognized as `Json`:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=3;normal
 model User {
   id       String @id
-|  jsonData Json?
+  jsonData Json?
 }
 ```
 
@@ -639,16 +639,16 @@ You can manually turn the `role` column into an enum with your desired values:
 
 After introspection, the type is now properly recognized as an enum:
 
-```prisma line-number file=schema.prisma
+```prisma line-number file=schema.prisma highlight=3,6-9;normal
 model User {
   id   String  @id
-|  role Role?
+  role Role?
 }
 
-|enum Role {
-|  ADMIN
-|  CUSTOMER
-|}
+enum Role {
+  ADMIN
+  CUSTOMER
+}
 ```
 
 ## Mismatching CUID length

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/04-upgrading-nexus-prisma-to-nexus.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/04-upgrading-nexus-prisma-to-nexus.mdx
@@ -85,39 +85,39 @@ npx prisma -v
 
 To get started, you can remove the old imports that are not needed any more with your new setup:
 
-```ts line-number
-- import { makePrismaSchema, prismaObjectType } from 'nexus-prisma'
-- import datamodelInfo from './generated/nexus-prisma'
-- import { prisma } from './generated/prisma-client'
+```ts line-number highlight=1-3;delete
+import { makePrismaSchema, prismaObjectType } from 'nexus-prisma'
+import datamodelInfo from './generated/nexus-prisma'
+import { prisma } from './generated/prisma-client'
 ```
 
 Instead, you now import the following into your application:
 
-```ts line-number
-+ import { nexusSchemaPrisma } from 'nexus-plugin-prisma/schema'
-+ import { objectType, makeSchema, queryType, mutationType } from '@nexus/schema'
-+ import { PrismaClient } from '@prisma/client'
+```ts line-number highlight=1-3;add
+import { nexusSchemaPrisma } from 'nexus-plugin-prisma/schema'
+import { objectType, makeSchema, queryType, mutationType } from '@nexus/schema'
+import { PrismaClient } from '@prisma/client'
 ```
 
 Next you need to adjust the code where you currently create your `GraphQLSchema`, most likely this is currently happening via the `makePrismaSchema` function in your code. Since this function was imported from the removed `nexus-prisma` package, you'll need to replace it with the `makeSchema` function from the `@nexus/schema` package. The way how the Prisma plugin for Nexus is used also changes in the latest version.
 
 Here's an example for such a configuration:
 
-```ts file=./src/index.ts line-number
-- const schema = makePrismaSchema({
-+ const schema = makeSchema({
+```ts file=./src/index.ts line-number highlight=2,12-14;add|1,8-11;delete
+ const schema = makePrismaSchema({
+ const schema = makeSchema({
 
   // Provide all the GraphQL types we've implemented
   types: [Query, Mutation, UserUniqueInput, User, Post, Category, Profile],
 
   // Configure the interface to Prisma
--  prisma: {
--    datamodelInfo,
--    client: prisma,
--  },
-+  plugins: [nexusSchemaPrisma({
-+    experimentalCRUD: true,
-+  })],
+  prisma: {
+    datamodelInfo,
+    client: prisma,
+  },
+  plugins: [nexusSchemaPrisma({
+    experimentalCRUD: true,
+  })],
 
   // Specify where Nexus should put the generated files
   outputs: {
@@ -146,13 +146,13 @@ Here's an example for such a configuration:
 
 If you previously typed the GraphQL `context` object that's passed through your resolver chain, you need to adjust the type like so:
 
-```ts file=./src/types.ts
-- import { Prisma } from './generated/prisma-client'
-+ import { PrismaClient } from '@prisma/client'
+```ts file=./src/types.ts highlight=2,6;add|1,5;delete
+import { Prisma } from './generated/prisma-client'
+import { PrismaClient } from '@prisma/client'
 
 export interface Context {
--  prisma: Prisma
-+  prisma: PrismaClient
+  prisma: Prisma
+  prisma: PrismaClient
 }
 ```
 
@@ -216,8 +216,8 @@ Note that `t.model` looks at the `name` attribute in the object that's passed as
 
 At this point, you might see errors on the relation fields `posts` and `profile`, e.g.:
 
-```
-- Missing type Post, did you forget to import a type to the root query?
+```bash highlight=1;delete
+Missing type Post, did you forget to import a type to the root query?
 ```
 
 This is because you didn't add the `Post` and `Profile` types to the GraphQL schema yet, the errors will go away once these types are part of the GraphQL schema as well!
@@ -423,20 +423,20 @@ queryType({
 
 The only thing that needs to be updated for this query is the call to Prisma since the new Prisma Client API looks a bit different from the one used in Prisma 1.
 
-```ts line-number
+```ts line-number highlight=6,9,12,13;normal
 queryType({
   definition(t) {
     t.list.field('posts', {
       type: 'Post',
       args: {
-|        searchString: stringArg({ nullable: true }),
+        searchString: stringArg({ nullable: true }),
       },
       resolve: (parent, { searchString }, context) => {
-|        return context.prisma.post.findMany({
+        return context.prisma.post.findMany({
           where: {
             OR: [
-|              { title: { contains: searchString } },
-|              { content: { contains: searchString } },
+              { title: { contains: searchString } },
+              { content: { contains: searchString } },
             ],
           },
         })
@@ -484,24 +484,24 @@ queryType({
 
 You now need to adjust the call to your `prisma` instance since the new Prisma Client API looks a bit different from the one used in Prisma 1.
 
-```ts line-number
+```ts line-number highlight=6,12-17;normal
 const Query = queryType({
   definition(t) {
     t.field('user', {
       type: 'User',
       args: {
-|        userUniqueInput: arg({
+        userUniqueInput: arg({
           type: 'UserUniqueInput',
           nullable: false,
        })
       },
       resolve: (_, args, context) => {
-|        return context.prisma.user.findUnique({
-|          where: {
-|            id: args.userUniqueInput?.id,
-|            email: args.userUniqueInput?.email
-|          }
-|        })
+        return context.prisma.user.findUnique({
+          where: {
+            id: args.userUniqueInput?.id,
+            email: args.userUniqueInput?.email
+          }
+        })
       }
     })
   }
@@ -569,7 +569,7 @@ mutationType({
 
 You now need to adjust the call to your `prisma` instance since the new Prisma Client API looks a bit different from the one used in Prisma 1.
 
-```ts line-number
+```ts line-number highlight=11-19;normal
 const Mutation = mutationType({
   definition(t) {
     t.field('createDraft', {
@@ -580,15 +580,15 @@ const Mutation = mutationType({
         authorId: stringArg({ nullable: false }),
       },
       resolve: (_, args, context) => {
-|        return context.prisma.post.create({
-|          data: {
-|            title: args.title,
-|            content: args.content,
-|            author: {
-|              connect: { id: args.authorId }
-|            }
-|          }
-|        })
+        return context.prisma.post.create({
+          data: {
+            title: args.title,
+            content: args.content,
+            author: {
+              connect: { id: args.authorId }
+            }
+          }
+        })
       }
     })
   }
@@ -631,7 +631,7 @@ mutationType({
 
 You now need to adjust the call to your `prisma` instance since the new Prisma Client API looks a bit different from the one used in Prisma 1.
 
-```ts
+```ts highlight=13-23;normal
 const Mutation = mutationType({
   definition(t) {
     t.field('updateBio', {
@@ -644,17 +644,17 @@ const Mutation = mutationType({
         bio: stringArg()
       },
       resolve: (_, args, context) => {
-|        return context.prisma.user.update({
-|          where: {
-|            id: args.userUniqueInput?.id,
-|            email: args.userUniqueInput?.email
-|          },
-|          data: {
-|            profile: {
-|              create: { bio: args.bio }
-|            }
-|          }
-|        })
+        return context.prisma.user.update({
+          where: {
+            id: args.userUniqueInput?.id,
+            email: args.userUniqueInput?.email
+          },
+          data: {
+            profile: {
+              create: { bio: args.bio }
+            }
+          }
+        })
       }
     })
   }
@@ -695,7 +695,7 @@ mutationType({
 
 You now need to adjust the call to your `prisma` instance since the new Prisma Client API looks a bit different from the one used in Prisma 1.
 
-```ts line-number
+```ts line-number highlight=14-21;normal
 const Mutation = mutationType({
   definition(t) {
     t.field('addPostToCategories', {
@@ -709,14 +709,14 @@ const Mutation = mutationType({
       },
       resolve: (_, args, context) => {
         const ids = args.categoryIds.map(id => ({ id }))
-|        return context.prisma.post.update({
-|          where: {
-|            id: args.postId
-|          },
-|          data: {
-|            categories: { connect: ids }
-|          }
-|        })
+        return context.prisma.post.update({
+          where: {
+            id: args.postId
+          },
+          data: {
+            categories: { connect: ids }
+          }
+        })
       }
     })
   }

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/05-upgrading-prisma-binding-to-nexus.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/05-upgrading-prisma-binding-to-nexus.mdx
@@ -269,7 +269,7 @@ At this point, any _relation fields_ might give you TypeScript errors (in this c
 
 Note that the `t.model.posts` relation exposes a _list_ of `Post` objects. By default, Nexus exposes only _pagination_ properties for that list – if you want to add _ordering_ and _filtering_ for that relation as well, you'll need to explicitly enable those:
 
-```ts line-number
+```ts line-number highlight=10-13;add
 const User = objectType({
   name: 'User',
   definition(t) {
@@ -279,10 +279,10 @@ const User = objectType({
     t.model.jsonData()
     t.model.role()
     t.model.profile()
-+    t.model.posts({
-+      filtering: true,
-+      ordering: true,
-+    })
+    t.model.posts({
+      filtering: true,
+      ordering: true,
+    })
   },
 })
 ```
@@ -465,13 +465,13 @@ Similar to `model`, this property is available because you're using the `nexus-p
 
 To add the `users` query to your GraphQL API, add the following lines to the query type definition:
 
-```ts line-number
+```ts line-number highlight=3-6;add
 const Query = queryType({
   definition(t) {
-+    t.crud.users({
-+      filtering: true,
-+      ordering: true,
-+    })
+    t.crud.users({
+      filtering: true,
+      ordering: true,
+    })
   }
 })
 ```
@@ -546,16 +546,16 @@ const resolvers = {
 
 To get the same behavior with Nexus, you'll need to add a `t.field` definition to the `queryType`:
 
-```ts line-number
+```ts line-number highlight=5-9;add
 const Query = queryType({
   definition(t) {
     // ... previous queries
 
-+    t.list.field('posts', {
-+      type: 'Post',
-+      nullable: false,
-+      args: { searchString: stringArg() }
-+    })
+    t.list.field('posts', {
+      type: 'Post',
+      nullable: false,
+      args: { searchString: stringArg() }
+    })
   }
 })
 ```
@@ -575,7 +575,7 @@ However, the code is missing the actual resolver logic. This is what you're goin
 
 You can add the resolver with Nexus as follows:
 
-```ts line-number
+```ts line-number highlight=9-19;add
 const Query = queryType({
   definition(t) {
     // ... previous queries
@@ -584,17 +584,17 @@ const Query = queryType({
       type: 'Post',
       nullable: false,
       args: { searchString: stringArg() },
-+      resolve: (_, args, context) => {
-+        return context.prisma.post.findMany({
-+          where: {
-+            OR: [{
-+              title: { contains: args.searchString }
-+            }, {
-+              content: { contains: args.searchString }
-+            }]
-+          }
-+        })
-+      }
+      resolve: (_, args, context) => {
+        return context.prisma.post.findMany({
+          where: {
+            OR: [{
+              title: { contains: args.searchString }
+            }, {
+              content: { contains: args.searchString }
+            }]
+          }
+        })
+      }
     })
   }
 })
@@ -657,30 +657,30 @@ const resolvers = {
 
 To get the same behavior with Nexus, you'll need to add a `t.field` definition to the `queryType` and define an `inputObjectType` that includes the two `@unique` fields of your `User` model:
 
-```ts line-number
-+import { inputObjectType, arg } from "@nexus/schema"
+```ts line-number highlight=1,3-9,15-23;add
+import { inputObjectType, arg } from "@nexus/schema"
 
-+const UserUniqueInput = inputObjectType({
-+  name: 'UserUniqueInput',
-+  definition(t) {
-+    t.string('id')
-+    t.string('email')
-+  },
-+})
+const UserUniqueInput = inputObjectType({
+  name: 'UserUniqueInput',
+  definition(t) {
+    t.string('id')
+    t.string('email')
+  },
+})
 
 const Query = queryType({
   definition(t) {
     // ... previous queries
 
-+    t.field('user', {
-+      type: 'User',
-+      args: {
-+        userUniqueInput: arg({
-+          type: 'UserUniqueInput',
-+          nullable: false,
-+       })
-+      }
-+    })
+    t.field('user', {
+      type: 'User',
+      args: {
+        userUniqueInput: arg({
+          type: 'UserUniqueInput',
+          nullable: false,
+       })
+      }
+    })
   }
 })
 ```
@@ -738,7 +738,7 @@ However, because the resolver is not yet implemented you will not get any data b
 
 That's because you're still missing the _resolver_ implementation for that query. You can add the resolver with Nexus as follows:
 
-```ts line-number
+```ts line-number highlight=22-29;add
 const UserUniqueInput = inputObjectType({
   name: 'UserUniqueInput',
   definition(t) {
@@ -760,14 +760,14 @@ const Query = queryType({
           nullable: false,
         })
       },
-+      resolve: (_, args, context) => {
-+        return context.prisma.user.findUnique({
-+          where: {
-+            id: args.userUniqueInput?.id,
-+            email: args.userUniqueInput?.email
-+          }
-+        })
-+      }
+      resolve: (_, args, context) => {
+        return context.prisma.user.findUnique({
+          where: {
+            id: args.userUniqueInput?.id,
+            email: args.userUniqueInput?.email
+          }
+        })
+      }
     })
   },
   }
@@ -796,9 +796,9 @@ const Mutation = mutationType({
 
 In order to make sure that the new `Mutation` type is picked by up Nexus, you need to add it to the `types` that are provided to `makeSchema`:
 
-```ts line-number
+```ts line-number highlight=2;normal
 export const schema = makeSchema({
-|types: [Query, User, Post, Profile, Category, UserUniqueInput, Mutation],
+  types: [Query, User, Post, Profile, Category, UserUniqueInput, Mutation],
   plugins: [nexusSchemaPrisma()],
   outputs: {
     schema: __dirname + '/../schema.graphql',
@@ -849,12 +849,12 @@ Similar to `model`, this property is available because you're using the `nexus-p
 
 To add the `createUser` mutation to your GraphQL API, add the following lines to the query type definition:
 
-```ts line-number
+```ts line-number highlight=3-5;add
 const Mutation = mutationType({
   definition(t) {
-+    t.crud.createOneUser({
-+      alias: 'createUser',
-+    })
+    t.crud.createOneUser({
+      alias: 'createUser',
+    })
   }
 })
 ```
@@ -924,29 +924,29 @@ const resolvers = {
 
 To get the same behavior with Nexus, you'll need to add a `t.field` definition to the `mutationType`:
 
-```ts line-number
+```ts line-number highlight=5-12;add
 const Mutation = mutationType({
   definition(t) {
     // ... previous mutations
 
-+    t.field('createDraft', {
-+      type: 'Post',
-+      args: {
-+        title: stringArg({ nullable: false }),
-+        content: stringArg(),
-+        authorId: stringArg({ nullable: false }),
-+      }
-+    })
+    t.field('createDraft', {
+      type: 'Post',
+      args: {
+        title: stringArg({ nullable: false }),
+        content: stringArg(),
+        authorId: stringArg({ nullable: false }),
+      }
+    })
   }
 })
 ```
 
 If you look at the generated SDL version of your GraphQL schema inside `schema.graphql`, you'll notice that this has added the correct _definition_ to your GraphQL schema already:
 
-```graphql line-number
+```graphql line-number highlight=3;normal
 type Mutation {
   createUser(data: UserCreateInput!): User!
-|  createDraft(title: String!, content: String, authorId: String!): Post!
+  createDraft(title: String!, content: String, authorId: String!): Post!
 }
 ```
 
@@ -971,7 +971,7 @@ However, because the resolver is not yet implemented, no new `Post` record will 
 
 That's because you're still missing the _resolver_ implementation for that mutation. You can add the resolver with Nexus as follows:
 
-```ts line-number
+```ts line-number highlight=12-22;add
 const Mutation = mutationType({
   definition(t) {
     // ... previous mutations
@@ -983,17 +983,17 @@ const Mutation = mutationType({
         content: stringArg(),
         authorId: stringArg({ nullable: false }),
       },
-+      resolve: (_, args, context) => {
-+        return context.prisma.post.create({
-+          data: {
-+            title: args.title,
-+            content: args.content,
-+            author: {
-+              connect: { id: args.authorId }
-+            }
-+          }
-+        })
-+      }
+      resolve: (_, args, context) => {
+        return context.prisma.post.create({
+          data: {
+            title: args.title,
+            content: args.content,
+            author: {
+              connect: { id: args.authorId }
+            }
+          }
+        })
+      }
     })
   }
 })
@@ -1041,32 +1041,32 @@ const resolvers = {
 
 To get the same behavior with Nexus, you'll need to add a `t.field` definition to the `mutationType`:
 
-```ts line-number
+```ts line-number highlight=5-13;add
 const Mutation = mutationType({
   definition(t) {
     // ... previous mutations
 
-+    t.field('updateBio', {
-+      type: 'User',
-+      args: {
-+        userUniqueInput: arg({
-+          type: 'UserUniqueInput',
-+          nullable: false
-+        }),
-+        bio: stringArg({ nullable: false })
-+      },
-+    })
+    t.field('updateBio', {
+      type: 'User',
+      args: {
+        userUniqueInput: arg({
+          type: 'UserUniqueInput',
+          nullable: false
+        }),
+        bio: stringArg({ nullable: false })
+      },
+    })
   }
 })
 ```
 
 If you look at the generated SDL version of your GraphQL schema inside `schema.graphql`, you'll notice that this has added the correct _definition_ to your GraphQL schema already:
 
-```graphql line-number
+```graphql line-number highlight=4;normal
 type Mutation {
   createUser(data: UserCreateInput!): User!
   createDraft(title: String!, content: String, authorId: String!): Post!
-|  updateBio(bio: String!, userUniqueInput: UserUniqueInput!): User
+  updateBio(bio: String!, userUniqueInput: UserUniqueInput!): User
 }
 ```
 
@@ -1091,7 +1091,7 @@ However, because the resolver is not yet implemented, nothing will be updated in
 
 That's because you're still missing the _resolver_ implementation for that query. You can add the resolver with Nexus as follows:
 
-```ts line-number
+```ts line-number highlight=14-26;add
 const Mutation = mutationType({
   definition(t) {
     // ... previous mutations
@@ -1105,19 +1105,20 @@ const Mutation = mutationType({
         }),
         bio: stringArg()
       },
-+      resolve: (_, args, context) => {
-+        return context.prisma.user.update({
-+          where: {
-+            id: args.userUniqueInput?.id,
-+            email: args.userUniqueInput?.email
-+          },
-+          data: {
-+            profile: {
-+              create: { bio: args.bio }
-+            }
-+          }
-+        })
+      resolve: (_, args, context) => {
+        return context.prisma.user.update({
+          where: {
+            id: args.userUniqueInput?.id,
+            email: args.userUniqueInput?.email
+          },
+          data: {
+            profile: {
+              create: { bio: args.bio }
+            }
+          }
+        })
       }
+    }
   }
 })
 ```
@@ -1167,33 +1168,33 @@ const resolvers = {
 
 To get the same behavior with Nexus, you'll need to add a `t.field` definition to the `mutationType`:
 
-```ts line-number
+```ts line-number highlight=5-14;add
 const Mutation = mutationType({
   definition(t) {
     // ... mutations from before
 
-+  t.field('addPostToCategories', {
-+      type: 'Post',
-+      args: {
-+        postId: stringArg({ nullable: false }),
-+        categoryIds: stringArg({
-+          list: true,
-+          nullable: false
-+        }),
-+      },
-+    })
+  t.field('addPostToCategories', {
+      type: 'Post',
+      args: {
+        postId: stringArg({ nullable: false }),
+        categoryIds: stringArg({
+          list: true,
+          nullable: false
+        }),
+      },
+    })
   }
 })
 ```
 
 If you look at the generated SDL version of your GraphQL schema inside `schema.graphql`, you'll notice that this has added the correct _definition_ to your GraphQL schema already:
 
-```graphql line-number
+```graphql line-number highlight=5;normal
 type Mutation {
   createUser(data: UserCreateInput!): User!
   createDraft(title: String!, content: String, authorId: String!): Post!
   updateBio(bio: String, userUniqueInput: UserUniqueInput!): User
-|  addPostToCategories(postId: String!, categoryIds: [String!]!): Post
+  addPostToCategories(postId: String!, categoryIds: [String!]!): Post
 }
 ```
 
@@ -1221,7 +1222,7 @@ However, because the resolver is not yet implemented, nothing will be updated in
 
 That's because you're still missing the _resolver_ implementation for that query. You can add the resolver with Nexus as follows:
 
-```ts line-number
+```ts line-number highlight=13-23;add
 const Mutation = mutationType({
   definition(t) {
     // ... mutations from before
@@ -1234,17 +1235,17 @@ const Mutation = mutationType({
           nullable: false
         }),
       },
-+      resolve: (_, args, context) => {
-+        const ids = args.categoryIds.map(id => ({ id }))
-+        return context.prisma.post.update({
-+          where: {
-+            id: args.postId
-+          },
-+          data: {
-+            categories: { connect: ids }
-+          }
-+        })
-+      }
+      resolve: (_, args, context) => {
+        const ids = args.categoryIds.map(id => ({ id }))
+        return context.prisma.post.update({
+          where: {
+            id: args.postId
+          },
+          data: {
+            categories: { connect: ids }
+          }
+        })
+      }
     })
   }
 })

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/06-upgrading-prisma-binding-to-sdl-first.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/06-upgrading-prisma-binding-to-sdl-first.mdx
@@ -767,7 +767,7 @@ The `PrismaClient` query API is inspired by the initial `prisma-binding` API, so
 
 Similar to the `prisma-binding` instance from Prisma 1, you also want to attach your `PrismaClient` from Prisma 2 to GraphQL's `context` so that in can be accessed inside your resolvers:
 
-```js line-number
+```js line-number highlight=10-13;delete|14;add
 const { PrismaClient } = require('@prisma/client')
 
 // ...
@@ -777,11 +777,11 @@ const server = new GraphQLServer({
   resolvers,
   context: req => ({
     ...req,
--    prisma: new Prisma({
--      typeDefs: 'src/generated/prisma.graphql',
--      endpoint: 'http://localhost:4466',
--    }),
-+    prisma: new PrismaClient()
+    prisma: new Prisma({
+      typeDefs: 'src/generated/prisma.graphql',
+      endpoint: 'http://localhost:4466',
+    }),
+    prisma: new PrismaClient()
   }),
 })
 ```
@@ -829,7 +829,7 @@ Since you're not using `prisma-binding` any more, you now need to resolve these 
 
 You can do so by adding a `User` field to your _resolver map_ and implement the resolvers for the `posts` and `profile` relations as follows:
 
-```js line-number
+```js line-number highlight=8-19;add
 const resolvers = {
   Query: {
     // ... your query resolvers
@@ -837,18 +837,18 @@ const resolvers = {
   Mutation: {
     // ... your mutation resolvers
   },
-+  User: {
-+    posts: (parent, args, context) => {
-+      return context.prisma.user.findUnique({
-+        where: { id: parent.id }
-+      }).posts()
-+    },
-+    profile: (parent, args, context) => {
-+       return context.prisma.user.findUnique({
-+         where: { id: parent.id }
-+       }).profile()
-+     }
-+   },
+  User: {
+    posts: (parent, args, context) => {
+      return context.prisma.user.findUnique({
+        where: { id: parent.id }
+      }).posts()
+    },
+    profile: (parent, args, context) => {
+       return context.prisma.user.findUnique({
+         where: { id: parent.id }
+       }).profile()
+     }
+   },
 }
 ```
 
@@ -909,7 +909,7 @@ Since you're not using `prisma-binding` any more, you now need to resolve these 
 
 You can do so by adding a `Post` field to your _resolver map_ and implement the resolvers for the `author` and `categories` relations as follows:
 
-```js line-number
+```js line-number highlight=11-22;add
 const resolvers = {
   Query: {
     // ... your query resolvers
@@ -920,18 +920,18 @@ const resolvers = {
   User: {
     // ... your type resolvers for `User` from before
   },
-+  Post: {
-+    author: (parent, args, context) => {
-+      return context.prisma.post.findUnique({
-+        where: { id: parent.id }
-+      }).author()
-+    },
-+    categories: (parent, args, context) => {
-+      return context.prisma.post.findUnique({
-+        where:  { id: parent.id }
-+      }).categories()
-+    }
-+  },
+  Post: {
+    author: (parent, args, context) => {
+      return context.prisma.post.findUnique({
+        where: { id: parent.id }
+      }).author()
+    },
+    categories: (parent, args, context) => {
+      return context.prisma.post.findUnique({
+        where:  { id: parent.id }
+      }).categories()
+    }
+  },
 }
 ```
 
@@ -976,7 +976,7 @@ Since you're not using `prisma-binding` any more, you now need to resolve this r
 
 You can do so by adding a `Profile` field to your _resolver map_ and implement the resolvers for the `owner` relation as follows:
 
-```js line-number
+```js line-number highlight=14-20;add
 const resolvers = {
   Query: {
     // ... your query resolvers
@@ -990,13 +990,13 @@ const resolvers = {
   Post: {
     // ... your type resolvers for `Post` from before
   },
-+  Profile: {
-+    user: (parent, args, context) => {
-+      return context.prisma.profile.findUnique({
-+        where: { id: parent.id }
-+      }).owner()
-+    }
-+  },
+  Profile: {
+    user: (parent, args, context) => {
+      return context.prisma.profile.findUnique({
+        where: { id: parent.id }
+      }).owner()
+    }
+  },
 }
 ```
 
@@ -1030,7 +1030,7 @@ Since you're not using `prisma-binding` any more, you now need to resolve this r
 
 You can do so by adding a `Category` field to your _resolver map_ and implement the resolvers for the `posts` and `profile` relations as follows:
 
-```js line-number
+```js line-number highlight=16-22;add
 const resolvers = {
   Query: {
     // ... your query resolvers
@@ -1047,13 +1047,13 @@ const resolvers = {
   Profile: {
     // ... your type resolvers for `User` from before
   },
-+  Category: {
-+    posts: (parent, args, context) => {
-+      return context.prisma.findUnique({
-+        where: { id: parent.id }
-+      }).posts()
-+    }
-+  },
+  Category: {
+    posts: (parent, args, context) => {
+      return context.prisma.findUnique({
+        where: { id: parent.id }
+      }).posts()
+    }
+  },
 }
 ```
 
@@ -1237,18 +1237,18 @@ const resolvers = {
 
 To get the same behavior with the new Prisma Client, you'll need to adjust your resolver implementation:
 
-```js line-number
+```js line-number highlight=3-11;normal
 const resolvers = {
   Query: {
-|    posts: (_, args, context) => {
-|      return context.prisma.post.findMany({
-|        where: {
-|          OR: [
-|            { title: { contains: args.searchString } },
-|            { content: { contains: args.searchString } },
-|          ],
-|        },
-|      })
+    posts: (_, args, context) => {
+      return context.prisma.post.findMany({
+        where: {
+          OR: [
+            { title: { contains: args.searchString } },
+            { content: { contains: args.searchString } },
+          ],
+        },
+      })
     },
     // ... other resolvers
   }
@@ -1310,14 +1310,14 @@ const resolvers = {
 
 To get the same behavior with the new Prisma Client, you'll need to adjust your resolver implementation:
 
-```js line-number
+```js line-number highlight=2-6;normal
 const resolvers = {
   Query: {
-|    user: (_, args, context) => {
-|      return context.prisma.user.findUnique({
-|        where: args.userUniqueInput,
-|      })
-|    }
+    user: (_, args, context) => {
+      return context.prisma.user.findUnique({
+        where: args.userUniqueInput,
+      })
+    }
     // ... other resolvers
   }
 }
@@ -1366,14 +1366,14 @@ const resolvers = {
 
 To get the same behavior with the new Prisma Client, you'll need to adjust your resolver implementation:
 
-```js line-number
+```js line-number highlight=3-7;normal
 const resolvers = {
   Mutation: {
-|    createUser: (_, args, context, info) => {
-|      return context.prisma.user.create({
-|        data: args.data
-|      })
-|    },
+    createUser: (_, args, context, info) => {
+      return context.prisma.user.create({
+        data: args.data
+      })
+    },
     // ... other resolvers
   }
 }
@@ -1432,22 +1432,22 @@ const resolvers = {
 
 To get the same behavior with the new Prisma Client, you'll need to adjust your resolver implementation:
 
-```js line-number
+```js line-number highlight=3-15;normal
 const resolvers = {
   Mutation: {
-|    createDraft: (_, args, context, info) => {
-|      return context.prisma.post.create({
-|        data: {
-|          title: args.title,
-|          content: args.content,
-|          author: {
-|            connect: {
-|              id: args.authorId,
-|            },
-|          },
-|        },
-|      })
-|    }
+    createDraft: (_, args, context, info) => {
+      return context.prisma.post.create({
+        data: {
+          title: args.title,
+          content: args.content,
+          author: {
+            connect: {
+              id: args.authorId,
+            },
+          },
+        },
+      })
+    }
     // ... other resolvers
   }
 }
@@ -1508,19 +1508,19 @@ const resolvers = {
 
 To get the same behavior with Prisma Client, you'll need to adjust your resolver implementation:
 
-```js line-number
+```js line-number highlight=3-12;normal
 const resolvers = {
   Mutation: {
-|    updateBio: (_, args, context, info) => {
-|      return context.prisma.user.update({
-|        data: {
-|          profile: {
-|            update: { bio: args.bio }
-|          }
-|        },
-|        where: args.userUniqueInput
-|      })
-|    },
+    updateBio: (_, args, context, info) => {
+      return context.prisma.user.update({
+        data: {
+          profile: {
+            update: { bio: args.bio }
+          }
+        },
+        where: args.userUniqueInput
+      })
+    },
     // ... other resolvers
   }
 }
@@ -1584,20 +1584,20 @@ const resolvers = {
 
 To get the same behavior with Prisma Client, you'll need to adjust your resolver implementation:
 
-```js line-number
+```js line-number highlight=3-13;normal
 const resolvers = {
   Mutation: {
-|    addPostToCategories: (_, args, context, info) => {
-|      const ids = args.categoryIds.map(id => ({ id }))
-|      return context.prisma.post.update({
-|        where: {
-|          id: args.postId
-|        },
-|        data: {
-|          categories: { connect: ids }
-|        }
-|      })
-|    },
+    addPostToCategories: (_, args, context, info) => {
+      const ids = args.categoryIds.map(id => ({ id }))
+      return context.prisma.post.update({
+        where: {
+          id: args.postId
+        },
+        data: {
+          categories: { connect: ids }
+        }
+      })
+    },
     // ... other resolvers
   }
 }


### PR DESCRIPTION
Usage of inline diff tokens in code blocks breaks prettier formatting #1985.