### PR TITLE
add: Deployment using serverless-webpack in lambda

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -342,7 +342,7 @@ This ensures the packaged archive is as small as possible.
 
 ### Deployment using `serverless-webpack`
 
-If you are using serverless-webpack, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin to automatically remove ``prisma generate`` and **unnecessary engines** to reduce package capacity.
+If you are using serverless-webpack, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin to automatically remove `prisma generate` and **unnecessary engines** to reduce package capacity.
 
 
 First, install the package by entering the following command.

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -340,7 +340,7 @@ package:
 
 This ensures the packaged archive is as small as possible.
 
-### Deployment using ``serverless-webpack``
+### Deployment using `serverless-webpack`
 
 If you are using serverless-webpack, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin to automatically remove ``prisma generate`` and **unnecessary engines** to reduce package capacity.
 

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -344,7 +344,7 @@ But, if you are using `serverless-webpack`, you cannot use that method.
 
 ### Deployment using `serverless-webpack`
 
-If you are using serverless-webpack, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin without any additional configuration.
+If you are using `serverless-webpack`, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin without any additional configuration. `serverless-webpack-prisma` does the following:
 
 
 1. There is no need to separately copy the schema.prisma file via the `webpack plugin`.

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -63,6 +63,12 @@ cd prisma-aws-lambda
 curl https://codeload.github.com/prisma/prisma-examples/tar.gz/latest | tar -xz --strip=3 prisma-examples-latest/deployment-platforms/aws-lambda/
 ```
 
+After downloading the example code, install the dependencies:
+
+```
+npm install
+```
+
 <!-- tar strip folder is a concatenation of the REPOSITORY-BRANCH/REF, e.g. prisma-examples-latest -->
 
 **Checkpoint:** `ls -1` should show:
@@ -78,12 +84,6 @@ package.json
 prisma
 schema.sql
 serverless.yml
-```
-
-After downloading the example code, install the dependencies:
-
-```
-npm install
 ```
 
 ## 2. Set the DATABASE_URL environment variable locally

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -340,18 +340,24 @@ package:
 
 This ensures the packaged archive is as small as possible.
 
+But, if you are using ``serverless-webpack``, you cannot use that method.
+
 ### Deployment using `serverless-webpack`
 
-If you are using serverless-webpack, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin to automatically remove `prisma generate` and **unnecessary engines** to reduce package capacity.
+If you are using serverless-webpack, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin without any additional configuration.
 
 
-First, install the package by entering the following command.
+1. There is no need to separately copy the schema.prisma file via the `webpack plugin`.
+2. There is no need to add `prisma generate` command to webpack options separately.
+3. Except for the Prisma engine used in Lambda, it is automatically deleted. This can save more than 40mb of capacity.
+   
+First, install the dev dependency by entering the following command:
 
 ```sh
 npm install -D serverless-webpack-prisma
 ```
 
-Add the corresponding plugin under the webpack plugin as shown below.
+Add the corresponding plugin under the `serverless-webpack` plugin as shown below.
 
 ```yaml
 plugins:
@@ -359,7 +365,7 @@ plugins:
   - serverless-webpack-prisma
 ```
 
-If you have already used the generate script below, please delete it.
+plugin automatically `prisma generate` so you don't need to use the webpack script option separately as shown below.
 
 ```yaml
 custom:
@@ -367,6 +373,20 @@ custom:
     packagerOptions:
       scripts:
         - prisma generate
+```
+
+If the setting is complete, check whether the engine is normally deleted and distributed through `serverless` deployment as shown below.
+
+```
+Serverless: Copy prisma schema for app...
+Serverless: Generate prisma client for app...
+Serverless: Remove unused prisma engine: 
+Serverless: - node_modules/.prisma/client/libquery_engine-darwin.dylib.node
+Serverless: - node_modules/@prisma/engines/introspection-engine-darwin
+Serverless: - node_modules/@prisma/engines/libquery_engine-darwin.dylib.node
+Serverless: - node_modules/@prisma/engines/migration-engine-darwin
+Serverless: - node_modules/@prisma/engines/prisma-fmt-darwin
+Serverless: Copying existing artifacts...
 ```
 
 ## Summary

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -392,9 +392,9 @@ module.exports = {
 In the case of TypeScript, we also insert the following configuration inside `exports`:
 
 ```javascript file=webpack.config.js
-...
+// ...initial config
 module.exports = {
-  ...
+  // ...initial config
   resolve: { extensions: ['.js', '.ts'] },
   module: {
     rules: [
@@ -405,7 +405,7 @@ module.exports = {
       },
     ],
   }
-  ...
+  // ...initial config
 };
 ```
 

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -375,7 +375,7 @@ custom:
         - prisma generate
 ```
 
-If the setting is complete, check whether the engine is normally deleted and distributed through `serverless` deployment as shown below.
+Once you've updated your `serverless.yml` file, redeploy your application to check whether the right engine is packaged and distributed by running `serverless deploy` as shown below.
 
 ```
 Serverless: Copy prisma schema for app...

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -340,7 +340,7 @@ package:
 
 This ensures the packaged archive is as small as possible.
 
-But, if you are using ``serverless-webpack``, you cannot use that method.
+But, if you are using `serverless-webpack`, you cannot use that method.
 
 ### Deployment using `serverless-webpack`
 

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -364,9 +364,9 @@ If the project includes TypeScript, ts-loader must also be installed.
 npm install -D ts-loader
 ```
 
-Next, create an <FileWithIcon text="webpack.config.js" icon="file"/> file in the project root directory and enter the following contents.
+Next, create a `webpack.config.js` file in the project root directory and enter the following contents.
 
-```javascript
+```javascript file=webpack.config.js
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path')
 const nodeExternals = require('webpack-node-externals')
@@ -379,6 +379,7 @@ module.exports = {
   entry: slsw.lib.entries,
   externals: [nodeExternals()],
   mode: isLocal ? 'development' : 'production',
+  optimization: { concatenateModules: false },
   resolve: { extensions: ['.js'] },
   output: {
     libraryTarget: 'commonjs',
@@ -390,10 +391,11 @@ module.exports = {
 
 In the case of TypeScript, we also insert the following configuration inside `exports`:
 
-```javascript
-...skip
+```javascript file=webpack.config.js
+...
 module.exports = {
-  ...skip
+  ...
+  resolve: { extensions: ['.js', '.ts'] },
   module: {
     rules: [
       {
@@ -403,7 +405,7 @@ module.exports = {
       },
     ],
   }
-  ...skip
+  ...
 };
 ```
 
@@ -414,25 +416,40 @@ Various settings can be checked in [Serverless Webpack](https://www.serverless.c
 Install the dev dependency by entering the following command:
 
 ```sh
-npm install -D serverless-webpack-prisma
+npm install -D serverless-webpack-prisma serverless
 ```
 
 Add the corresponding plugin under the `serverless-webpack` plugin as shown below.
 
-```yaml
+```yaml file=serverless.yaml
 plugins:
   - serverless-webpack
   - serverless-webpack-prisma
+
+custom:
+  webpack:
+    includeModules: true
 ```
 
 plugin automatically `prisma generate` so you don't need to use the webpack script option separately as shown below.
 
-```yaml
+```yaml file=serverless.yaml
 custom:
   webpack:
     packagerOptions:
       scripts:
         - prisma generate
+```
+
+unnecessary resources are also deleted by the plugin, so there is no need to add a package.patterns to `serverless.yml` as shown below.
+
+```yaml file=serverless.yml
+package:
+  patterns:
+    - '!node_modules/.prisma/client/libquery_engine-*'
+    - 'node_modules/.prisma/client/libquery_engine-rhel-*'
+    - '!node_modules/prisma/libquery_engine-*'
+    - '!node_modules/@prisma/engines/**'
 ```
 
 Once you've updated your `serverless.yml` file, redeploy your application to check whether the right engine is packaged and distributed by running `serverless deploy` as shown below.

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -346,25 +346,25 @@ But, if you are using `serverless-webpack`, you cannot use that method.
 
 If you are using `serverless-webpack`, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin without any additional configuration. `serverless-webpack-prisma` does the following:
 
-1. Copies your schema.prisma via the Webpack plugin
+1. Copies your `schema.prisma` via the Webpack plugin
 2. Runs the `prisma generate` command. This means there is no need to add the command to the webpack options separately
 3. Packages the correct Prisma engine used in the Lambda. This can save more than 40mb of capacity.
 
 <details><summary>If you are not using webpack yet</summary>
 
-Install packages to use `webpack`.
+Install dependencies.
 
 ```sh
 npm install -D webpack serverless-webpack webpack-node-externals
 ```
 
-If the project includes TypeScript, ts-loader must also be installed.
+Install`ts-loader` if your project uses TypeScript.
 
 ```sh
 npm install -D ts-loader
 ```
 
-Next, create a `webpack.config.js` file in the project root directory and enter the following contents.
+Next, create a `webpack.config.js` file in the project root directory and copy and paste the following configuration.
 
 ```javascript file=webpack.config.js
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -409,7 +409,7 @@ module.exports = {
 };
 ```
 
-Various settings can be checked in [Serverless Webpack](https://www.serverless.com/plugins/serverless-webpack).
+Refer to the [Serverless Webpack documentation](https://www.serverless.com/plugins/serverless-webpack) for additional configuration.
 
 </details>
 
@@ -419,9 +419,9 @@ Install the dev dependency by entering the following command:
 npm install -D serverless-webpack-prisma serverless
 ```
 
-Add the corresponding plugin under the `serverless-webpack` plugin as shown below.
+Update your `serverless.yml` by adding the `serverless-webpack` to the plugins list. 
 
-```yaml file=serverless.yaml
+```yaml file=serverless.yml
 plugins:
   - serverless-webpack
   - serverless-webpack-prisma
@@ -433,7 +433,7 @@ custom:
 
 `serverless-webpack-prisma` automatically runs `prisma generate` so you don't need to use the webpack script option separately as shown below.
 
-```yaml file=serverless.yaml
+```yaml file=serverless.yml
 custom:
   webpack:
     packagerOptions:
@@ -441,7 +441,7 @@ custom:
         - prisma generate
 ```
 
-unnecessary resources are also deleted by the plugin, so there is no need to add a package.patterns to `serverless.yml` as shown below.
+`serverless-webpack-prisma` removes the unnecessary dependencies and packages the right Prisma engine to be used in your Lambda. Therefore, delete it in the `package.patterns` configuration in your `serverless.yml` file.
 
 ```yaml file=serverless.yml
 package:
@@ -452,7 +452,7 @@ package:
     - '!node_modules/@prisma/engines/**'
 ```
 
-Once you've updated your `serverless.yml` file, redeploy your application to check whether the right engine is packaged and distributed by running `serverless deploy` as shown below.
+Once you've updated your `serverless.yml` file, redeploy your application by running `serverless deploy`. The deployment output will show you the correct Prisma Engine is packaged and distributed.
 
 ```
 Serverless: Copy prisma schema for app...

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -340,6 +340,35 @@ package:
 
 This ensures the packaged archive is as small as possible.
 
+### Deployment using ``serverless-webpack``
+
+If you are using serverless-webpack, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin to automatically remove ``prisma generate`` and **unnecessary engines** to reduce package capacity.
+
+
+First, install the package by entering the following command.
+
+```sh
+npm install -D serverless-webpack-prisma
+```
+
+Add the corresponding plugin under the webpack plugin as shown below.
+
+```yaml
+plugins:
+  - serverless-webpack
+  - serverless-webpack-prisma
+```
+
+If you have already used the generate script below, please delete it.
+
+```yaml
+custom:
+  webpack:
+    packagerOptions:
+      scripts:
+        - prisma generate
+```
+
 ## Summary
 
 Congratulations! You have successfully deployed the API to AWS Lambda.

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -346,11 +346,10 @@ But, if you are using `serverless-webpack`, you cannot use that method.
 
 If you are using `serverless-webpack`, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin without any additional configuration. `serverless-webpack-prisma` does the following:
 
+1. Copies your schema.prisma via the Webpack plugin
+2. Runs the `prisma generate` command. This means there is no need to add the command to the webpack options separately
+3. Packages the correct Prisma engine used in the Lambda. This can save more than 40mb of capacity.
 
-1. There is no need to separately copy the schema.prisma file via the `webpack plugin`.
-2. There is no need to add `prisma generate` command to webpack options separately.
-3. Except for the Prisma engine used in Lambda, it is automatically deleted. This can save more than 40mb of capacity.
-   
 First, install the dev dependency by entering the following command:
 
 ```sh
@@ -380,7 +379,7 @@ Once you've updated your `serverless.yml` file, redeploy your application to che
 ```
 Serverless: Copy prisma schema for app...
 Serverless: Generate prisma client for app...
-Serverless: Remove unused prisma engine: 
+Serverless: Remove unused prisma engine:
 Serverless: - node_modules/.prisma/client/libquery_engine-darwin.dylib.node
 Serverless: - node_modules/@prisma/engines/introspection-engine-darwin
 Serverless: - node_modules/@prisma/engines/libquery_engine-darwin.dylib.node

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -431,7 +431,7 @@ custom:
     includeModules: true
 ```
 
-plugin automatically `prisma generate` so you don't need to use the webpack script option separately as shown below.
+`serverless-webpack-prisma` automatically runs `prisma generate` so you don't need to use the webpack script option separately as shown below.
 
 ```yaml file=serverless.yaml
 custom:

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -350,7 +350,68 @@ If you are using `serverless-webpack`, you can use the [serverless-webpack-prism
 2. Runs the `prisma generate` command. This means there is no need to add the command to the webpack options separately
 3. Packages the correct Prisma engine used in the Lambda. This can save more than 40mb of capacity.
 
-First, install the dev dependency by entering the following command:
+<details><summary>If you are not using webpack yet</summary>
+
+Install packages to use `webpack`.
+
+```sh
+npm install -D webpack serverless-webpack webpack-node-externals
+```
+
+If the project includes TypeScript, ts-loader must also be installed.
+
+```sh
+npm install -D ts-loader
+```
+
+Next, create an <FileWithIcon text="webpack.config.js" icon="file"/> file in the project root directory and enter the following contents.
+
+```javascript
+/* eslint-disable @typescript-eslint/no-var-requires */
+const path = require('path')
+const nodeExternals = require('webpack-node-externals')
+const slsw = require('serverless-webpack')
+const { isLocal } = slsw.lib.webpack
+
+module.exports = {
+  target: 'node',
+  stats: 'normal',
+  entry: slsw.lib.entries,
+  externals: [nodeExternals()],
+  mode: isLocal ? 'development' : 'production',
+  resolve: { extensions: ['.js'] },
+  output: {
+    libraryTarget: 'commonjs',
+    filename: '[name].js',
+    path: path.resolve(__dirname, '.webpack'),
+  },
+}
+```
+
+In the case of TypeScript, we also insert the following configuration inside `exports`:
+
+```javascript
+...skip
+module.exports = {
+  ...skip
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  }
+  ...skip
+};
+```
+
+Various settings can be checked in [Serverless Webpack](https://www.serverless.com/plugins/serverless-webpack).
+
+</details>
+
+Install the dev dependency by entering the following command:
 
 ```sh
 npm install -D serverless-webpack-prisma


### PR DESCRIPTION
## Describe this PR

When deploying using serverless-webpack , it is impossible to deploy except for a specific engine using package.pattern as in the documentation. So, the Lambda engine capacity reached almost 80MB, which made it impossible to deploy.

## Changes

- The serverless-webpack-prisma library was developed separately to make it easier to use.
- Documentation has been added so that all users who use serverless-webpack can use Prisma smoothly.

## What issue does this fix?

- https://github.com/prisma/prisma/issues/6644
- https://github.com/prisma/prisma/issues/2303

## Any other relevant information

None!