### PR TITLE
fix(use-custom-model-and-field-names): Fix a typo

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
@@ -91,7 +91,7 @@ model users {
 }
 ```
 
-The are a few "issues" with this Prisma schema when the Prisma Client API is generated:
+There are a few "issues" with this Prisma schema when the Prisma Client API is generated:
 
 **Adhering to Prisma's naming conventions**
 


### PR DESCRIPTION
Fix a small typo in page "Using custom model and field names"