### PR TITLE
Fix docs typo: ```build-vercel``` should be ```vercel-build```

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/300-deploying-to-vercel.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/300-deploying-to-vercel.mdx
@@ -110,7 +110,7 @@ Generating the Prisma Client in `vercel-build` ensures that the generated Prisma
 
 ### Database migrations and deployments
 
-In the example you deployed, migrations are applied using the `prisma migrate deploy` command during the Vercel build (as defined in the `build-vercel` script in `package.json`).
+In the example you deployed, migrations are applied using the `prisma migrate deploy` command during the Vercel build (as defined in the `vercel-build` script in `package.json`).
 
 Vercel has two environments: _preview_ and _production_, where preview deployments are for pull requests and production is for the `main` branch. It's important to keep this distinction in mind in relation to the database.
 


### PR DESCRIPTION
```vercel-build``` is correctly referenced in other areas of the doc - just not this line. 