### PR TITLE
Comparison/Mongoose Fetching Relations Type Fix

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/03-prisma-and-mongoose.mdx
+++ b/content/200-concepts/300-more/400-comparisons/03-prisma-and-mongoose.mdx
@@ -86,7 +86,7 @@ const posts = await prisma.user
 **Mongoose**
 
 ```ts
-const userWithPosts = await User.findById(id).populate('posts')
+const userWithPosts = await User.findById(id).populate('post')
 ```
 
 ## Filtering for concrete values


### PR DESCRIPTION
![CleanShot 2021-08-19 at 17 44 34@2x](https://user-images.githubusercontent.com/1702215/130089487-afdfd88d-3d52-4dcd-88b8-784b3e0d3f60.png)
In the docs, the example has a field called `post` but in the equivalent code for mongoose, it's displaying with plurals `posts` which can be very misleading for some people, it should be `post` not `posts`