### PR TITLE
Add Node.js 16.X support

### DIFF
--- a/content/400-reference/100-system-requirements.mdx
+++ b/content/400-reference/100-system-requirements.mdx
@@ -9,7 +9,7 @@ The [latest version of Prisma](https://www.npmjs.com/package/@prisma/client) req
 
 |                       | Minimum required version |
 | :-------------------- | :----------------------- |
-| Node.js               | 12.6.X / 14.X            |
+| Node.js               | 12.6.X / 14.X / 16.X     |
 | TypeScript (optional) | 4.1.X                    |
 | Yarn (optional)       | 1.19.2                   |
 


### PR DESCRIPTION
Since Node.js 16 is now LTS
>Prisma supports and tests all _Active LTS_ and _Maintenance LTS_ **Node.js** releases.
