### PR TITLE
Restructure "connection urls"

### DIFF
--- a/content/400-reference/300-database-reference/02-connection-urls.mdx
+++ b/content/400-reference/300-database-reference/02-connection-urls.mdx
@@ -21,6 +21,20 @@ Make sure you have this information at hand when getting started with Prisma. If
 
 </TopBlock>
 
+## Format
+
+The format of the connection URL depends on the _database connector_ you're using. Prisma generally supports the standard formats for each database. You can find out more about the connection URL of your database on the dedicated docs page:
+
+- [PostgreSQL](/concepts/database-connectors/postgresql)
+- [MySQL](/concepts/database-connectors/mysql)
+- [SQLite](/concepts/database-connectors/sqlite)
+- [MongoDB](/concepts/database-connectors/mongodb)
+- [Microsoft SQL Server](/concepts/database-connectors/sql-server)
+
+### Special characters
+
+For MySQL and PostgreSQL, you must percentage-encode special characters in any part of your connection URL - including passwords. For example, `p@$$w0rd` becomes `p%40%24%24w0rd`.
+
 ## Examples
 
 Here are examples for the connection URLs of the databases Prisma supports:
@@ -30,7 +44,7 @@ Here are examples for the connection URLs of the databases Prisma supports:
 ```prisma file=schema.prisma
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://janedoe:mypassword@localhost:5432/mydb"
+  url      = "postgresql://janedoe:mypassword@localhost:5432/mydb?schema=sample"
 }
 ```
 
@@ -92,16 +106,4 @@ You can then either set the environment variable in your terminal or by providin
 DATABASE_URL=postgresql://janedoe:mypassword@localhost:5432/mydb
 ```
 
-## Format
 
-The format of the connection URL depends on the _database connector_ you're using. Prisma generally supports the standard formats for each database. You can find out more about the connection URL of your database on the dedicated docs page:
-
-- [PostgreSQL](/concepts/database-connectors/postgresql)
-- [MySQL](/concepts/database-connectors/mysql)
-- [SQLite](/concepts/database-connectors/sqlite)
-- [MongoDB](/concepts/database-connectors/mongodb)
-- [Microsoft SQL Server](/concepts/database-connectors/sql-server)
-
-### Special characters
-
-For MySQL and PostgreSQL, you must percentage-encode special characters in any part of your connection URL - including passwords. For example, `p@$$w0rd` becomes `p%40%24%24w0rd`.

--- a/content/400-reference/300-database-reference/02-connection-urls.mdx
+++ b/content/400-reference/300-database-reference/02-connection-urls.mdx
@@ -33,7 +33,7 @@ The format of the connection URL depends on the _database connector_ you're usin
 
 ### Special characters
 
-For MySQL and PostgreSQL, you must percentage-encode special characters in any part of your connection URL - including passwords. For example, `p@$$w0rd` becomes `p%40%24%24w0rd`.
+For MySQL and PostgreSQL, you must [percentage-encode special characters](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding) in any part of your connection URL - including passwords. For example, `p@$$w0rd` becomes `p%40%24%24w0rd`.
 
 ## Examples
 


### PR DESCRIPTION
Link to provider specific format pages first, then examples.
Also add a schema to Postgres Example.

Related: https://github.com/prisma/prisma/issues/2983#issuecomment-963418548
