### PR TITLE
docs: update name of arm64 platform

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -202,8 +202,8 @@ The following tables list all supported operating systems with the name of the b
 
 | Build OS                 | Prisma engine build name  | OpenSSL |
 | :----------------------- | :------------------------ | :-----: |
-| Linux ARM64-based distro | `linux-arm-openssl-1.0.x` |  1.0.x  |
-| Linux ARM64-based distro | `linux-arm-openssl-1.1.x` |  1.1.x  |
+| Linux ARM64-based distro | `linux-arm64-openssl-1.0.x` |  1.0.x  |
+| Linux ARM64-based distro | `linux-arm64-openssl-1.1.x` |  1.1.x  |
 
 ### Examples
 


### PR DESCRIPTION
The name of arm64 platform changed in 3.1 release so this PR updates the platform name. 