### PR TITLE
mistake: table name missed

### DIFF
--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
@@ -132,7 +132,7 @@ With the _expand and contract_ pattern, renaming the field `bio` to `biography` 
    ```
 
    ```sql file=prisma/migrations/20210420000000_copy_biography/migration.sql
-   UPDATE table SET biography = bio;
+   UPDATE "Profile" SET biography = bio;
    ```
 
 4. Verify the integrity of the `biography` field in the database


### PR DESCRIPTION
UPDATE table SET biography = bio; => UPDATE "Profile" SET biography = bio;

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
