### PR TITLE
Add note about writes to JSON nullability sections

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -880,6 +880,31 @@ prisma.log.findMany({
 })
 ```
 
+This also applies to create, update and upsert. To insert a `null` value
+into a Json field, you would write:
+
+```ts
+import { Prisma } from '@prisma/client'
+
+prisma.log.create({
+  data: {
+    meta: Prisma.JsonNull,
+  },
+})
+```
+
+And to insert a database `NULL` into a Json field, you would write:
+
+```ts
+import { Prisma } from '@prisma/client'
+
+prisma.log.create({
+  data: {
+    meta: Prisma.DbNull,
+  },
+})
+```
+
 <Admonition type="info">
 
 These null enums do not apply to MongoDB because there is not a difference between a JSON null and a database NULL.

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -868,7 +868,7 @@ model Log {
 }
 ```
 
-```ts
+```ts highlight=6;normal
 import { Prisma } from '@prisma/client'
 
 prisma.log.findMany({
@@ -883,7 +883,7 @@ prisma.log.findMany({
 This also applies to `create`, `update` and `upsert`. To insert a `null` value
 into a `Json` field, you would write:
 
-```ts
+```ts highlight=5;normal
 import { Prisma } from '@prisma/client'
 
 prisma.log.create({
@@ -895,7 +895,7 @@ prisma.log.create({
 
 And to insert a database `NULL` into a Json field, you would write:
 
-```ts
+```ts highlight=5;normal
 import { Prisma } from '@prisma/client'
 
 prisma.log.create({

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -880,8 +880,8 @@ prisma.log.findMany({
 })
 ```
 
-This also applies to create, update and upsert. To insert a `null` value
-into a Json field, you would write:
+This also applies to `create`, `update` and `upsert`. To insert a `null` value
+into a `Json` field, you would write:
 
 ```ts
 import { Prisma } from '@prisma/client'

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
@@ -77,7 +77,7 @@ prisma.log.findMany({
 
 To fix this, you'll import and use one of the new null types:
 
-```ts
+```ts highlight=7;normal
 import { Prisma } from '@prisma/client'
 
 prisma.log.findMany({
@@ -94,7 +94,7 @@ prisma.log.findMany({
 This also applies to `create`, `update` and `upsert`. To insert a `null` value
 into a `Json` field, you would write:
 
-```ts
+```ts highlight=5;normal
 import { Prisma } from '@prisma/client'
 
 prisma.log.create({
@@ -106,7 +106,7 @@ prisma.log.create({
 
 And to insert a database `NULL` into a Json field, you would write:
 
-```ts
+```ts highlight=5;normal
 import { Prisma } from '@prisma/client'
 
 prisma.log.create({

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
@@ -91,6 +91,31 @@ prisma.log.findMany({
 })
 ```
 
+This change also affects create, update and upsert. To insert a `null` value
+into a Json field, you would write:
+
+```ts
+import { Prisma } from '@prisma/client'
+
+prisma.log.create({
+  data: {
+    meta: Prisma.JsonNull,
+  },
+})
+```
+
+And to insert a database `NULL` into a Json field, you would write:
+
+```ts
+import { Prisma } from '@prisma/client'
+
+prisma.log.create({
+  data: {
+    meta: Prisma.DbNull,
+  },
+})
+```
+
 <Admonition type="warning">
 
 This API change does not apply to the MongoDB connector where there is not a difference between a JSON null and a database NULL.

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/index.mdx
@@ -91,8 +91,8 @@ prisma.log.findMany({
 })
 ```
 
-This change also affects create, update and upsert. To insert a `null` value
-into a Json field, you would write:
+This also applies to `create`, `update` and `upsert`. To insert a `null` value
+into a `Json` field, you would write:
 
 ```ts
 import { Prisma } from '@prisma/client'


### PR DESCRIPTION
## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

There was some confusion about using `null` on JSON fields in prisma/prisma#9264

More context: https://prisma-company.slack.com/archives/C016KUHB1R6/p1631899968147800

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->
- Added section to [Working with JSON Fields](https://deploy-preview-2348--prisma2-docs.netlify.app/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values)
- Added section to [Upgrading to Prisma 3](https://deploy-preview-2348--prisma2-docs.netlify.app/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3#json-null-equality)

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

Closes: https://github.com/prisma/prisma/issues/9264
