### PR TITLE
Fix query example for deleting all data with raw SQL

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -942,7 +942,7 @@ for (const {
 } of await prisma.$queryRaw`SELECT tablename FROM pg_tables WHERE schemaname='public'`) {
   if (tablename !== '_prisma_migrations') {
     try {
-      await prisma.$queryRaw(`TRUNCATE TABLE "public"."${tablename}" CASCADE;`)
+      await prisma.$queryRawUnsafe(`TRUNCATE TABLE "public"."${tablename}" CASCADE;`)
     } catch (error) {
       console.log({ error })
     }


### PR DESCRIPTION
## Describe this PR

The example is using `$queryRaw` with a parameter of type `string`, even though the function only accepts a parameter of type `TemplateStringsArray | Sql`. This is incorrect and the execution of this code will not work.

## Changes

Replaced `$queryRaw` with `$queryRawUnsafe` that accepts a `string` as a parameter.
