### PR TITLE
Update 055-aggregation-grouping-summarizing.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
@@ -252,7 +252,7 @@ The following constraints apply when you combine `groupBy` and `orderBy`:
 
 #### Order by aggregate group
 
-You can **order by aggregate group**. Prisma added support for using the ORDER BY clause with aggregated groups in relational databases in version [2.21.0](https://github.com/prisma/prisma/releases/2.21.0) and support for MongoDB in [3.3.4](https://github.com/prisma/prisma/releases/3.4.0). 
+You can **order by aggregate group**. Prisma added support for using `orderBy with aggregated groups in relational databases in version [2.21.0](https://github.com/prisma/prisma/releases/2.21.0) and support for MongoDB in [3.3.4](https://github.com/prisma/prisma/releases/3.4.0). 
 
 The following example sorts each `city` group by the number of users in that group (largest group first):
 

--- a/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
@@ -252,7 +252,7 @@ The following constraints apply when you combine `groupBy` and `orderBy`:
 
 #### Order by aggregate group
 
-You can **order by aggregate group**. Prisma added support for using `orderBy with aggregated groups in relational databases in version [2.21.0](https://github.com/prisma/prisma/releases/2.21.0) and support for MongoDB in [3.3.4](https://github.com/prisma/prisma/releases/3.4.0). 
+You can **order by aggregate group**. Prisma added support for using `orderBy with aggregated groups in relational databases in version [2.21.0](https://github.com/prisma/prisma/releases/2.21.0) and support for MongoDB in [3.4.0](https://github.com/prisma/prisma/releases/3.4.0). 
 
 The following example sorts each `city` group by the number of users in that group (largest group first):
 


### PR DESCRIPTION
Rewrote the new section about using `orderBy` with aggregate groups, to avoid the SQL-specific term `ORDER BY`.