### PR TITLE
Added mobile breakpoint to fix alignment

### DIFF
--- a/src/components/customMdx/navigationLinksContainer.tsx
+++ b/src/components/customMdx/navigationLinksContainer.tsx
@@ -13,6 +13,14 @@ const ButtonContainer = styled.section<Props>`
   border-top: solid 2px ${(p) => p.theme.colors.gray100};
   padding-top: 2rem;
   margin: 2rem 0;
+
+  @media (max-width: 992px) {
+		flex-direction: column;
+
+     & > a {
+      margin-bottom: 1.5rem;
+      }
+	}
 `
 
 const NavigationLinksContainer: React.FC<Props> = ({ children, isFirstLink }) => {


### PR DESCRIPTION
This PR adds a breakpoint to put the navigation buttons in the getting started guide onto a new line, instead of staying on the horizontal axis