### PR TITLE
Typo fix in 07-mongodb.mdx

### DIFF
--- a/content/200-concepts/200-database-connectors/07-mongodb.mdx
+++ b/content/200-concepts/200-database-connectors/07-mongodb.mdx
@@ -47,7 +47,7 @@ Because MongoDB is currently a preview feature, you need to explicitly define th
 ```prisma file=schema.prisma
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["mongoDb"]
+  previewFeatures = ["mongodb"]
 }
 ```
 


### PR DESCRIPTION
## Describe this PR

Fixing a type in the mongodb docs. 

re: 

```
In order to use the mongodb provider,
you need to set the mongodb feature flag.
You can define the feature flag like this:

generator client {
    provider = "prisma-client-js"
    previewFeatures = ["mongodb"]
  }
```
which is printed out from the console when using `mongoDb`.

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

- changed `mongoDb` to `mongodb`
<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

Typo

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
