### PR TITLE
Patch typeorm uses mssql

### DIFF
--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -398,7 +398,7 @@ Assume you have the following database connection details in `ormconfig.json`:
 
 ```json file=ormconfig.json
 {
-  "type": "sql-server",
+  "type": "mssql",
   "host": "localhost",
   "port": 1433,
   "username": "alice",


### PR DESCRIPTION
Thanks to @janpio I noticed the change from mssql to sql-server was wrong since it was in the TypeORM config file which is `mssql` indeed (cf. https://github.com/typeorm/typeorm/blob/master/docs/connection-options.md#common-connection-options)