### PR TITLE
remove mention of dotenv associated with DEBUG

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
@@ -12,7 +12,7 @@ You can enable debugging output in Prisma Client via the [`DEBUG`](/reference/ap
 - `prisma:client`: Prints relevant debug messages happening in the Prisma Client runtime
 - `prisma*`: Prints all debug messages from Prisma Client or CLI
 - `*`: Prints all debug messages
-  
+
 <Admonition type="info">
 
 Prisma Client can be configured to log warnings, errors and information related to queries sent to the database. See [Configuring logging](./working-with-prismaclient/logging) for more information.

--- a/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/140-debugging.mdx
@@ -11,8 +11,8 @@ You can enable debugging output in Prisma Client via the [`DEBUG`](/reference/ap
 - `prisma:engine`: Prints relevant debug messages happening in a Prisma [engine](https://github.com/prisma/prisma-engines/)
 - `prisma:client`: Prints relevant debug messages happening in the Prisma Client runtime
 - `prisma*`: Prints all debug messages from Prisma Client or CLI
-- `*`: Prints all debug messages, including external sources such as `dotenv`
-
+- `*`: Prints all debug messages
+  
 <Admonition type="info">
 
 Prisma Client can be configured to log warnings, errors and information related to queries sent to the database. See [Configuring logging](./working-with-prismaclient/logging) for more information.


### PR DESCRIPTION
Related https://github.com/prisma/prisma/issues/9428

## Describe this PR

Not relevant anymore with 3.5.0 and not really worth to mention that it was available in a previous version I think