### PR TITLE
Remove false/outdated note

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
@@ -50,8 +50,6 @@ This command does two things:
 1. It creates a new SQL migration file for this migration
 1. It runs the SQL migration file against the database
 
-> **Note**: `generate` is called under the hood by default, after running `prisma migrate dev`. If the `prisma-client-js` generator is defined in your schema, this will check if `@prisma/client` is installed and install it if it's missing.
-
 Great, you now created three tables in your database with Prisma Migrate 🚀
 
 <SwitchTech technologies={['*', 'postgresql']}>


### PR DESCRIPTION
The note states "Note: generate is called under the hood by default, after running prisma migrate dev. If the prisma-client-js generator is defined in your schema, this will check if @prisma/client is installed and install it if it's missing." however when I ran prisma migrate dev, @prisma/client did not get installed, furthermore installing @prisma/client is actually the next step in the tutorial so this note seems outdated?

## Describe this PR

Note is bunk...running prisma migrate dev doesn't install @prisma/client even though it's defined in the schema provided.

## Changes

Deleted note.

## What issue does this fix?

Removes false/outdated information.

## Any other relevant information

Please let me know if I'm wrong here!
