### PR TITLE
Add warning about main env file

### DIFF
--- a/content/300-guides/125-development-environment/050-environment-variables/200-using-multiple-env-files.mdx
+++ b/content/300-guides/125-development-environment/050-environment-variables/200-using-multiple-env-files.mdx
@@ -20,6 +20,12 @@ One solution is to have multiple `.env` files which each represent different env
 
 </Admonition>
 
+<Admonition type="warning">
+
+When using multiple `.env` files you have to remove your main `.env` file because otherwise it will still be read.
+  
+</Admonition>
+
 Then using a package like [`dotenv-cli`](https://www.npmjs.com/package/dotenv-cli), you can load the correct connection URL for the environment you are working in.
 
 </TopBlock>


### PR DESCRIPTION
## Describe this PR

I have had a `.env` and a `.env.test` file and when executing `dotenv -e .env.test -- npx prisma migrate dev` then Prisma was sill prefering the `.env` file over my `.env.test` file. That's why I suggest to highlight that the main `.env` file has to be removed.

## Changes

I added an admonition.

## What issue does this fix?

Spending time on finding it out yourself.

## Any other relevant information

No.
