### PR TITLE
fix typo and remove unnecessary spaces

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -149,7 +149,7 @@ The following list of `Post` MongoDB documents each have a `userId` field which 
 
 #### Comparing one-to-one and one-to-many relations
 
-In MongoDB, the only difference between a 1-1 and a 1-n is the number of documents referencing another doucment in the database - there are no constraints.
+In MongoDB, the only difference between a 1-1 and a 1-n is the number of documents referencing another document in the database - there are no constraints.
 
 ## Required and optional relation fields in one-to-many relations
 
@@ -188,9 +188,9 @@ model User {
 }
 
 model Post {
-  id        String  @id @default(dbgenerated()) @db.ObjectId @map("_id")
-  author    User?   @relation(fields: [authorId], references: [id])
-  authorId  String?  @db.ObjectId
+  id       String  @id @default(dbgenerated()) @db.ObjectId @map("_id")
+  author   User?   @relation(fields: [authorId], references: [id])
+  authorId String?  @db.ObjectId
 }
 ```
 


### PR DESCRIPTION
Fixed typo `doucment` -> `document`
Removed unnecessary spaces in mongodb example