### PR TITLE
fix(command-reference): Remove wrong limitation about `db seed` and Mongo

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -667,13 +667,6 @@ npx prisma db push --schema=/tmp/schema.prisma
 
 ### <inlinecode>db seed</inlinecode> (Preview)
 
-<Admonition type="warning">
-
-**MongoDB not supported** <br />
-`db push` uses the Migration Engine and does not currently support the [MongoDB connector](./../../concepts/database-connectors/mongodb).
-
-</Admonition>
-
 > **Note**: `db seed` is currently in [Preview](../../../about/prisma/releases#preview). Features in Preview may still have some issues, and are not recommended for use in production environments. To access commands in Preview, you must opt-in via the `--preview-feature` flag. For a simple and integrated way to re-create data in your development database as often as needed, check out our [seeding guide](../../../guides/database/seed-database).
 
 #### Remarks


### PR DESCRIPTION
See context: https://prisma-company.slack.com/archives/CGMCB82N8/p1630530095025100