### PR TITLE
Named Constraints: Fix typo in command example

### DIFF
--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/100-named-constraints.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/100-named-constraints.mdx
@@ -79,7 +79,7 @@ If you want to keep your Prisma Schema clean and if you have no reasons preventi
 
 Run `prisma migrate dev` to create a migration updating the constraint names to Prisma's defaults.
 
-Afterwards, do not forget to `prisma migrated deploy` against your production environment if you have one to also update the names there. The schema below has no explicit constraint or index names spelled out, so Prisma will infer them.
+Afterwards, do not forget to `prisma migrate deploy` against your production environment if you have one to also update the names there. The schema below has no explicit constraint or index names spelled out, so Prisma will infer them.
 
 1. Example schema:
 


### PR DESCRIPTION
`prisma migrate` not `prisma migrated`.

I did not find any further hits for:
 `git grep "prisma migrate[a-z] "`