### PR TITLE
Add missing field to documentation

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -396,6 +396,8 @@ model CategoriesOnPosts {
   category   Category @relation(fields: [categoryId], references: [id])
   categoryId Int
   assignedAt DateTime @default(now())
+  assignedBy User     @relation(fields: [userId], references: [id])
+  userId     Int
 
   @@id([postId, categoryId])
 }
@@ -404,7 +406,7 @@ model CategoriesOnPosts {
 In this example, the `assignedAt` field stores additional information about the relation between `Post` and `Category`:
 
 - `assignedAt` stores _when_ the post was added to the category
-- `assignedBy` store _who_ added the post to the category
+- `assignedBy` stores _who_ added the post to the category
 
 Note that the same rules as for [1-n-relations](one-to-many-relations) apply (because `Post`↔ `CategoriesOnPosts` and `Category` ↔ `CategoriesOnPosts` are both in fact 1-n-relations), which means one side of the relation needs to be annotated with the `@relation` attribute.
 


### PR DESCRIPTION
Line 409 references an "assignedBy" field that doesn't exist on the model shown.
This change on line 399 adds the assignedBy field to CategoriesOnPosts, as well as the necessary userId field.