### PR TITLE
Update testing docs to use MockDeepProxy interface instead of MockProxy interface

### DIFF
--- a/content/300-guides/150-testing/100-unit-testing.mdx
+++ b/content/300-guides/150-testing/100-unit-testing.mdx
@@ -84,7 +84,7 @@ The following steps guide you through mocking the Prisma Client using a singleto
 
    ```ts file=singleton.ts
    import { PrismaClient } from '@prisma/client'
-   import { mockDeep, mockReset, MockProxy } from 'jest-mock-extended'
+   import { mockDeep, mockReset, MockDeepProxy } from 'jest-mock-extended'
 
    import prisma from './client'
 
@@ -97,7 +97,7 @@ The following steps guide you through mocking the Prisma Client using a singleto
      mockReset(prismaMock)
    })
 
-   export const prismaMock = prisma as unknown as MockProxy<PrismaClient>
+   export const prismaMock = prisma as unknown as MockDeepProxy<PrismaClient>
    ```
 
 The singleton file tells Jest to mock a default export (the Prisma client instantiated in `./client.ts`), and uses the `mockDeep` method from `jest-mock-extended` to enable access to the objects and methods available on the Prisma client. It then resets the mocked instance before each test is run.
@@ -110,14 +110,14 @@ Another popular pattern that can be used is dependency injection.
 
    ```ts file=context.ts
    import { PrismaClient } from '@prisma/client'
-   import { MockProxy, mockDeep } from 'jest-mock-extended'
+   import { MockDeepProxy, mockDeep } from 'jest-mock-extended'
 
    export type Context = {
      prisma: PrismaClient
    }
 
    export type MockContext = {
-     prisma: MockProxy<PrismaClient>
+     prisma: MockDeepProxy<PrismaClient>
    }
 
    export const createMockContext = (): MockContext => {

--- a/content/300-guides/150-testing/100-unit-testing.mdx
+++ b/content/300-guides/150-testing/100-unit-testing.mdx
@@ -85,7 +85,7 @@ The following steps guide you through mocking the Prisma Client using a singleto
    ```ts file=singleton.ts
    import { PrismaClient } from '@prisma/client'
    import { mockDeep, mockReset } from 'jest-mock-extended'
-   import { DeepMockProxy } from "jest-mock-extended/lib/Mock";
+   import { DeepMockProxy } from 'jest-mock-extended/lib/Mock';
 
    import prisma from './client'
 

--- a/content/300-guides/150-testing/100-unit-testing.mdx
+++ b/content/300-guides/150-testing/100-unit-testing.mdx
@@ -84,7 +84,8 @@ The following steps guide you through mocking the Prisma Client using a singleto
 
    ```ts file=singleton.ts
    import { PrismaClient } from '@prisma/client'
-   import { mockDeep, mockReset, MockDeepProxy } from 'jest-mock-extended'
+   import { mockDeep, mockReset } from 'jest-mock-extended'
+   import { DeepMockProxy } from "jest-mock-extended/lib/Mock";
 
    import prisma from './client'
 


### PR DESCRIPTION
I had type errors when using the example docs for testing. These updates made the type errors go away.

If there are additional things I need to take care of for an official PR let me know.

Thanks for all your hard work!