### PR TITLE
fix: postgresql raw query ILIKE example

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -197,7 +197,7 @@ When you use `ILIKE`, the `%` wildcard character(s) should be included in the va
 const userName = 'Sarah'
 const emailFragment = 'prisma.io'
 const result = await prisma.$queryRawUnsafe(
-  `SELECT * FROM "User" WHERE (name = $1 OR email = $2)`, 
+  `SELECT * FROM "User" WHERE (name = $1 OR email ILIKE $2)`, 
   userName,
   `%${emailFragment}`)
 ```


### PR DESCRIPTION
fix: postgresql raw query ILIKE example