### PR TITLE
fix(link-checker): add list of URLs to never treat as broken

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,11 +33,12 @@ const gatsbyRemarkPlugins = [
   {
     resolve: require.resolve('./plugins/gatsby-remark-check-links-numberless'),
     options: {
-      ignore: [
-        '/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres',
-        '/docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres',
-        '/docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres',
-      ]
+      // Do not surface links to these pages as broken:
+      exceptions: [
+        '/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres',
+        '/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres',
+        '/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres',
+      ],
     },
   },
   {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,8 @@ const gatsbyRemarkPlugins = [
     options: {
       ignore: [
         '/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres',
+        '/docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres',
+        '/docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres',
       ]
     },
   },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,6 +32,11 @@ const gatsbyRemarkPlugins = [
   },
   {
     resolve: require.resolve('./plugins/gatsby-remark-check-links-numberless'),
+    options: {
+      ignore: [
+        '/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres',
+      ]
+    },
   },
   {
     resolve: 'gatsby-remark-copy-linked-files',

--- a/plugins/gatsby-remark-check-links-numberless/index.js
+++ b/plugins/gatsby-remark-check-links-numberless/index.js
@@ -107,6 +107,7 @@ module.exports = async function plugin(
 
   let totalBrokenLinks = 0
   const prefixedIgnore = ignore.map(withPathPrefix)
+  console.log('prefixIgnore', prefixedIgnore)
   const prefixedExceptions = exceptions.map(withPathPrefix)
   const pathKeys = Object.keys(linksMap)
   const pathKeysWithoutIndex = pathKeys.map((p) =>
@@ -116,6 +117,7 @@ module.exports = async function plugin(
   for (const pathL in linksMap) {
     if (prefixedIgnore.includes(pathL)) {
       // don't count broken links for ignored pages
+      console.log('Do not cound this borken link:', pathL)
       continue
     }
 

--- a/plugins/gatsby-remark-check-links-numberless/index.js
+++ b/plugins/gatsby-remark-check-links-numberless/index.js
@@ -107,7 +107,6 @@ module.exports = async function plugin(
 
   let totalBrokenLinks = 0
   const prefixedIgnore = ignore.map(withPathPrefix)
-  console.log('prefixIgnore', prefixedIgnore)
   const prefixedExceptions = exceptions.map(withPathPrefix)
   const pathKeys = Object.keys(linksMap)
   const pathKeysWithoutIndex = pathKeys.map((p) =>
@@ -116,8 +115,7 @@ module.exports = async function plugin(
 
   for (const pathL in linksMap) {
     if (prefixedIgnore.includes(pathL)) {
-      // don't count broken links for ignored pages
-      console.log('Do not cound this borken link:', pathL)
+      // don't check links on ignored pages
       continue
     }
 
@@ -127,6 +125,7 @@ module.exports = async function plugin(
         // return true for broken links, false = pass
         const { key, hasHash, hashIndex } = getHeadingsMapKey(link.tranformedUrl, pathL)
         if (prefixedExceptions.includes(key)) {
+          // do not test this link as it is on the list of exceptions
           return false
         }
 


### PR DESCRIPTION
This adds a list of known URLs (pages that use the tech switcher) to the link checker configuration, that are not checked for broken links to avoid false positives.