### PR TITLE
fix(error-reference): Fix misleading description of `message`

### DIFF
--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -62,7 +62,7 @@ Errors that can occur include:
 | **Property**    | **Description**                                  |
 | :-------------- | :----------------------------------------------- |
 | `errorCode`     | A Prisma-specific error code.                    |
-| `message`       | Error message associated with error code.        |
+| `message`       | Error message associated with [error code](#error-codes).        |
 | `clientVersion` | Version of Prisma Client (for example, `2.19.0`) |
 
 ### <inlinecode>PrismaClientValidationError</inlinecode>
@@ -74,7 +74,7 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 
 | **Property** | **Description**                                           |
 | :----------- | :-------------------------------------------------------- |
-| `message`    | Error message associated with [error code](#error-codes). |
+| `message`    | Error message. |
 
 ## Error codes
 


### PR DESCRIPTION
closes https://github.com/prisma/prisma/issues/10221