### PR TITLE
Change wrong filename types.ts to context.ts

### DIFF
--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/05-upgrading-prisma-binding-to-nexus.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/05-upgrading-prisma-binding-to-nexus.mdx
@@ -157,12 +157,12 @@ new GraphQLServer({ schema, context: createContext() }).start(() =>
 
 Note that this setup already contains the configuration of the Prisma plugin for Nexus. This will enable the `t.model` and `t.crud` functionality that you'll get to know later in this guide.
 
-In the `typegenAutoConfig` setting, you're providing additional types that help your editor to provide your autocompletion as you develop your app. Right now it references a file named `types.ts` that you don't have in your project yet. This file will contain the type of your `context` object that's passed through your GraphQL resolver chain.
+In the `typegenAutoConfig` setting, you're providing additional types that help your editor to provide your autocompletion as you develop your app. Right now it references a file named `context.ts` that you don't have in your project yet. This file will contain the type of your `context` object that's passed through your GraphQL resolver chain.
 
-Create the new `types.ts` file inside the `src` directory:
+Create the new `context.ts` file inside the `src` directory:
 
 ```terminal copy
-touch src/types.ts
+touch src/context.ts
 ```
 
 Now add the following code to it:


### PR DESCRIPTION
There are references to `types.ts` but the actual file should be called `context.ts`


## What issue does this fix?
Fixes https://github.com/prisma/docs/issues/1342

