### PR TITLE
Add missing --schema argument to `migrate dev` command

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -732,9 +732,10 @@ The `migrate dev` command updates your database using migrations during developm
 
 #### Arguments
 
-| Argument | Required | Description                                                                 | Default |
-| :------- | :------- | :-------------------------------------------------------------------------- | :------ |
-| `--name` | No       | The name of the migration. If no name is provided, the CLI will prompt you. |         |
+| Argument   | Required | Description                                                                                                                                       | Default                                          |
+| :--------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------- |
+| `--name`   | No       | The name of the migration. If no name is provided, the CLI will prompt you.                                                                       |                                                  |
+| `--schema` | No       | Specifies the path to the desired schema.prisma file to be processed instead of the default path. Both absolute and relative paths are supported. | `./schema.prisma`<br /> `./prisma/schema.prisma` |
 
 #### Examples
 


### PR DESCRIPTION
Hi !
I noticed that the `--schema` argument was missing from the `migrate dev` command reference, but was present for every other `migrate *` commands.

However, it's a supported option (as documented [here in source code](https://github.com/prisma/prisma/blob/master/src/packages/migrate/src/commands/MigrateDev.ts#L62)).

This PR adds this missing argument, using the same text as the other commands.

