### PR TITLE
Update 060-full-text-search.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -74,14 +74,14 @@ Here's how the following queries would match that text:
 
 | Query            | Match? | Description                         |
 | :--------------- | :----- | :---------------------------------- |
-| `fox & dog`      | Yes    | The text contains fox and dog       |
-| `dog & fox`      | Yes    | The text contains dog and fox       |
-| `dog & cat`      | No     | The text doesn't contain cat        |
-| `!cat`           | Yes    | There is not cat in the text        |
-| `fox \| cat`     | Yes    | The text contains fox or cat        |
-| `cat \| pig`     | No     | The text doesn't contain cat or pig |
-| `fox <-> dog`    | Yes    | dog follows fox in the text         |
-| `dog <-> fox`    | No     | dog doesn't follow fox in the text  |
+| fox & dog      | Yes    | The text contains fox and dog       |
+| dog & fox      | Yes    | The text contains dog and fox       |
+| dog & cat      | No     | The text doesn't contain cat        |
+| !cat           | Yes    | There is not cat in the text        |
+| fox | cat      | Yes    | The text contains fox or cat        |
+| cat | pig      | No     | The text doesn't contain cat or pig |
+| fox <-> dog    | Yes    | dog follows fox in the text         |
+| dog <-> fox    | No     | dog doesn't follow fox in the text  |
 
 ## Adding Indexes
 

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -74,14 +74,14 @@ Here's how the following queries would match that text:
 
 | Query            | Match? | Description                         |
 | :--------------- | :----- | :---------------------------------- |
-| fox & dog      | Yes    | The text contains fox and dog       |
-| dog & fox      | Yes    | The text contains dog and fox       |
-| dog & cat      | No     | The text doesn't contain cat        |
-| !cat           | Yes    | There is not cat in the text        |
-| fox | cat      | Yes    | The text contains fox or cat        |
-| cat | pig      | No     | The text doesn't contain cat or pig |
-| fox <-> dog    | Yes    | dog follows fox in the text         |
-| dog <-> fox    | No     | dog doesn't follow fox in the text  |
+| `fox & dog`      | Yes    | The text contains fox and dog       |
+| `dog & fox`      | Yes    | The text contains dog and fox       |
+| `dog & cat`      | No     | The text doesn't contain cat        |
+| `!cat`           | Yes    | There is not cat in the text        |
+| <inlinecode>fox &#124; cat</inlinecode>      | Yes    | The text contains fox or cat        |
+| <inlinecode>cat &#124; pig</inlinecode>      | No     | The text doesn't contain cat or pig |
+| `fox <-> dog`    | Yes    | dog follows fox in the text         |
+| `dog <-> fox`    | No     | dog doesn't follow fox in the text  |
 
 ## Adding Indexes
 


### PR DESCRIPTION
Unfortunately pipes can't be escaped in our docs markdown parser right now. Created an issue: https://github.com/prisma/docs/issues/2217