### PR TITLE
docs: include missing 'as' in text

### DIFF
--- a/content/200-concepts/050-overview/100-what-is-prisma/100-data-modeling.mdx
+++ b/content/200-concepts/050-overview/100-what-is-prisma/100-data-modeling.mdx
@@ -109,7 +109,7 @@ interface User {
 
 Notice how the `User` model in both cases has the same properties as the `users` table in the previous example. While it's often the case that there's a 1:1 mapping between database tables and application models, it can also happen that models are represented completely differently in the database and your application.
 
-With this setup, you can retrieve records from the `users` table and store them instances of your `User` type. The following example code snippet uses [`pg`](https://node-postgres.com/) as the driver for PostgreSQL and creates a `User` instance based on the above defined JavaScript class:
+With this setup, you can retrieve records from the `users` table and store them as instances of your `User` type. The following example code snippet uses [`pg`](https://node-postgres.com/) as the driver for PostgreSQL and creates a `User` instance based on the above defined JavaScript class:
 
 ```js
 const resultRows = await client.query('SELECT * FROM users WHERE user_id = 1')


### PR DESCRIPTION
Include a missed word `as` in documentation text at [Data modelling on the application level](https://www.prisma.io/docs/concepts/overview/what-is-prisma/data-modeling#data-modeling-on-the-application-level), the penultimate paragraph