### PR TITLE
Made MongoDB authorId optional

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -190,7 +190,7 @@ model User {
 model Post {
   id        String  @id @default(dbgenerated()) @db.ObjectId @map("_id")
   author    User?   @relation(fields: [authorId], references: [id])
-  authorId  String  @db.ObjectId
+  authorId  String?  @db.ObjectId
 ```
 
 </tab>


### PR DESCRIPTION
Fixes a bug in one of the examples where the authorId should be optional and was not.