### PR TITLE
update Database seeding script for Next.js

### DIFF
--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -156,7 +156,7 @@ Here we suggest some specific seed scripts for different situations. You are fre
 
    ```ts
    "prisma": {
-     "seed": "ts-node --compiler-options \"{\\\"module\\\":\\\"commonjs\\\"}\" prisma/seed.ts"
+      "seed": "ts-node -O {\"module\":\"CommonJS\"} prisma/seed.ts"
    },
    ```
 


### PR DESCRIPTION
## Describe this PR

The seeding script mentioned in the docs, doesn't work  for Next.js + TS projects and threw an error.  For more details, check out this [issue](https://github.com/prisma/prisma/issues/9211)


## Changes

Update seeding script to work with Next.js

This script doesn't work anymore with Prisma 3

```bash
 "prisma": {
     "seed": "ts-node --compiler-options \"{\\\"module\\\":\\\"commonjs\\\"}\" prisma/seed.ts"
   },
```

After

```bash
   "prisma": {
      "seed": "ts-node -O {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
```

## What issue does this fix?

Fixes this [issue](https://github.com/prisma/prisma/issues/9211)