### PR TITLE
Update mongodb supported version per #8305

### DIFF
--- a/content/400-reference/300-database-reference/03-supported-databases.mdx
+++ b/content/400-reference/300-database-reference/03-supported-databases.mdx
@@ -38,5 +38,5 @@ Support for the following databases is available as a Preview:
 
 | Database    | Version |
 | ----------- | ------- |
-| MongoDB     | 4.2+    |
+| MongoDB     | 4.4+    |
 | PlanetScale | \*      |


### PR DESCRIPTION
Per this issue https://github.com/prisma/prisma/issues/8305 the supported version for mongodb should be 4.4+.