### PR TITLE
Prisma Schema reference: Update attributes signatures for `namedConstraints` (and `referentialActions`)

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2357,7 +2357,7 @@ The name of the `name` argument on the `@relation` attribute can be omitted (`re
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?)
 ```
 
-Starting with 2.28 if the `referentialActions` preview flag is enabled the signature changes.
+As of 2.28.0, if the `referentialActions` preview flag is enabled the signature changes.
 
 ```ts no-lines
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1313,7 +1313,7 @@ The name of the `fields` argument on the `@@id` attribute can be omitted:
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @@id(_ fields: FieldReference[])
 ```
 
@@ -1524,7 +1524,7 @@ id Int @id @default(autoincrement())
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @default(_ value: Expression)
 ```
 
@@ -2006,7 +2006,7 @@ The name of the `fields` argument on the `@@unique` attribute can be omitted:
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @@unique(_ fields: FieldReference[], name: String?)
 ```
 
@@ -2241,13 +2241,13 @@ The _name_ of the `fields` argument on the `@@index` attribute can be omitted:
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @@index(_ fields: FieldReference[], name: String?)
 ```
 
-As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes. 
+As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes.
 
->**Note**: The old `name` argument will still be accepted to avoid a breaking change.
+> **Note**: The old `name` argument will still be accepted to avoid a breaking change.
 
 ```prisma no-lines
 @@index(_ fields: FieldReference[], map: String?)
@@ -2353,7 +2353,7 @@ The name of the `name` argument on the `@relation` attribute can be omitted (`re
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?)
 ```
 
@@ -2411,7 +2411,7 @@ The name of the `name` argument on the `@map` attribute can be omitted:
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @map(_ name: String)
 ```
 
@@ -2487,7 +2487,7 @@ The name of the `name` argument on the `@@map` attribute can be omitted
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @@map(_ name: String)
 ```
 
@@ -2557,7 +2557,7 @@ N/A
 
 #### Signature
 
-```ts no-lines
+```prisma no-lines
 @updatedAt
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1819,7 +1819,7 @@ N/A
 @unique
 ```
 
-Starting with 2.29 if you have the `namedConstraints` preview flag enabled the signature changes.
+As of 2.29.0, if you have the `namedConstraints` preview flag enabled the signature changes.
 
 ```no-lines
 @unique(map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2245,7 +2245,9 @@ The _name_ of the `fields` argument on the `@@index` attribute can be omitted:
 @@index(_ fields: FieldReference[], name: String?)
 ```
 
-Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes. The old name argument will still be accepted though to prevent a breaking change.
+As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes. 
+
+>**Note**: The old `name` argument will still be accepted to prevent a breaking change.
 
 ```ts no-lines
 @@index(_ fields: FieldReference[], map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1040,7 +1040,7 @@ N/A
 @id
 ```
 
-Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes:
+As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes:
 
 ```ts no-lines
 @@id(map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1043,7 +1043,7 @@ N/A
 As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes:
 
 ```ts no-lines
-@@id(map: String?)
+@id(map: String?)
 ```
 
 #### Examples

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1317,7 +1317,7 @@ The name of the `fields` argument on the `@@id` attribute can be omitted:
 @@id(_ fields: FieldReference[])
 ```
 
-Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes:
+As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes:
 
 ```ts no-lines
 @@id(_ fields: FieldReference[], name: String?, map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2012,7 +2012,7 @@ The name of the `fields` argument on the `@@unique` attribute can be omitted:
 
 As of 2.29.0, if you have the `namedConstraints` preview flag enabled the signature changes.
 
-```no-lines
+```prisma no-lines
 @@unique(_ fields: FieldReference[], name: String?, map: String?)
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2363,7 +2363,7 @@ As of 2.28.0, if the `referentialActions` preview flag is enabled the signature 
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)
 ```
 
-Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes again unless you are using Sqlite.
+As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes again unless you are using SQLite.
 
 ```ts no-lines
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1040,6 +1040,12 @@ N/A
 @id
 ```
 
+Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes:
+
+```ts no-lines
+@@id(map: String?)
+```
+
 #### Examples
 
 In most cases, you want your database to create the ID. To do this, annotate the ID field with the `@default` attribute and initialize the field with a [function](#attribute-functions).
@@ -1311,6 +1317,12 @@ The name of the `fields` argument on the `@@id` attribute can be omitted:
 @@id(_ fields: FieldReference[])
 ```
 
+Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes:
+
+```ts no-lines
+@@id(_ fields: FieldReference[], name: String?, map: String?)
+```
+
 ##### Specify a multi-field ID on two `String` fields
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases only" icon="database"/>]}>
@@ -1514,6 +1526,12 @@ id Int @id @default(autoincrement())
 
 ```ts no-lines
 @default(_ value: Expression)
+```
+
+Starting with 2.30 if the `namedConstraints` preview flag is enabled the signature changes if you are using SqlServer. This database supports named defaults:
+
+```ts no-lines
+@default(_ value: Expression, map: String?)
 ```
 
 #### Examples
@@ -1801,6 +1819,12 @@ N/A
 @unique
 ```
 
+Starting with 2.29 if you have the `namedConstraints` preview flag enabled the signature changes.
+
+```no-lines
+@unique(map: String?)
+```
+
 #### Examples
 
 ##### Specify a unique attribute on a required `String` field
@@ -1984,6 +2008,12 @@ The name of the `fields` argument on the `@@unique` attribute can be omitted:
 
 ```ts no-lines
 @@unique(_ fields: FieldReference[], name: String?)
+```
+
+Starting with 2.29 if you have the `namedConstraints` preview flag enabled the signature changes.
+
+```no-lines
+@@unique(_ fields: FieldReference[], name: String?, map: String?)
 ```
 
 #### Examples
@@ -2215,6 +2245,12 @@ The _name_ of the `fields` argument on the `@@index` attribute can be omitted:
 @@index(_ fields: FieldReference[], name: String?)
 ```
 
+Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes. The old name argument will still be accepted though to prevent a breaking change.
+
+```ts no-lines
+@@index(_ fields: FieldReference[], map: String?)
+```
+
 #### Examples
 
 Assume you want to add an index for the `title` field of the `Post` model
@@ -2317,6 +2353,18 @@ The name of the `name` argument on the `@relation` attribute can be omitted (`re
 
 ```ts no-lines
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?)
+```
+
+Starting with 2.28 if the `referentialActions` preview flag is enabled the signature changes.
+
+```ts no-lines
+@relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)
+```
+
+Starting with 2.29 if the `namedConstraints` preview flag is enabled the signature changes again unless you are using Sqlite.
+
+```ts no-lines
+@relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)
 ```
 
 #### Examples

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1821,7 +1821,7 @@ N/A
 
 As of 2.29.0, if you have the `namedConstraints` preview flag enabled the signature changes.
 
-```no-lines
+```prisma no-lines
 @unique(map: String?)
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1530,7 +1530,7 @@ id Int @id @default(autoincrement())
 
 As of 2.30.0, if the `namedConstraints` preview flag is enabled the signature changes if you are using Microsoft Sql Server. This database supports named defaults:
 
-```ts no-lines
+```prisma no-lines
 @default(_ value: Expression, map: String?)
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2360,7 +2360,7 @@ The name of the `name` argument on the `@relation` attribute can be omitted (`re
 As of 2.28.0, if the `referentialActions` preview flag is enabled the signature changes.
 
 ```ts no-lines
-@relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)
+@relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?)
 ```
 
 As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes again unless you are using SQLite.

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2359,7 +2359,7 @@ The name of the `name` argument on the `@relation` attribute can be omitted (`re
 
 As of 2.28.0, if the `referentialActions` preview flag is enabled the signature changes.
 
-```ts no-lines
+```prisma no-lines
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?)
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1042,7 +1042,7 @@ N/A
 
 As of 2.29.0, if the `namedConstraints` preview feature flag is enabled the signature changes to:
 
-```ts no-lines
+```prisma no-lines
 @id(map: String?)
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2010,7 +2010,7 @@ The name of the `fields` argument on the `@@unique` attribute can be omitted:
 @@unique(_ fields: FieldReference[], name: String?)
 ```
 
-Starting with 2.29 if you have the `namedConstraints` preview flag enabled the signature changes.
+As of 2.29.0, if you have the `namedConstraints` preview flag enabled the signature changes.
 
 ```no-lines
 @@unique(_ fields: FieldReference[], name: String?, map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2247,7 +2247,7 @@ The _name_ of the `fields` argument on the `@@index` attribute can be omitted:
 
 As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes. 
 
->**Note**: The old `name` argument will still be accepted to prevent a breaking change.
+>**Note**: The old `name` argument will still be accepted to avoid a breaking change.
 
 ```ts no-lines
 @@index(_ fields: FieldReference[], map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1528,7 +1528,7 @@ id Int @id @default(autoincrement())
 @default(_ value: Expression)
 ```
 
-Starting with 2.30 if the `namedConstraints` preview flag is enabled the signature changes if you are using SqlServer. This database supports named defaults:
+As of 2.30.0, if the `namedConstraints` preview flag is enabled the signature changes if you are using Microsoft Sql Server. This database supports named defaults:
 
 ```ts no-lines
 @default(_ value: Expression, map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2363,7 +2363,7 @@ As of 2.28.0, if the `referentialActions` preview flag is enabled the signature 
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?)
 ```
 
-As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes again unless you are using SQLite.
+As of 2.29.0, if the `namedConstraints` and `referentialActions` preview flags are enabled the signature changes again (unless you are using SQLite).
 
 ```ts no-lines
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2249,7 +2249,7 @@ As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature ch
 
 >**Note**: The old `name` argument will still be accepted to avoid a breaking change.
 
-```ts no-lines
+```prisma no-lines
 @@index(_ fields: FieldReference[], map: String?)
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1040,7 +1040,7 @@ N/A
 @id
 ```
 
-As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes:
+As of 2.29.0, if the `namedConstraints` preview feature flag is enabled the signature changes to:
 
 ```ts no-lines
 @id(map: String?)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1319,7 +1319,7 @@ The name of the `fields` argument on the `@@id` attribute can be omitted:
 
 As of 2.29.0, if the `namedConstraints` preview flag is enabled the signature changes:
 
-```ts no-lines
+```prisma no-lines
 @@id(_ fields: FieldReference[], name: String?, map: String?)
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2365,7 +2365,7 @@ As of 2.28.0, if the `referentialActions` preview flag is enabled the signature 
 
 As of 2.29.0, if the `namedConstraints` and `referentialActions` preview flags are enabled the signature changes again (unless you are using SQLite).
 
-```ts no-lines
+```prisma no-lines
 @relation(_ name: String?, fields: FieldReference[]?, references: FieldReference[]?, onDelete: ReferentialAction?, onUpdate: ReferentialAction?, map: String?)
 ```
 


### PR DESCRIPTION
Fixes https://github.com/prisma/docs/issues/2120