### PR TITLE
fix: some ineffective finally clauses

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -76,11 +76,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database.mdx
@@ -25,11 +25,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -49,11 +51,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/250-querying-the-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/250-querying-the-database.mdx
@@ -27,11 +27,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -53,11 +55,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database.mdx
@@ -29,11 +29,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -53,11 +55,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database.mdx
@@ -31,11 +31,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -57,11 +59,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -232,11 +232,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
+  .then(async () => {
+    await prisma.$disconnect()
   })
-  .finally(async () => {
-    await prisma.disconnect()
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/100-connection-management.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/100-connection-management.mdx
@@ -71,11 +71,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -220,11 +220,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -161,9 +161,13 @@ async function main() {
 }
 
 main()
-  .catch(console.error)
-  .finally(() => {
-    prisma.$disconnect()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -226,7 +226,7 @@ Here we suggest some specific seed scripts for different situations. You are fre
       .then(async () => {
         await prisma.$disconnect()
       })
-      .catch((e) => {
+      .catch(async (e) => {
         console.error(e)
         await prisma.$disconnect()
         process.exit(1)

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -116,12 +116,13 @@ Here we suggest some specific seed scripts for different situations. You are fre
     }
 
     main()
-      .catch((e) => {
-        console.error(e)
-        process.exit(1)
-      })
-      .finally(async () => {
+      .then(async () => {
         await prisma.$disconnect()
+      })
+      .catch(async (e) => {
+        console.error(e)
+        await prisma.$disconnect()
+        process.exit(1)
       })
     ```
 
@@ -222,12 +223,13 @@ Here we suggest some specific seed scripts for different situations. You are fre
     }
 
     main()
+      .then(async () => {
+        await prisma.$disconnect()
+      })
       .catch((e) => {
         console.error(e)
-        process.exit(1)
-      })
-      .finally(async () => {
         await prisma.$disconnect()
+        process.exit(1)
       })
     ```
 

--- a/content/300-guides/050-database/900-advanced-database-tasks/08-sql-views.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/08-sql-views.mdx
@@ -595,11 +595,13 @@ In the following section, you will use the `drafts` model property to return `Po
    }
 
    main()
-     .catch((e) => {
-       throw e
-     })
-     .finally(async () => {
+     .then(async () => {
        await prisma.$disconnect()
+     })
+     .catch(async (e) => {
+       console.error(e)
+       await prisma.$disconnect()
+       process.exit(1)
      })
    ```
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -884,9 +884,13 @@ async function main() {
 }
 
 main()
-  .catch(console.error)
-  .finally(() => {
-    prisma.$disconnect()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/150-referential-actions.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/150-referential-actions.mdx
@@ -152,11 +152,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -187,10 +189,12 @@ async function main() {
 }
 
 main()
-  .catch(e => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -184,11 +184,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -227,11 +229,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -286,11 +290,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 
@@ -792,11 +798,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 

--- a/content/500-support/050-creating-bug-reports.mdx
+++ b/content/500-support/050-creating-bug-reports.mdx
@@ -95,11 +95,13 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    throw e
-  })
-  .finally(async () => {
+  .then(async () => {
     await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
   })
 ```
 


### PR DESCRIPTION
## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

Code snippets for short living scripts have ineffective finally chain.

```ts
(async()=>{ console.log(1); throw 1 })()
  .catch(() => { console.log(2); process.exit(1) })  // or re-throw.
  .finally(() => { console.log(3) }) // unreachable
```

Finally clause with unsafe catch clause has no effect as _finally_. (It's run when no error, but if it's desired, `.then` is enough.)

I chosen the style below.

```ts
  .then(async () => {
    await prisma.$disconnect()
  })
  .catch(async (e) => {
    console.error(e)
    await prisma.$disconnect()
    process.exit(1)
  })
```

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
