### PR TITLE
Fix typo in MongoDb schema example

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -186,10 +186,12 @@ model User {
   id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
   posts Post[]
 }
+
 model Post {
-id        String  @id @default(dbgenerated()) @db.ObjectId @map("_id")
-author    User?   @relation(fields: [authorId], references: [id])
-authorId  String?  @db.ObjectId
+  id        String  @id @default(dbgenerated()) @db.ObjectId @map("_id")
+  author    User?   @relation(fields: [authorId], references: [id])
+  authorId  String?  @db.ObjectId
+}
 ```
 
 </tab>


### PR DESCRIPTION
Found missing bracket in MongoDB Schema example

https://www.prisma.io/docs/concepts/components/prisma-schema/relations/one-to-many-relations#required-and-optional-relation-fields-in-one-to-many-relations

![image](https://user-images.githubusercontent.com/30436259/132822765-739066d1-8160-4052-ba40-d53f5bc211d3.png)
