### PR TITLE
Documenting the referential integrity setting

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -12,13 +12,15 @@ Referential integrity means a set of constraints or triggers to handle the consi
 
 The referential integrity can either be handled in the database using foreign keys, or in the Prisma Client. There are pros and cons on both. In general, if the database supports foreign keys, it is usually the preferred choice and the default for SQL databases when using Prisma.
 
-In certain cases, either when the database doesn't support foreign keys, or when they are not preferred due to scaling reasons, Prisma can disable them and handle the the referential integrity in the client.
+In certain cases, either when the database doesn't support foreign keys, or when they are not preferred due to scaling reasons, Prisma can disable them and handle the referential integrity in the client.
 
 </TopBlock>
 
-## Setting the integrity in the datasource
+## Setting the referential integrity in the datasource
 
 Changing the referential integrity can be done in the [`datasource`](/reference/api-reference/prisma-schema-reference#datasource) block, using the `referentialIntegrity` parameter. The default for all SQL databases is `foreignKeys` and MongoDB defaults to `prisma`, which is the only setting that can be used with the connector.
+
+Because referential integrity is currently a preview feature, you need to explicitly define that in the generator block with `previewFeatures = ["referentialIntegrity"]`.
 
 ```prisma
 datasource db {

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -1,0 +1,74 @@
+---
+title: 'Referential integrity'
+metaTitle: 'Referential integrity'
+metaDescription: 'Referential integrity lets you define how the consistency of relations is handled.'
+tocDepth: 2
+---
+
+<TopBlock>
+
+Referential integrity means a set of constraints or triggers to handle the consistency of data of a [`@relation`](/reference/api-reference/prisma-schema-reference#relation). It can mean preventing a deletion of a record referred from other records, or it can be a cascading action defined in the field's [`referential actions`](/concepts/components/prisma-schema/relations/referential-actions). 
+
+The referential integrity can either be handled in the database using foreign keys, or in the Prisma Client. There are pros and cons on both. In general, if the database supports foreign keys, it is usually the preferred choice and the default for SQL databases when using Prisma.
+
+In certain cases, either when the database doesn't support foreign keys, or when they are not preferred due to scaling reasons, Prisma can disable them and handle the the referential integrity in the client.
+
+</TopBlock>
+
+## Setting the integrity in the datasource
+
+Changing the referential integrity can be done in the [`datasource`](/reference/api-reference/prisma-schema-reference#datasource) block, using the `referentialIntegrity` parameter. The default for all SQL databases is `foreignKeys` and MongoDB defaults to `prisma`, which is the only setting that can be used with the connector.
+
+```prisma
+datasource ds {
+  provider = "mysql"
+  url = "mysql://"
+  referentialIntegrity = "prisma"
+}
+
+generator js {
+  previewFeatures = ["referentialIntegrity"]
+}
+```
+
+Setting the value to `prisma` removes all foreign keys previously created in the next migration, and handles the integrity in the client. The value `foreignKeys` creates foreign keys to all relations in the next migration, letting the database to handle the integrity.
+
+## Handling the integrity in Prisma
+
+If the integrity is handled by the Prisma Client, for now there will be reduced amount of available [referential actions](/concepts/components/prisma-schema/relations/referential-actions) available in the data model:
+
+| action     | `onUpdate` | `onDelete` |
+|:-----------|:-----------|:-----------|
+| Restrict   | no         | yes        |
+| SetNull    | no         | yes        |
+| SetDefault | no         | no         |
+| Cascade    | no         | yes        |
+| NoAction   | no         | yes        |
+
+In this mode, any [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) database queries will not trigger any of the actions, and they should be handled manually if deleting or updating records using the [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) queries.
+
+The relations are needed for the client to be able to join data between models, so when introspecting a database with the `prisma` integrity, existing relations are kept in the data model. This has some caveats:
+
+- When a model in the database is deleted, the relation on the other side gets deleted, if existing.
+- When a scalar field used in a relation field gets deleted or renamed, the relation field is kept as-is, leading to validation errors. The user must fix the relation before continuing to use the data model in this case.
+
+Any of the actions only work with `onDelete` for now, the issue to follow for the `onUpdate` counterparts is here:
+
+https://github.com/prisma/prisma/issues/9014
+
+## Handling the integrity with foreign keys
+
+Having the referential integrity handled in the database, all referential actions supported by the database are available:
+
+| action      | `onUpdate` | `onDelete` |
+|:------------|:-----------|:-----------|
+| Restrict⟒   | yes        | yes        |
+| SetNull     | yes        | yes        |
+| SetDefault⟑ | yes        | yes        |
+| Cascade     | yes        | yes        |
+| NoAction    | yes        | yes        |
+
+- ⟒ Not supported on SQL Server
+- ⟑ Not supported on MySQL/InnoDB
+
+In this mode the [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) database queries will trigger actions accordingly.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -20,13 +20,14 @@ In certain cases, either when the database doesn't support foreign keys, or when
 Changing the referential integrity can be done in the [`datasource`](/reference/api-reference/prisma-schema-reference#datasource) block, using the `referentialIntegrity` parameter. The default for all SQL databases is `foreignKeys` and MongoDB defaults to `prisma`, which is the only setting that can be used with the connector.
 
 ```prisma
-datasource ds {
-  provider = "mysql"
-  url = "mysql://"
+datasource db {
+  provider             = "mysql"
+  url                  = "mysql://"
   referentialIntegrity = "prisma"
 }
 
 generator js {
+  provider        = "prisma-client-js"
   previewFeatures = ["referentialIntegrity"]
 }
 ```

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -3,6 +3,7 @@ title: 'Referential integrity'
 metaTitle: 'Referential integrity'
 metaDescription: 'Referential integrity lets you define how the consistency of relations is handled.'
 tocDepth: 2
+preview: true
 ---
 
 <TopBlock>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -22,7 +22,7 @@ Changing the referential integrity can be done in the [`datasource`](/reference/
 ```prisma
 datasource db {
   provider             = "mysql"
-  url                  = "mysql://"
+  url                  = env("DATABASE_URL")
   referentialIntegrity = "prisma"
 }
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -51,7 +51,7 @@ If the integrity is handled by the Prisma Client, for now there will be reduced 
 
 In this mode, any [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) database queries will not trigger any of the actions, and they should be handled manually if deleting or updating records using the [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) queries.
 
-The relations are needed for the client to be able to join data between models, so when introspecting a database with the `prisma` integrity, existing relations are kept in the data model. This has some caveats:
+The relations are needed for the client to be able to join data between models, so when using the `db pull` command to a database with the `prisma` integrity, existing relations are kept in the data model. This has some caveats:
 
 - When a model in the database is deleted, the relation on the other side gets deleted, if existing.
 - When a scalar field used in a relation field gets deleted or renamed, the relation field is kept as-is, leading to validation errors. The user must fix the relation before continuing to use the data model in this case.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -35,9 +35,9 @@ generator js {
 }
 ```
 
-Setting the value to `prisma` removes all foreign keys previously created in the next migration, and handles the integrity in the client. The value `foreignKeys` creates foreign keys to all relations in the next migration, letting the database to handle the integrity.
+Setting the value to `prisma` will remove all foreign keys previously created in the next migration when using Prisma Migrate and the referential integrity will be handled by the client. The value `foreignKeys` creates foreign keys for all relations in the next migration when using Prisma Migrate, letting the database handle the referential integrity.
 
-## Handling the integrity in Prisma
+## Handling the referential integrity in Prisma
 
 If the integrity is handled by the Prisma Client, for now there will be reduced amount of available [referential actions](/concepts/components/prisma-schema/relations/referential-actions) available in the data model:
 
@@ -60,7 +60,7 @@ Any of the actions only work with `onDelete` for now, the issue to follow for th
 
 https://github.com/prisma/prisma/issues/9014
 
-## Handling the integrity with foreign keys
+## Handling the referential integrity with foreign keys
 
 Having the referential integrity handled in the database, all referential actions supported by the database are available:
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -14,11 +14,12 @@ Defines a [data source](/concepts/components/prisma-schema/data-sources) <span c
 
 A `datasource` block accepts the following fields:
 
-| Name                | Required | Type                                                             | Description                                                                                                                                                    |
-| ------------------- | -------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `provider`          | **Yes**  | String (`postgresql`, `mysql`, `sqlite`, `sqlserver`, `mongodb`) | Describes which data source connectors to use.                                                                                                                 |
-| `url`               | **Yes**  | String (URL)                                                     | Connection URL including authentication info. Most connectors use [the syntax provided by the database](/reference/database-reference/connection-urls#format). |
-| `shadowDatabaseUrl` | No       | String (URL)                                                     | Connection URL to the shadow database used by Prisma Migrate. Allows you to use a cloud-hosted database as the shadow database.                                |
+| Name                   | Required | Type                                                             | Description                                                                                                                                                    |
+|------------------------|----------|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `provider`             | **Yes**  | String (`postgresql`, `mysql`, `sqlite`, `sqlserver`, `mongodb`) | Describes which data source connectors to use.                                                                                                                 |
+| `url`                  | **Yes**  | String (URL)                                                     | Connection URL including authentication info. Most connectors use [the syntax provided by the database](/reference/database-reference/connection-urls#format). |
+| `shadowDatabaseUrl`    | No       | String (URL)                                                     | Connection URL to the shadow database used by Prisma Migrate. Allows you to use a cloud-hosted database as the shadow database.                                |
+| `referentialIntegrity` | No       | String (`foreignKeys`, `prisma`)                                 | Allows setting the [referential integrity](/concepts/components/prisma-schema/relations/referential-integrity).                                                |
 
 The following providers are available:
 


### PR DESCRIPTION
Describing the `referentialIntegrity` setting.

[rendered](https://deploy-preview-2336--prisma2-docs.netlify.app/docs/concepts/components/prisma-schema/relations/referential-integrity)