### PR TITLE
interactive transactions: update concept and tx guide with a better example

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
@@ -91,7 +91,7 @@ model users {
 }
 ```
 
-The are a few "issues" with this Prisma schema when the Prisma Client API is generated:
+There are a few "issues" with this Prisma schema when the Prisma Client API is generated:
 
 **Adhering to Prisma's naming conventions**
 

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/130-logging.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/130-logging.mdx
@@ -68,7 +68,7 @@ The following example subscribes to all `query` events and write the `duration` 
 <CodeWithResult expanded="{true}">
 <cmd>
 
-```ts highlight=4,5,22-24;normal
+```ts highlight=4,5,22-25;normal
 const prisma = new PrismaClient({
   log: [
     {

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -165,7 +165,7 @@ main()
   })
 ```
 
-In the example above, both `update` queries run within a database transaction. When your application reaches the end of the function, the transaction is **committed** to the database.
+In the example above, both `update` queries run within a database transaction. When the application reaches the end of the function, the transaction is **committed** to the database.
 
 If your application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction.
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -113,7 +113,7 @@ This is a great use-case for interactive transactions because we need to perform
 
 In the example below, Alice and Bob each have $100 in their account. If you try to send more money than you have, the transfer is rejected.
 
-We'd expect Alice to be able to make 1 transfer for $100 and the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
+Alice is expected to be able to make 1 transfer for $100 while the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
 
 ```tsx
 import { PrismaClient } from '@prisma/client'

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -111,7 +111,7 @@ As experienced developers, we want to make sure that during the transfer,
 
 This is a great use-case for interactive transactions because we need to perform logic in-between the writes to check the balance.
 
-In the example below, Alice and Bob each have $100 in their account. If you try to send more money than you have, the transfer is rejected.
+In the example below, Alice and Bob each have $100 in their account. If they try to send more money than they have, the transfer is rejected.
 
 Alice is expected to be able to make 1 transfer for $100 while the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -89,11 +89,9 @@ Instead of immediately awaiting the result of each operation when it's performed
 
 ### Interactive Transactions (in Preview)
 
-Sometimes you need more control over what queries execute within a transaction.
+Sometimes you need more control over what queries execute within a transaction. Interactive transactions are meant to provide you with an escape hatch.
 
-Interactive transactions are commonly used when the result of one query depends on another query and you want to run both queries within a single transaction.
-
-To support this use case and more, you can enable interactive transactions by adding `interactiveTransactions` in the generator of your Prisma Schema:
+You can enable interactive transactions by adding `interactiveTransactions` in the generator of your Prisma Schema:
 
 ```prisma
 generator client {
@@ -104,46 +102,70 @@ generator client {
 
 Then you can pass an async function into [`$transaction`](../../../guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
 
-The following is an example of purchasing a movie ticket online. In this example, we really don't want to sell the same ticket twice:
+Let's say we're building an online banking system. One of the actions we want to perform is to send money from one person to another person.
+
+As experienced developers, we want to make sure that during the transfer,
+
+- the amount doesn't disappear
+- the amount isn't doubled
+
+This is a great use-case for interactive transactions because we need to perform logic in-between the writes to check the balance.
+
+In the example below, Alice and Bob each have $100 in their account. If you try to send more money than you have, the transfer is rejected.
+
+We'd expect Alice to be able to make 1 transfer for $100 and the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
 
 ```tsx
-import { Ticket } from 'prisma'
+import { PrismaClient } from '@prisma/client'
+const prisma = new PrismaClient()
 
-const userEmail = 'alice@prisma.io'
-const movieName = 'October Sky'
-
-// Start a transaction
-const ticket: Ticket = await prisma.$transaction(async (prisma) => {
-  // Find an available ticket
-  const availableTicket = await prisma.ticket.findFirst({
-    where: {
-      claimedBy: null,
-      movie: {
-        name: movieName,
+async function transfer(from: string, to: string, amount: number) {
+  return await prisma.$transaction(async (prisma) => {
+    // 1. Decrement amount from the sender.
+    const sender = await prisma.account.update({
+      data: {
+        balance: {
+          decrement: amount,
+        },
       },
-    },
+      where: {
+        email: from,
+      },
+    })
+    // 2. Verify that the sender's balance didn't go below zero.
+    if (sender.balance < 0) {
+      throw new Error(`${from} doesn't have enough to send ${amount}`)
+    }
+    // 3. Increment the recipient's balance by amount
+    const recipient = prisma.account.update({
+      data: {
+        balance: {
+          increment: amount,
+        },
+      },
+      where: {
+        email: to,
+      },
+    })
+    return recipient
   })
+}
 
-  // Throw an error if no tickets are available
-  if (!availableTicket) {
-    // This will rollback the transaction
-    throw new Error(`Oh no! ${movieName} is all booked.`)
-  }
+async function main() {
+  // This transfer is successful
+  await transfer('alice@prisma.io', 'bob@prisma.io', 100)
+  // This transfer fails because Alice doesn't have enough funds in her account
+  await transfer('alice@prisma.io', 'bob@prisma.io', 100)
+}
 
-  // Claim the ticket, commit the transaction, and return
-  // the result
-  return prisma.ticket.update({
-    data: {
-      claimedBy: userEmail,
-    },
-    where: {
-      id: availableTicket.id,
-    },
+main()
+  .catch(console.error)
+  .finally(() => {
+    prisma.$disconnect()
   })
-})
 ```
 
-In the example above, both the `findFirst` and `update` queries run within a database transaction. When your application reaches the end of the function, the transaction is **committed** to the database.
+In the example above, both `update` queries run within a database transaction. When your application reaches the end of the function, the transaction is **committed** to the database.
 
 If your application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction.
 
@@ -159,7 +181,7 @@ try {
 }
 ```
 
-Additionally, the transaction API supports a 2nd parameter with the following configuration options:
+The interactive transaction API has a 2nd parameter with the following configuration options:
 
 - `maxWait`: The maximum amount of time the Prisma Client will wait to acquire a transaction from the database. The default is 2 seconds.
 - `timeout`: The maximum amount of time the interactive transaction can run before being canceled and rolled back. The default value is 5 seconds.
@@ -187,7 +209,9 @@ transaction functions. We recommend you get in and out as quick as possible!
 
 </Admonition>
 
-## Transaction isolation level
+## Limitations
+
+### Transaction Isolation Level
 
 Transaction isolation level is not currently configurable at a Prisma level and is not explicitly set by Prisma.
 
@@ -195,6 +219,12 @@ Transaction isolation level is not currently configurable at a Prisma level and 
 - [Default transaction isolation level in SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
 - [Default transaction isolation level in MySQL](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
 
-## Join the conversation on GitHub
+### Concurrent Interactive Transactions May Timeout
+
+Interactive transactions have an issue where multiple concurrent transactions on the same rows may result in a timeout.
+
+We're planning to resolve this limitation soon. Follow along with [this issue](https://github.com/prisma/prisma/issues/8707) for updates.
+
+## Join the Conversation on GitHub
 
 If you'd like to see transactions supported in the future, [please join the discussion on GitHub](https://github.com/prisma/prisma-client-js/issues/349).

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -102,7 +102,7 @@ generator client {
 
 Then you can pass an async function into [`$transaction`](../../../guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
 
-Let's say we're building an online banking system. One of the actions we want to perform is to send money from one person to another person.
+Imagine that you are building an online banking system. One of the actions to perform is to send money from one person to another.
 
 As experienced developers, we want to make sure that during the transfer,
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -101,7 +101,9 @@ generator client {
 ```
 
 Then you can pass an async function into [`$transaction`](../../../guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
+
 ## Example
+
 Imagine that you are building an online banking system. One of the actions to perform is to send money from one person to another.
 
 As experienced developers, we want to make sure that during the transfer,

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -101,7 +101,7 @@ generator client {
 ```
 
 Then you can pass an async function into [`$transaction`](../../../guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
-
+## Example
 Imagine that you are building an online banking system. One of the actions to perform is to send money from one person to another.
 
 As experienced developers, we want to make sure that during the transfer,

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -892,7 +892,7 @@ main()
   })
 ```
 
-In the example above, both `update` queries run within a database transaction. When your application reaches the end of the function, the transaction is **committed** to the database.
+In the example above, both `update` queries run within a database transaction. When the application reaches the end of the function, the transaction is **committed** to the database.
 
 If your application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction.
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -838,47 +838,65 @@ generator client {
 
 Then you can pass an async function into [$transaction](https://www.prisma.io/docs/guides/performance-and-optimization/prisma-client-transactions-guide/#transaction-api).
 
-The following is an example of purchasing a movie ticket online. This is a good use case for an interactive transactions because you don't want to sell the same ticket twice.
+In the example below, Alice and Bob each have $100 in their account. If you try to send more money than you have, the transfer is rejected.
 
-```ts highlight=6,8,25;normal
-import { Seat } from 'prisma'
-const userEmail = 'alice@prisma.io'
-const movieName = 'HiddenFigures'
+We'd expect Alice to be able to make 1 transfer for $100 and the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
 
-// Start a transaction
-const seat: Seat = await prisma.$transaction(async (prisma) => {
-  // Find an available seat
-  const availableSeat = await prisma.seat.findFirst({
-    where: {
-      claimedBy: null,
-      movie: {
-        name: movieName,
+```ts
+import { PrismaClient } from '@prisma/client'
+const prisma = new PrismaClient()
+
+async function transfer(from: string, to: string, amount: number) {
+  return await prisma.$transaction(async (prisma) => {
+    // 1. Decrement amount from the sender.
+    const sender = await prisma.account.update({
+      data: {
+        balance: {
+          decrement: amount,
+        },
       },
-    },
+      where: {
+        email: from,
+      },
+    })
+    // 2. Verify that the sender's balance didn't go below zero.
+    if (sender.balance < 0) {
+      throw new Error(`${from} doesn't have enough to send ${amount}`)
+    }
+    // 3. Increment the recipient's balance by amount
+    const recipient = prisma.account.update({
+      data: {
+        balance: {
+          increment: amount,
+        },
+      },
+      where: {
+        email: to,
+      },
+    })
+    return recipient
   })
+}
 
-  // Throw an error if no seats are available
-  if (!availableSeat) {
-    // This will rollback the transaction
-    throw new Error(`Oh no! ${movieName} is all booked.`)
-  }
+async function main() {
+  // This transfer is successful
+  await transfer('alice@prisma.io', 'bob@prisma.io', 100)
+  // This transfer fails because Alice doesn't have enough funds in her account
+  await transfer('alice@prisma.io', 'bob@prisma.io', 100)
+}
 
-  // Claim the seat, commit the transaction, and return
-  // the result
-  return prisma.seat.update({
-    data: {
-      claimedBy: userEmail,
-    },
-    where: {
-      id: availableSeat.id,
-    },
+main()
+  .catch(console.error)
+  .finally(() => {
+    prisma.$disconnect()
   })
-})
 ```
 
-In the example above, both the `findFirst` and `update` queries run within a database transaction. When your application reaches the end of the function, the transaction is **committed** to the database.
+In the example above, both `update` queries run within a database transaction. When your application reaches the end of the function, the transaction is **committed** to the database.
 
-If your application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction. To catch the exception, you can wrap `$transaction` in a try-catch block.
+If your application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction.
+
+You can learn more about interactive transactions in our [Transactions and Batch Queries documentation](https://www.prisma.io/docs/concepts/components/prisma-client/transactions#interactive-transactions-in-preview).
 
 <Admonition type="warning">
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -838,7 +838,7 @@ generator client {
 
 Then you can pass an async function into [$transaction](https://www.prisma.io/docs/guides/performance-and-optimization/prisma-client-transactions-guide/#transaction-api).
 
-In the example below, Alice and Bob each have $100 in their account. If you try to send more money than you have, the transfer is rejected.
+In the example below, Alice and Bob each have $100 in their account. If they try to send more money than they have, the transfer is rejected.
 
 We'd expect Alice to be able to make 1 transfer for $100 and the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -894,7 +894,7 @@ main()
 
 In the example above, both `update` queries run within a database transaction. When the application reaches the end of the function, the transaction is **committed** to the database.
 
-If your application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction.
+If the application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction.
 
 You can learn more about interactive transactions in our [Transactions and Batch Queries documentation](https://www.prisma.io/docs/concepts/components/prisma-client/transactions#interactive-transactions-in-preview).
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -840,7 +840,7 @@ Then you can pass an async function into [$transaction](https://www.prisma.io/do
 
 In the example below, Alice and Bob each have $100 in their account. If they try to send more money than they have, the transfer is rejected.
 
-We'd expect Alice to be able to make 1 transfer for $100 and the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
+The expected outcome would be for Alice to make 1 transfer for $100 and the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
 
 ```ts
 import { PrismaClient } from '@prisma/client'

--- a/content/300-guides/125-development-environment/050-environment-variables/index.mdx
+++ b/content/300-guides/125-development-environment/050-environment-variables/index.mdx
@@ -77,13 +77,27 @@ Refer to the `dotenv` documentation for information about [what happens if an en
 
 ### Expanding variables
 
-Variables stored in `.env` files can be expanded using the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). This is useful when dealing with PaaS or similar products. such as Heroku):
+Variables stored in `.env` files can be expanded using the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). 
 
-```
-# .env
+```env file=.env
 DATABASE_URL=postgresql://test:test@localhost:5432/test
 DATABASE_URL_WITH_SCHEMA=${DATABASE_URL}?schema=public
 ```
+
+This will make the environment variable `DATABASE_URL_WITH_SCHEMA` with value `postgresql://test:test@localhost:5432/test?schema=public` available for Prisma.
+
+You can also use environment variables in the expansion that are set _outside_ of the `.env` file, for example a database URL that is set on a PaaS like Heroku or similar:
+
+```terminal
+# environment variable already set in the environment of the system
+export DATABASE_URL=postgresql://test:test@localhost:5432/test
+```
+
+```env file=.env
+DATABASE_URL_WITH_SCHEMA=${DATABASE_URL}?schema=foo
+```
+
+This will make the environment variable `DATABASE_URL_WITH_SCHEMA` with value `postgresql://test:test@localhost:5432/test?schema=foo` available for Prisma. 
 
 ### Example: Set the `DATABASE_URL` environment variable in an `.env` file
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3847,9 +3847,9 @@
       "integrity": "sha512-BU1DNNDhdzqjHtycpUzDrU8+jf6ZY+fbXvCV/rbqG+0JifljlIo4vbkHDMg97gBi1Do8pTLZGlTH16FlniKgAg=="
     },
     "@prisma/lens": {
-      "version": "0.0.223",
-      "resolved": "https://registry.npmjs.org/@prisma/lens/-/lens-0.0.223.tgz",
-      "integrity": "sha512-M436DC4UQfkKl/2Ka870+ecKE2c3PMosUL7e4KJrMIzgjM1gZPau/JrkhxudFhvRge0JUWuemLpdxBSIOoGkXw==",
+      "version": "0.0.224",
+      "resolved": "https://registry.npmjs.org/@prisma/lens/-/lens-0.0.224.tgz",
+      "integrity": "sha512-t86spV9SEyDCCQU9cmHr5zUBSNOWFqXp91pLVbbbaPCXxr8yuoaAN+s4Z0hkodk9xHlxsxEHR3fb9rovMBR5kg==",
       "requires": {
         "feather-icons": "4.28.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3847,9 +3847,9 @@
       "integrity": "sha512-BU1DNNDhdzqjHtycpUzDrU8+jf6ZY+fbXvCV/rbqG+0JifljlIo4vbkHDMg97gBi1Do8pTLZGlTH16FlniKgAg=="
     },
     "@prisma/lens": {
-      "version": "0.0.222",
-      "resolved": "https://registry.npmjs.org/@prisma/lens/-/lens-0.0.222.tgz",
-      "integrity": "sha512-vb5+HGpR+l0EUjCS+tb0Quam9AT2xUGMiwDW13A8Z+P6DVFVJTMdotrwTRZsR9mIVlLM6cskmsHCbXBtuzxMKQ==",
+      "version": "0.0.223",
+      "resolved": "https://registry.npmjs.org/@prisma/lens/-/lens-0.0.223.tgz",
+      "integrity": "sha512-M436DC4UQfkKl/2Ka870+ecKE2c3PMosUL7e4KJrMIzgjM1gZPau/JrkhxudFhvRge0JUWuemLpdxBSIOoGkXw==",
       "requires": {
         "feather-icons": "4.28.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@percy/agent": "0.28.6",
     "@philpl/buble": "0.19.7",
     "@prisma/client": "2.29.1",
-    "@prisma/lens": "0.0.222",
+    "@prisma/lens": "0.0.223",
     "@reach/router": "1.3.4",
     "algoliasearch": "4.9.1",
     "babel-plugin-styled-components": "1.13.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@percy/agent": "0.28.6",
     "@philpl/buble": "0.19.7",
     "@prisma/client": "2.29.1",
-    "@prisma/lens": "0.0.223",
+    "@prisma/lens": "0.0.224",
     "@reach/router": "1.3.4",
     "algoliasearch": "4.9.1",
     "babel-plugin-styled-components": "1.13.2",


### PR DESCRIPTION
This is part 1 of 2 for providing a better example for interactive transactions. Here's what's changed:

- [Transactions and Batch Queries](https://deploy-preview-2227--prisma2-docs.netlify.app/docs/concepts/components/prisma-client/transactions#interactive-transactions-in-preview): Reworked the example
- [Transaction Guide](https://deploy-preview-2227--prisma2-docs.netlify.app/docs/guides/performance-and-optimization/prisma-client-transactions-guide#interactive-transactions-in-preview): Reworked the example (mostly copy and paste from Transactions and Batch Queries)
 
Technically these examples should show concurrent requests since that's the point of transactions, but we're waiting on https://github.com/prisma/prisma/issues/8707. After that it's just a matter of changing the transfers from sync to async. This will be part 2 of 2.

---

The problem with the current example is that for concurrent requests the findFirst's happen async and the updates happen sync. This means that the findFirst's both see an untaken seat and the updates will both book that seat. Double-booking problem all over again. There are two solutions to this:

1. https://github.com/prisma/prisma/issues/8580: where you explicitly say, lock this row because we're going to update it soon.
2. https://github.com/prisma/prisma/issues/8668: where you set the isolation level to a higher level.

But we don't plan to solve these just yet. 

