### PR TITLE
Replace incorrect date format

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1689,7 +1689,7 @@ model User {
 ```prisma
 model User {
   id    String  @default(dbgenerated()) @db.ObjectId @map("_id")
-  data  DateTime  @default("2021-07-15T05:29:43.410Z")
+  data  DateTime  @default("2020-03-19T14:21:00+02:00")
 }
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1671,7 +1671,7 @@ model User {
 
 ##### Default value for a `DateTime`
 
-Note that static default values for `DateTime` are based on the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. However, they must always include the time including the [time offsets from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC).
+Note that static default values for `DateTime` are based on the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>
@@ -1679,7 +1679,7 @@ Note that static default values for `DateTime` are based on the [ISO 8601](https
 ```prisma
 model User {
   email  String    @unique
-  data   DateTime  @default("2020-03-19T14:21:00+0200")
+  data   DateTime  @default("2021-07-15T05:29:43.410Z")
 }
 ```
 
@@ -1689,7 +1689,7 @@ model User {
 ```prisma
 model User {
   id    String  @default(dbgenerated()) @db.ObjectId @map("_id")
-  data  DateTime  @default("2020-03-19T14:21:00+0200")
+  data  DateTime  @default("2021-07-15T05:29:43.410Z")
 }
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1679,7 +1679,7 @@ Note that static default values for `DateTime` are based on the [ISO 8601](https
 ```prisma
 model User {
   email  String    @unique
-  data   DateTime  @default("2021-07-15T05:29:43.410Z")
+  data   DateTime  @default("2020-03-19T14:21:00+02:00")
 }
 ```
 


### PR DESCRIPTION
The format in the docs was incorrect as only ISO Strings are accepted.