### PR TITLE
Restructure `namedConstraints` preview feature guide page

### DIFF
--- a/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
+++ b/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Enabling `namedConstriaints` preview feature'
-metaTitle: 'Enabling `namedConstriaints` preview feature'
+title: 'Enabling `namedConstraints` preview feature'
+metaTitle: 'Enabling `namedConstraints` preview feature'
 metaDescription: 'How to use the Preview feature `namedConstraints`.'
 ---
 
@@ -8,7 +8,7 @@ metaDescription: 'How to use the Preview feature `namedConstraints`.'
 
 This page describes manual upgrade steps that you need to perform after upgrading to Prisma 2.29.0 (or newer) and you want to use the `namedConstraints` Preview feature.
 
-After you choose to enable the `namedConstraints` Preview feature, choose a workflow (Prisma Migrate or Introspection) and upgrade path that suits your requirements:
+After you enable the `namedConstraints` Preview feature, choose a workflow (Prisma Migrate or Introspection) and upgrade path that suits your requirements:
     
 </TopBlock>
 

--- a/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
+++ b/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Enabling the `namedConstraints` preview feature'
+title: 'Enabling `namedConstraints`'
 metaTitle: 'Enabling the `namedConstraints` preview feature'
 metaDescription: 'How to use the Preview feature `namedConstraints`.'
 ---

--- a/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
+++ b/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Enabling `namedConstraints` preview feature'
-metaTitle: 'Enabling `namedConstraints` preview feature'
+title: 'Enabling the `namedConstraints` preview feature'
+metaTitle: 'Enabling the `namedConstraints` preview feature'
 metaDescription: 'How to use the Preview feature `namedConstraints`.'
 ---
 

--- a/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
+++ b/content/300-guides/300-upgrade-guides/300-upgrading-to-use-preview-features/050-enabling-named-constraints.mdx
@@ -1,20 +1,18 @@
 ---
-title: 'Enabling named constraints'
-metaTitle: 'Enabling named constraints'
-metaDescription: 'How to use the Preview feature named constraints.'
+title: 'Enabling `namedConstriaints` preview feature'
+metaTitle: 'Enabling `namedConstriaints` preview feature'
+metaDescription: 'How to use the Preview feature `namedConstraints`.'
 ---
 
 <TopBlock>
 
-This page describes manual upgrade steps that you need to perform after upgrading to Prisma 2.29.0 if you want to use the `namedConstraints` Preview feature.
+This page describes manual upgrade steps that you need to perform after upgrading to Prisma 2.29.0 (or newer) and you want to use the `namedConstraints` Preview feature.
 
+After you choose to enable the `namedConstraints` Preview feature, choose a workflow (Prisma Migrate or Introspection) and upgrade path that suits your requirements:
+    
 </TopBlock>
 
-## Optional: Enable the <inlinecode>namedConstraints</inlinecode> Preview feature
-
-If you choose to enable the `namedConstraints` Preview feature, choose a workflow (Prisma Migrate or Introspection) and upgrade path that suits your requirements:
-
-### Upgrade paths for Prisma Migrate users
+## Upgrade paths for Prisma Migrate users
 
 Use the following guide if your project uses Prisma Migrate. Choose the upgrade path that matches your requirements:
 
@@ -23,7 +21,7 @@ Use the following guide if your project uses Prisma Migrate. Choose the upgrade 
 
 <!-- TODO Step 0 make sure all your environments are using the same constraint names  -->
 
-#### Upgrade path 1: I want to maintain my existing constraint and index names
+### Upgrade path 1: I want to maintain my existing constraint and index names
 
 1.  Enable the `namedConstraints` Preview:
 
@@ -146,7 +144,7 @@ Use the following guide if your project uses Prisma Migrate. Choose the upgrade 
     npx prisma migrate deploy
     ```
 
-#### Upgrade path 2: I want to use Prismas default constraint and index names
+### Upgrade path 2: I want to use Prismas default constraint and index names
 
 1. Enable the `namedConstraints` Preview:
 
@@ -165,7 +163,7 @@ Use the following guide if your project uses Prisma Migrate. Choose the upgrade 
 
    This migration renames any constraints that do not currently follow Prisma's naming convention.
 
-### Upgrade path for introspection only users
+## Upgrade path for introspection only users
 
 Use the following guide if you use introspection only.
 


### PR DESCRIPTION
This PR restructures the preview feature guide page a bit.

Preview: https://deploy-preview-2112--prisma2-docs.netlify.app/docs/guides/upgrade-guides/upgrading-to-use-preview-features/enabling-named-constraints