### PR TITLE
Added docs about the json nullability breaking change

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -846,6 +846,48 @@ console.log(checkJson.length)
 </tab>
 </TabbedContent>
 
+## Filtering by Null Values
+
+There are two types of null values possible for a Json field in an SQL database.
+
+- Database NULL: The value in the database is a NULL.
+- JSON null: The value in the database contains a JSON value that is null.
+
+To differentiate between these possibilities, we've introduced three null enums you can use to filter on
+
+- `JsonNull`: Selects the null value in JSON.
+- `DbNull`: Selects the NULL value in the database.
+- `AnyNull`: Selects both null JSON values and NULL database values.
+
+For example,
+
+```prisma
+model Log {
+  id   Int  @id
+  meta Json
+}
+```
+
+```ts
+import { Prisma } from '@prisma/client'
+
+prisma.log.findMany({
+  where: {
+    data: {
+      meta: Prisma.AnyNull,
+    },
+  },
+})
+```
+
+<Admonition type="info">
+
+These null enums does not apply to MongoDB because there is not a difference between a JSON null and a database NULL.
+
+They also do not apply to the `array_contains` operator becuase there can only be a JSON null within an JSON array. Since there cannot be a database NULL within a JSON array, `{ array_contains: null }` is not ambiguous.
+
+</Admonition>
+
 ## <inlinecode>Json</inlinecode> FAQs
 
 ### Can you select a subset of JSON key/values to return?

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -882,7 +882,7 @@ prisma.log.findMany({
 
 <Admonition type="info">
 
-These null enums does not apply to MongoDB because there is not a difference between a JSON null and a database NULL.
+These null enums do not apply to MongoDB because there is not a difference between a JSON null and a database NULL.
 
 They also do not apply to the `array_contains` operator becuase there can only be a JSON null within an JSON array. Since there cannot be a database NULL within a JSON array, `{ array_contains: null }` is not ambiguous.
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -859,7 +859,7 @@ To differentiate between these possibilities, we've introduced three null enums 
 - `DbNull`: Selects the NULL value in the database.
 - `AnyNull`: Selects both null JSON values and NULL database values.
 
-For example,
+For example:
 
 ```prisma
 model Log {

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -853,7 +853,7 @@ There are two types of null values possible for a Json field in an SQL database.
 - Database NULL: The value in the database is a NULL.
 - JSON null: The value in the database contains a JSON value that is null.
 
-To differentiate between these possibilities, we've introduced three null enums you can use to filter on
+To differentiate between these possibilities, we've introduced three null enums you can use to filter on:
 
 - `JsonNull`: Selects the null value in JSON.
 - `DbNull`: Selects the NULL value in the database.

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
@@ -42,7 +42,8 @@ You can learn more about the new `$queryRaw` and `$queryRawUnsafe` methods in th
 
 ### [Json Null Equality](../../../../concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values)
 
-We recently learned from [a community member](https://github.com/prisma/prisma/issues/8399) that you cannot filter a `Json` field by a null value. This is because `{ equals: null }` checks if the column value in the database is `NULL`, not if the JSON value inside the column equals `null`.
+You cannot filter a `Json` field by a null value.  [See this GitHub issue](https://github.com/prisma/prisma/issues/8399). 
+This is because `{ equals: null }` checks if the column value in the database is `NULL`, not if the JSON value inside the column equals `null`.
 
 To fix this problem, we decided to split null on Json fields into `JsonNull`, `DbNull` and `AnyNull`.
 

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
@@ -67,7 +67,7 @@ prisma.log.findMany({
     data: {
       meta: {
         equals: null
-                ^ TypeError: // TODO @millsp fill in error
+                ^ TypeError: Type 'null' is not assignable to type
         }
     },
   },
@@ -83,7 +83,7 @@ prisma.log.findMany({
   where: {
     data: {
       meta: {
-        equals: Prisma.AnyNull, // TODO @millsp is this right?
+        equals: Prisma.AnyNull,
       },
     },
   },

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
@@ -40,6 +40,64 @@ This means that if your application relied on `$queryRaw` calls using _strings_,
 
 You can learn more about the new `$queryRaw` and `$queryRawUnsafe` methods in the [Raw database access](../../../../concepts/components/prisma-client/raw-database-access) section of the docs.
 
+### [Json Null Equality](../../../../concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values)
+
+We recently learned from [a community member](https://github.com/prisma/prisma/issues/8399) that you cannot filter a `Json` field by a null value. This is because `{ equals: null }` checks if the column value in the database is `NULL`, not if the JSON value inside the column equals `null`.
+
+To fix this problem, we decided to split null on Json fields into `JsonNull`, `DbNull` and `AnyNull`.
+
+- **JsonNull**: Selects the null value in JSON.
+- **DbNull**: Selects the NULL value in the database.
+- **AnyNull:** Selects both null JSON values and NULL database values.
+
+Given the following model in your Prisma Schema:
+
+```ts
+model Log {
+  id Int @id
+  meta Json
+}
+```
+
+Starting in 3.0.1, you'll see a TypeError if you try to filter by null on a `Json` field:
+
+```ts
+prisma.log.findMany({
+  where: {
+    data: {
+      meta: {
+        equals: null
+                ^ TypeError: // TODO @millsp fill in error
+        }
+    },
+  },
+});
+```
+
+To fix this, you'll import and use one of the new null types:
+
+```ts
+import { Prisma } from '@prisma/client'
+
+prisma.log.findMany({
+  where: {
+    data: {
+      meta: {
+        equals: Prisma.AnyNull, // TODO @millsp is this right?
+      },
+    },
+  },
+})
+```
+
+<Admonition type="warning">
+
+This API change does not apply to the MongoDB connector where there is not a difference between a JSON null and a database NULL.
+
+They also do not apply to the `array_contains` operator becuase there can only be a JSON null within an JSON array. Since there cannot be a database NULL within a JSON array, `{ array_contains: null }` is not ambiguous.
+
+</Admonition>
+
 ## Specific upgrade paths
 
 <Subsections />


### PR DESCRIPTION
This is a PR onto `epic/prisma-3`:

- [Documents the Prisma 3 breaking change](https://deploy-preview-2265--prisma2-docs.netlify.app/docs/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3)
- [Adds a section to the JSON filtering concept about querying for null values](https://deploy-preview-2265--prisma2-docs.netlify.app/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values)
