### PR TITLE
namedConstraints: Remove that map can be an unnamed argument name for `@id` and `@unique`

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -980,7 +980,7 @@ Attributes modify the behavior of a [field](#model-fields) or block (e.g. [model
 - _Field_ attributes are prefixed with `@`
 - _Block_ attributes are prefixed with `@@`
 
-Some attributes take arguments. Arguments in attributes are always named, but in most cases the argument _name_ can be omitted.
+Some attributes take arguments. Arguments in attributes are always named, but in some cases one of the argument's _name_ can be omitted.
 
 > **Note**: The leading underscore in a signature means the _argument name_ can be omitted.
 
@@ -1041,7 +1041,7 @@ Defines a single-field ID on the model.
 #### Signature
 
 ```prisma no-lines
-@id(_ map: String)
+@id(map: String)
 ```
 
 #### Examples
@@ -1840,7 +1840,7 @@ Defines a unique constraint for this field.
 #### Signature
 
 ```ts no-lines
-@unique(_ map: String?)
+@unique(map: String?)
 ```
 
 #### Examples


### PR DESCRIPTION
and explain the unnamed argument names a bit better while I am at it - I hope.

Decision made in https://prisma-company.slack.com/archives/C024SCGH291/p1625677909006700, implementation will be adapted