### PR TITLE
change orderBy asc to desc in findFirst

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -432,7 +432,7 @@ You can also [paginate your results](pagination).
 
 The following [`findFirst`](/reference/api-reference/prisma-client-reference#findfirst) <span class="api"></span> query returns the _most recently created user_ with at least one post that has more than 100 likes:
 
-1. Order users by ascending ID (largest first) - the largest ID is the most recent
+1. Order users by descending ID (largest first) - the largest ID is the most recent
 2. Return the first user in ascending order with at least one post that has more than 100 likes
 
 ```ts
@@ -447,7 +447,7 @@ The following [`findFirst`](/reference/api-reference/prisma-client-reference#fin
       }
     },
     orderBy: {
-      id: "asc"
+      id: "desc"
     }
   })
 }

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -433,7 +433,7 @@ You can also [paginate your results](pagination).
 The following [`findFirst`](/reference/api-reference/prisma-client-reference#findfirst) <span class="api"></span> query returns the _most recently created user_ with at least one post that has more than 100 likes:
 
 1. Order users by descending ID (largest first) - the largest ID is the most recent
-2. Return the first user in ascending order with at least one post that has more than 100 likes
+2. Return the first user in descending order with at least one post that has more than 100 likes
 
 ```ts
   const findUser = await prisma.user.findFirst({


### PR DESCRIPTION
In findFirst description it stated to fetch the largest ID as it is the most recent but in orderBy it was using asc i.e. lowest first
so changed the orderBy to desc
