### PR TITLE
Remove mention of TLS workaround

### DIFF
--- a/content/200-concepts/100-components/250-preview-features/100-sql-server/001-sql-server-start-from-scratch.mdx
+++ b/content/200-concepts/100-components/250-preview-features/100-sql-server/001-sql-server-start-from-scratch.mdx
@@ -160,8 +160,6 @@ To connect to your Microsoft SQL Server database:
    DATABASE_URL="sqlserver://localhost:1433;database=mydb;user=sa;password=r@ndomP@$$w0rd;trustServerCertificate=true"
    ```
 
-   > To get around TLS issues, add `encrypt=DANGER_PLAINTEXT` (**[not required in 2.15.0 and later](https://github.com/prisma/tiberius/issues/65)** if you are connecting to Microsoft SQL Server from MacOS specifically.
-
 1. Adjust the connection URL to match your setup - see [Microsoft SQL Server connection URL](sql-server-connection-string) for more information.
 
    > Make sure TCP/IP connections are enabled via [SQL Server Configuration Manager](https://docs.microsoft.com/en-us/sql/relational-databases/sql-server-configuration-manager) to avoid `No connection could be made because the target machine actively refused it. (os error 10061)`


### PR DESCRIPTION
There was a remaining note about `DANGER_PLAINTEXT` in the getting started from scratch guide.