### PR TITLE
fix: changes wrong field name in the increment example

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4280,7 +4280,7 @@ const updatePosts = await prisma.post.updateMany({
 })
 ```
 
-#### Set all `count` fields of all `Post` records to `0`
+#### Set all `views` fields of all `Post` records to `0`
 
 ```ts
 const updatePosts = await prisma.post.updateMany({


### PR DESCRIPTION
## Describe this PR

It fixes wrong field name in setting value to posts.

## Changes

It changes `count` to `views` field to be consistent with code example below.

## What issue does this fix?

There is no issue for that.

