### PR TITLE
Update 01-migrate-from-typeorm.mdx

### DIFF
--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -1081,6 +1081,6 @@ This would also result in a more ergonomic and less verbose Prisma Client API to
 
 <Admonition type="warning">
   
-Some providers like DigitalOcean enforce primary keys on all tables for replication. In such a case, the user would have to switch to the explicit syntax, and manually create the join model with a primary key. This is because Join tables created by Prisma for many-to-many relations using implicit syntax in Prisma Schema do not have primary keys. 
+If your database provider requires tables to have primary keys, you have to use explicit syntax, and manually create the join model with a primary key. This is because relation tables (JOIN tables) created by Prisma (expressed via `@relation`) for many-to-many relations using implicit syntax in Prisma Schema do not have primary keys. 
   
 </Admonition>

--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -1081,6 +1081,6 @@ This would also result in a more ergonomic and less verbose Prisma Client API to
 
 <Admonition type="warning">
   
-If your database provider requires tables to have primary keys, you have to use explicit syntax, and manually create the join model with a primary key. This is because relation tables (JOIN tables) created by Prisma (expressed via `@relation`) for many-to-many relations using implicit syntax in Prisma Schema do not have primary keys. 
+If your database provider requires tables to have primary keys then you have to use explicit syntax, and manually create the join model with a primary key. This is because relation tables (JOIN tables) created by Prisma (expressed via `@relation`) for many-to-many relations using implicit syntax do not have primary keys. 
   
 </Admonition>

--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -1078,3 +1078,7 @@ model Post {
 ```
 
 This would also result in a more ergonomic and less verbose Prisma Client API to modify the records in this relation, because you have a direct path from `Post` to `Category` (and the other way around) instead of needing to traverse the `PostToCategories` model first.
+
+<Admonition type="warning">
+If your database provider automatically creates a primary key, and you want to use m-n relations, you need to use explicit relation syntax, manually create the join model, and verify that this join model has a primary key. This is because Join tables created by Prisma for m-n relations using implicit syntax in Prisma Schema do not have primary keys. 
+</Admonition>

--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -1081,6 +1081,6 @@ This would also result in a more ergonomic and less verbose Prisma Client API to
 
 <Admonition type="warning">
   
-If your database provider automatically creates a primary key, and you want to use m-n relations, you need to use explicit relation syntax, manually create the join model, and verify that this join model has a primary key. This is because Join tables created by Prisma for m-n relations using implicit syntax in Prisma Schema do not have primary keys. 
+Some providers like DigitalOcean enforce primary keys on all tables for replication. In such a case, the user would have to switch to the explicit syntax, and manually create the join model with a primary key. This is because Join tables created by Prisma for many-to-many relations using implicit syntax in Prisma Schema do not have primary keys. 
   
 </Admonition>

--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -1080,5 +1080,7 @@ model Post {
 This would also result in a more ergonomic and less verbose Prisma Client API to modify the records in this relation, because you have a direct path from `Post` to `Category` (and the other way around) instead of needing to traverse the `PostToCategories` model first.
 
 <Admonition type="warning">
+  
 If your database provider automatically creates a primary key, and you want to use m-n relations, you need to use explicit relation syntax, manually create the join model, and verify that this join model has a primary key. This is because Join tables created by Prisma for m-n relations using implicit syntax in Prisma Schema do not have primary keys. 
+  
 </Admonition>


### PR DESCRIPTION
Added warning at the bottom of this topic, in section about implicit syntax is m-n relations, about the enforced primary key issue. See [Issue #958](https://github.com/prisma/docs/issues/958).
