### PR TITLE
add prisma-tql-types-gen

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
@@ -67,6 +67,7 @@ The following is a list of community created generators.
 - [`prisma-docs-generator`](https://github.com/pantharshit00/prisma-docs-generator): Generates an individual API reference for Prisma Client
 - [`prisma-json-schema-generator`](https://github.com/valentinpalkovic/prisma-json-schema-generator): Transforms the Prisma schema in [JSON schema](https://json-schema.org/)
 - [`typegraphql-prisma`](https://github.com/MichalLytek/typegraphql-prisma#readme): Generates [TypeGraphQL](https://typegraphql.com/) CRUD resolvers for Prisma models
+- [`prisma-typegraphql-types-gen`](https://github.com/YassinEldeeb/prisma-tgql-types-gen): Generates [TypeGraphQL](https://typegraphql.com/) class types and enums from your prisma type definitions, the generated output can be edited without being overwritten by the next gen and has the ability to correct you when you mess up the types with your edits.
 - [`nexus-prisma`](https://github.com/prisma/nexus-prisma/): Allows to project Prisma models to GraphQL via [GraphQL Nexus](https://nexusjs.org/docs/)
 - [`prisma-nestjs-graphql`](https://github.com/unlight/prisma-nestjs-graphql): Generates object types, inputs, args, etc. from the Prisma schema file for usage with `@nestjs/graphql` module
 - [`prisma-appsync`](https://github.com/maoosi/prisma-appsync): Generates a full-blown GraphQL API for [AWS AppSync](https://aws.amazon.com/appsync/)


### PR DESCRIPTION
## Describe this PR

Added a new community generator

## Changes

- Added prisma-typegraphql-types-generator package to community generators section with a brief description on how it works.

## What issue does this fix?

- Allowing for having a single source of truth when working with prisma and typegraphql where developers can model their data in `prisma.schema` file and typegraphql type classes and enums will be generated and registered with TypegraphQL.
- The generated output is very human readable and doesn't look like generated code what so ever.
- The generated output can be edited so developers can add fields to the generated models that are processed by the field resolvers in the graphql api.
- When developers mess up the types by editing the generated output the generator will correct them.