### PR TITLE
Removes `scroll-smooth` from `Layout`

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -114,12 +114,6 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
   const { site } = useLayoutQuery()
   const { header, footer } = site.siteMetadata
 
-  React.useEffect(() => {
-    if (typeof window !== undefined) {
-      require('smooth-scroll')('a[href*="#"]')
-    }
-  }, [])
-
   return (
     <ThemeProvider theme={theme}>
       <LensProvider>


### PR DESCRIPTION
A [recent change](https://github.com/prisma/docs/commit/9f8d8d0ba79c28263cae7ce49d324d5aca466923#diff-0b75a532e530ce749a966d77dffeea3593e67560e5894213143637ee1d84aef5R119) added "smooth" scrolling to hash anchor links. If the section is far from the current scroll position, the transition is very slow. For example, this is very noticeable in the [schema reference page](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference).

To reproduce it, go to https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference and click on `enum` in the ToC on the right side. Also, here's a demo: https://www.loom.com/share/22946890eaaa4f7fb392d351e2e92247

This PR removes this behavior and fixes https://github.com/prisma/docs/issues/1996.