### PR TITLE
fix(prisma-client-reference): Specify atomic number operations behavior on null values

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4228,6 +4228,7 @@ export type IntFieldUpdateOperationsInput = {
 ### Remarks
 
 - You can only perform **one** atomic update per field, per query.
+- If a field is `null`, it will not be updated by `increment`, `decrement`, `multiply`, or `divide`.
 
 ### Examples
 


### PR DESCRIPTION
Clarify behaviour of null values with atomic number operations