### PR TITLE
Add `tocDepth` to the frontmatter.

### DIFF
--- a/content/200-concepts/100-components/07-prisma-data-platform.mdx
+++ b/content/200-concepts/100-components/07-prisma-data-platform.mdx
@@ -4,6 +4,7 @@ metaTitle: 'Prisma Data Platform (Concept)'
 metaDescription: 'The Prisma Data Platform (Early Access) provides a collaborative, cloud-based environment supporting application developers who are using Prisma and other open source tools. The main features of the Platform include a visual data browser, query console, a data proxy (purpose-built for Prisma!), and integration with your Prisma schema and databases.'
 experimental: false
 earlyaccess: true
+tocDepth: 2
 ---
 
 <TopBlock>


### PR DESCRIPTION
Each .md file in our docs has (or should have) a frontmatter section to define metadata and control behaviour of docs once published, etc. The new Platform document was missing the `tocDepth` flag so the right-side ToC was not auto-expanding. 