### PR TITLE
Update About section with release notes

### DIFF
--- a/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
@@ -7,7 +7,7 @@ metaDescription: Prisma Client features that are currently in preview.
 
 The following [Preview](../../../../about/releases#preview) feature flags are available for Prisma Client and the Prisma schema:
 
-- [`orderByRelations`](../prisma-client/filtering-and-sorting#sort-by-relation-aggregate-value-preview) [Submit feedback](https://github.com/prisma/prisma/issues/5438)
+- [`orderByRelation`](../prisma-client/filtering-and-sorting#sort-by-relation-aggregate-value-preview) [Submit feedback](https://github.com/prisma/prisma/issues/5438)
 - [`selectRelationCount`](../prisma-client/aggregation-grouping-summarizing#count-relations) [Submit feedback](https://github.com/prisma/prisma/issues/6312)
 - [`orderByAggregateGroup`](../prisma-client/aggregation-grouping-summarizing#order-by-aggregate-group-preview) [Submit feedback](https://github.com/prisma/prisma/issues/6545)
 - [`referentialActions`](../prisma-schema/relations/referential-actions)

--- a/content/600-about/08-releases.mdx
+++ b/content/600-about/08-releases.mdx
@@ -14,6 +14,8 @@ This page explains the release process of Prisma, how it's versioned and how to 
 
 Prisma releases typically happen every two weeks. Note that this is _not_ a hard rule – releases might be postponed for internal reasons.
 
+[Check out all the releases notes in GitHub](https://github.com/prisma/prisma/releases).
+
 ## Product maturity levels
 
 A release can include products or features at different maturity levels. Maturity level describes a product or feature's completeness and what users can expect in terms of breaking changes.


### PR DESCRIPTION
Updates:
* Adding link to release notes in the Releases and maturity levels description
* Fixing a typo in a feature flag's name