### PR TITLE
fix(error-reference): Add structure

### DIFF
--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -13,7 +13,7 @@ This page describes Prisma exceptions and error codes. For more information abou
 
 ## Prisma Client error types
 
-Prisma Client throws different kinds of errors, that can have the following exception types with the documented data fields for information:
+Prisma Client throws different kinds of errors. The following lists the exception types, and their documented data fields:
 
 ### <inlinecode>PrismaClientKnownRequestError</inlinecode>
 

--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -11,7 +11,11 @@ This page describes Prisma exceptions and error codes. For more information abou
 
 </TopBlock>
 
-## <inlinecode>PrismaClientKnownRequestError</inlinecode>
+## Prisma Client error types
+
+Prisma Client throws different kinds of errors, that can have the following exception types with the documented data fields for information:
+
+### <inlinecode>PrismaClientKnownRequestError</inlinecode>
 
 Prisma Client throws a `PrismaClientKnownRequestError` exception if the query engine returns a known error related to the request - for example, a unique constraint violation.
 
@@ -22,7 +26,7 @@ Prisma Client throws a `PrismaClientKnownRequestError` exception if the query en
 | `message`       | Error message associated with [error code](#error-codes).                                                        |
 | `clientVersion` | Version of Prisma Client (for example, `2.19.0`)                                                                 |
 
-## <inlinecode>PrismaClientUnknownRequestError</inlinecode>
+### <inlinecode>PrismaClientUnknownRequestError</inlinecode>
 
 Prisma Client throws a `PrismaClientUnknownRequestError` exception if the query engine returns an error related to a request that does not have an error code.
 
@@ -31,7 +35,7 @@ Prisma Client throws a `PrismaClientUnknownRequestError` exception if the query 
 | `message`       | Error message associated with [error code](#error-codes). |
 | `clientVersion` | Version of Prisma Client (for example, `2.19.0`)          |
 
-## <inlinecode>PrismaClientRustPanicError</inlinecode>
+### <inlinecode>PrismaClientRustPanicError</inlinecode>
 
 Prisma Client throws a `PrismaClientRustPanicError` exception if the underlying engine crashes and exits with a non-zero exit code. In this case, the Prisma Client or the whole Node process must be restarted.
 
@@ -40,7 +44,7 @@ Prisma Client throws a `PrismaClientRustPanicError` exception if the underlying 
 | `message`       | Error message associated with [error code](#error-codes). |
 | `clientVersion` | Version of Prisma Client (for example, `2.19.0`)          |
 
-## <inlinecode>PrismaClientInitializationError</inlinecode>
+### <inlinecode>PrismaClientInitializationError</inlinecode>
 
 Prisma Client throws a `PrismaClientInitializationError` exception if something goes wrong when the query engine is started and the connection to the database is created. This happens either:
 
@@ -61,7 +65,7 @@ Errors that can occur include:
 | `message`       | Error message associated with error code.        |
 | `clientVersion` | Version of Prisma Client (for example, `2.19.0`) |
 
-## <inlinecode>PrismaClientValidationError</inlinecode>
+### <inlinecode>PrismaClientValidationError</inlinecode>
 
 Prisma Client throws a `PrismaClientValidationError` exception if validation fails - for example:
 


### PR DESCRIPTION
A suggestion for a bit more headline structure on the error reference page