### PR TITLE
Trailing underscore on "Configuring the name of the relation table in implicit many-to-many relations"

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -353,17 +353,17 @@ CREATE TABLE "Post" (
 
 #### Configuring the name of the relation table in implicit many-to-many relations
 
-When using Prisma Migrate, you can configure the name of the relation table that's managed by Prisma using the `@relation` attribute. The only requirement is that it starts with an underscore. For example, if you want the relation table to be called `_MyRelationTable` instead of the default name `_CategoryToPost`, you can specify it as follows:
+When using Prisma Migrate, you can configure the name of the relation table that's managed by Prisma using the `@relation` attribute. For example, if you want the relation table to be called `_MyRelationTable` instead of the default name `_CategoryToPost`, you can specify it as follows:
 
 ```prisma
 model Post {
   id         Int        @id @default(autoincrement())
-  categories Category[] @relation("_MyRelationTable")
+  categories Category[] @relation("MyRelationTable")
 }
 
 model Category {
   id    Int    @id @default(autoincrement())
-  posts Post[] @relation("_MyRelationTable")
+  posts Post[] @relation("MyRelationTable")
 }
 ```
 


### PR DESCRIPTION
## Describe this PR

Writing @relation("_MyRelationTable") with 1 underscore results in the creation of a table named "__MyRelationTable" (with 2 underscores), while writing @relation("MyRelationTable") without underscore creates a table named "_MyRelationTable" with 1 underscore.

## Changes

Removed the mention "The only requirement is that it starts with an underscore.", removed the underscore from @relation("_MyRelationTable")

