### PR TITLE
Remove section "Concurrent Interactive Transactions May Timeout"

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -221,11 +221,6 @@ Transaction isolation level is not currently configurable at a Prisma level and 
 - [Default transaction isolation level in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
 - [Default transaction isolation level in MySQL](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
 
-### Concurrent Interactive Transactions May Timeout
-
-Interactive transactions have an issue where multiple concurrent transactions on the same rows may result in a timeout.
-
-We're planning to resolve this limitation soon. Follow along with [this issue](https://github.com/prisma/prisma/issues/8707) for updates.
 
 ## Join the Conversation on GitHub
 


### PR DESCRIPTION
## Describe this PR

It looks like this section is able to be removed now. I came across this and was confused as to whether or not it was fixed until I read through the related PRs and saw that it was resolved.

## Changes

N/a

## What issue does this fix?

N/a

## Any other relevant information

Initial GH Issue: https://github.com/prisma/prisma/issues/8707
Related PR: https://github.com/prisma/prisma/pull/10295