### PR TITLE
Add correct import for DeepMockProxy

### DIFF
--- a/content/300-guides/150-testing/100-unit-testing.mdx
+++ b/content/300-guides/150-testing/100-unit-testing.mdx
@@ -85,7 +85,7 @@ The following steps guide you through mocking the Prisma Client using a singleto
    ```ts file=singleton.ts
    import { PrismaClient } from '@prisma/client'
    import { mockDeep, mockReset } from 'jest-mock-extended'
-   import { DeepMockProxy } from 'jest-mock-extended/lib/Mock'
+   import { DeepMockProxy } from 'jest-mock-extended/lib/cjs/Mock'
 
    import prisma from './client'
 
@@ -112,7 +112,7 @@ Another popular pattern that can be used is dependency injection.
    ```ts file=context.ts
    import { PrismaClient } from '@prisma/client'
    import { mockDeep } from 'jest-mock-extended'
-   import { DeepMockProxy } from 'jest-mock-extended/lib/Mock'
+   import { DeepMockProxy } from 'jest-mock-extended/lib/cjs/Mock'
 
    export type Context = {
      prisma: PrismaClient


### PR DESCRIPTION
I believe the import here is outdated! Was trying to follow along and found the import to be from /cjs/Mock! 