### PR TITLE
Replace outdated graphql server link

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/300-next-steps.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/300-next-steps.mdx
@@ -89,7 +89,7 @@ The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository c
 | :------------------------------------------------------------------------------------------------------------------ | :----------- | --------------------------------------------------------------------------------------------------- |
 | [`rest-nextjs-api-routes`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-api-routes) | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a REST API                                   |
 | [`graphql-nextjs`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-nextjs)                 | Fullstack    | Simple [Next.js](https://nextjs.org/) app (React) with a GraphQL API                                |
-| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-apollo-server)   | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
+| [`graphql-apollo-server`](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql)   | Backend only | Simple GraphQL server based on [`apollo-server`](https://www.apollographql.com/docs/apollo-server/) |
 | [`rest-express`](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express)                     | Backend only | Simple REST API with Express.JS                                                                     |
 | [`grpc`](https://github.com/prisma/prisma-examples/tree/latest/typescript/grpc)                                     | Backend only | Simple gRPC API                                                                                     |
 


### PR DESCRIPTION
Original url links to a redirect. Updated to use the redirect url.