### PR TITLE
Make join table names consistent in 300-many-to-many-relations.mdx

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -29,16 +29,16 @@ In this example, the model representing the relation table **defines additional 
 model Post {
   id         Int                 @id @default(autoincrement())
   title      String
-  categories CategoryToPost[]
+  categories CategoriesOnPosts[]
 }
 
 model Category {
   id    Int                 @id @default(autoincrement())
   name  String
-  posts CategoryToPost[]
+  posts CategoriesOnPosts[]
 }
 
-model CategoryToPost {
+model CategoriesOnPosts {
   post       Post     @relation(fields: [postId], references: [id])
   postId     Int // relation scalar field (used in the `@relation` attribute above)
   category   Category @relation(fields: [categoryId], references: [id])
@@ -60,7 +60,7 @@ CREATE TABLE "Post" (
     id SERIAL PRIMARY KEY
 );
 -- Relation table + indexes -------------------------------------------------------
-CREATE TABLE "CategoryToPost" (
+CREATE TABLE "CategoriesOnPosts" (
     "categoryId" integer NOT NULL,
     "postId" integer NOT NULL,
     "assignedBy" text NOT NULL
@@ -68,17 +68,17 @@ CREATE TABLE "CategoryToPost" (
     FOREIGN KEY ("categoryId")  REFERENCES "Category"(id),
     FOREIGN KEY ("postId") REFERENCES "Post"(id)
 );
-CREATE UNIQUE INDEX "CategoryToPost_category_post_unique" ON "CategoryToPost"("categoryId" int4_ops,"postId" int4_ops);
+CREATE UNIQUE INDEX "CategoriesOnPosts_category_post_unique" ON "CategoriesOnPosts"("categoryId" int4_ops,"postId" int4_ops);
 ```
 
 #### Querying an explicit many-to-many
 
-The following section demonstrates how to query an explicit many-to-many relation. You can query the relation model directly (`prisma.categoryToPost(...)`), or use nested queries to go from `Post` -> `CategoryToPost` -> `Category` or the other way.
+The following section demonstrates how to query an explicit many-to-many relation. You can query the relation model directly (`prisma.categoriesOnPosts(...)`), or use nested queries to go from `Post` -> `CategoriesOnPosts` -> `Category` or the other way.
 
 The following query:
 
 1. Creates a `Post`
-2. Creates a category assigment, or `CategoryToPost` (assigned by Bob, assigned today)
+2. Creates a category assigment, or `CategoriesOnPosts` (assigned by Bob, assigned today)
 3. Creates a new `Category`
 
 ```ts
@@ -105,7 +105,7 @@ const createCategory = await prisma.post.create({
 The following query:
 
 - Creates a new `Post`
-- Creates a new category assignment, or `CategoryToPost`
+- Creates a new category assignment, or `CategoriesOnPosts`
 - Connects the category assignment to existing categories (with IDs `9` and `22`)
 
 ```ts
@@ -173,7 +173,7 @@ const getAssignments = await prisma.category.findMany({
 })
 ```
 
-The following query gets all category assignments (`CategoryToPost`) records that were assigned by `"Bob"` to one of 5 posts:
+The following query gets all category assignments (`CategoriesOnPosts`) records that were assigned by `"Bob"` to one of 5 posts:
 
 ```ts
 const getAssignments = await prisma.categoriesOnPosts.findMany({
@@ -375,22 +375,22 @@ When using Prisma, you can create relation tables by defining [models](/concepts
 
 Relation tables are also often used to add "meta-information" to a relation. For example, to store _when_ the relation was created.
 
-Here is an example for a relation table called `CategoryToPost`:
+Here is an example for a relation table called `CategoriesOnPosts`:
 
 ```prisma
 model Post {
   id         Int                 @id @default(autoincrement())
   title      String
-  categories CategoryToPost[]
+  categories CategoriesOnPosts[]
 }
 
 model Category {
   id    Int                 @id @default(autoincrement())
   name  String
-  posts CategoryToPost[]
+  posts CategoriesOnPosts[]
 }
 
-model CategoryToPost {
+model CategoriesOnPosts {
   post       Post     @relation(fields: [postId], references: [id])
   postId     Int
   category   Category @relation(fields: [categoryId], references: [id])

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -375,7 +375,7 @@ When using Prisma, you can create relation tables by defining [models](/concepts
 
 Relation tables are also often used to add "meta-information" to a relation. For example, to store _when_ the relation was created.
 
-Here is an example for a relation table called `CategoriesToPost`:
+Here is an example for a relation table called `CategoryToPost`:
 
 ```prisma
 model Post {

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -29,16 +29,16 @@ In this example, the model representing the relation table **defines additional 
 model Post {
   id         Int                 @id @default(autoincrement())
   title      String
-  categories CategoriesOnPosts[]
+  categories CategoryToPost[]
 }
 
 model Category {
   id    Int                 @id @default(autoincrement())
   name  String
-  posts CategoriesOnPosts[]
+  posts CategoryToPost[]
 }
 
-model CategoriesOnPosts {
+model CategoryToPost {
   post       Post     @relation(fields: [postId], references: [id])
   postId     Int // relation scalar field (used in the `@relation` attribute above)
   category   Category @relation(fields: [categoryId], references: [id])
@@ -73,7 +73,7 @@ CREATE UNIQUE INDEX "CategoryToPost_category_post_unique" ON "CategoryToPost"("c
 
 #### Querying an explicit many-to-many
 
-The following section demonstrates how to query an explicit many-to-many relation. You can query the relation model directly (`prisma.categoryOnPost(...)`), or use nested queries to go from `Post` -> `CategoryOnPost` -> `Category` or the other way.
+The following section demonstrates how to query an explicit many-to-many relation. You can query the relation model directly (`prisma.categoryToPost(...)`), or use nested queries to go from `Post` -> `CategoryToPost` -> `Category` or the other way.
 
 The following query:
 
@@ -173,7 +173,7 @@ const getAssignments = await prisma.category.findMany({
 })
 ```
 
-The following query gets all category assignments (`CategoryOnPost`) records that were assigned by `"Bob"` to one of 5 posts:
+The following query gets all category assignments (`CategoryToPost`) records that were assigned by `"Bob"` to one of 5 posts:
 
 ```ts
 const getAssignments = await prisma.categoriesOnPosts.findMany({
@@ -375,22 +375,22 @@ When using Prisma, you can create relation tables by defining [models](/concepts
 
 Relation tables are also often used to add "meta-information" to a relation. For example, to store _when_ the relation was created.
 
-Here is an example for a relation table called `CategoriesOnPosts`:
+Here is an example for a relation table called `CategoriesToPost`:
 
 ```prisma
 model Post {
   id         Int                 @id @default(autoincrement())
   title      String
-  categories CategoriesOnPosts[]
+  categories CategoryToPost[]
 }
 
 model Category {
   id    Int                 @id @default(autoincrement())
   name  String
-  posts CategoriesOnPosts[]
+  posts CategoryToPost[]
 }
 
-model CategoriesOnPosts {
+model CategoryToPost {
   post       Post     @relation(fields: [postId], references: [id])
   postId     Int
   category   Category @relation(fields: [categoryId], references: [id])


### PR DESCRIPTION
## Describe this PR

I noticed there was a mix of using `CategoriesOnPosts`, `CategoryOnPost` and `CategoryToPost` for the example join table. I've updated these to be consistent - though could maybe do with a technical review to check I've picked the right one!

## Changes

Renamed join table to `CategoryToPost`throughout.

## What issue does this fix?



## Any other relevant information


