### PR TITLE
Update 400-nextjs-prisma-client-dev-practices.mdx

### DIFF
--- a/content/500-support/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/500-support/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -23,13 +23,14 @@ The solution in this case is to instantiate a single instance `PrismaClient` and
 ```ts file=./db
 import { PrismaClient } from '@prisma/client'
 
+declare global {
+  var prisma: PrismaClient | undefined
+}
+
 // Prevent multiple instances of Prisma Client in development
-declare const global: typeof globalThis & { prisma?: PrismaClient }
-
-const prisma = global.prisma || new PrismaClient()
-if (process.env.NODE_ENV === 'development') global.prisma = prisma
-
-export default prisma
+if (process.env.NODE_ENV === 'development' && !globalThis.prisma) {
+  globalThis.prisma = new PrismaClient()
+}
 ```
 
 After creating this file, you can now import this `PrismaClient` instance anywhere in your Next.js `pages` as follows:

--- a/content/500-support/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/500-support/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -24,7 +24,7 @@ The solution in this case is to instantiate a single instance `PrismaClient` and
 import { PrismaClient } from '@prisma/client'
 
 // Prevent multiple instances of Prisma Client in development
-declare const global: NodeJS.Global & { prisma?: PrismaClient }
+declare const global: typeof globalThis & { prisma?: PrismaClient }
 
 const prisma = global.prisma || new PrismaClient()
 if (process.env.NODE_ENV === 'development') global.prisma = prisma


### PR DESCRIPTION
Hello! I ran into a little error when following the docs for instantiating a Prisma Client in a Next.js app using Typescript. It isn't a bug within Prisma itself, but rather a typing issue of the global object in Node. 

I'm pretty sure ```Global``` type on ```NodeJs.Global``` was removed in @node/types 16.0.0. Getting a "Namespace 'NodeJS' has no exported member 'Global'" error. Replacing it with ```typeof globalThis``` does the trick.

Perhaps this is just due to the version of @types/node that next.js installs automatically, but here are the current versions I'm running:
```
Node - 16.0.0
Next.js -  11.1.0
@prisma/client - 2.29.1
prisma: 2.29.1
```
