### PR TITLE
fix(mdx-examples): fix "CodeWithResult outputResultText" example to actually use it

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/01-mdx-examples.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-mdx-examples.mdx
@@ -481,7 +481,7 @@ https://pris.ly/d/getting-started
 Code:
 
 ````
-<CodeWithResult expanded={true}>
+<CodeWithResult outputResultText="some output" expanded={true}>
 
 <cmd>
 


### PR DESCRIPTION
code block after example did not contain correct code