### PR TITLE
Fix section heading level

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/400-self-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/400-self-relations.mdx
@@ -225,7 +225,7 @@ This relation expresses the following:
 
 Note that you can also require each user to have a teacher by making the `teacher` field [required](../data-model#optional-and-mandatory-fields).
 
-### One-to-many self-relations in the database
+## One-to-many self-relations in the database
 
 ### Relational databases
 
@@ -312,7 +312,7 @@ This relation expresses the following:
 
 Note that this n-n-relation is [implicit](many-to-many-relations#implicit-many-to-many-relations). This means Prisma maintains a [relation table](../relations/many-to-many-relations#relation-tables) for it in the underlying database:
 
-### Many-to-many self-relations in the database
+## Many-to-many self-relations in the database
 
 ### Relational databases
 


### PR DESCRIPTION
The heading level was previously wrong, making it look like certain subsections were empty.


Wrong: 

![wrong](https://user-images.githubusercontent.com/29299547/130652594-6d162cb5-c334-434a-a052-a8d1ddfe7305.png)

Correct: 

![correct](https://user-images.githubusercontent.com/29299547/130652544-a08b2579-906a-4718-965e-506a42e045a1.jpg)
