### PR TITLE
Swap introspect db seed images

### DIFF
--- a/content/200-concepts/050-overview/100-what-is-prisma/index.mdx
+++ b/content/200-concepts/050-overview/100-what-is-prisma/index.mdx
@@ -289,6 +289,6 @@ The typical workflow when using **SQL migrations and introspection** is slightly
 1. (Re-)generate Prisma Client
 1. Use Prisma Client in your application code to access your database
 
-![Introspection workflow](../../../doc-images/prisma-introspection-development-workflow.png)
+![Introspection workflow](https://res.cloudinary.com/prismaio/image/upload/v1628761155/docs/ToNkpb2.png)
 
 To learn more about the introspection workflow, please refer the [introspection section](../../components/introspection).


### PR DESCRIPTION
This PR swaps out the images that had `prisma introspect` for ones that say `prisma db pull`

The change was made in cloudinary, i only had to change 1 url in this PR. That means that the changes are now live, except for this one image. 

If anyone knows of any more places i may have missed then let me know. 

Fixes: https://github.com/prisma/docs/issues/2135