### PR TITLE
fix: 🐛 scroll speed

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -116,7 +116,7 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
 
   React.useEffect(() => {
     if (typeof window !== undefined) {
-      require('smooth-scroll')('a[href*="#"]')
+      require('smooth-scroll')('a[href*="#"]', { speed: 1000, speedAsDuration: true })
     }
   }, [])
 


### PR DESCRIPTION
This is a little fix to remove the long smooth scroll on certain pages in the docs.