### PR TITLE
docs: Fix date model name in Prisma Migrate table for MySql conector

### DIFF
--- a/content/200-concepts/200-database-connectors/04-mysql.mdx
+++ b/content/200-concepts/200-database-connectors/04-mysql.mdx
@@ -132,7 +132,7 @@ The MySQL connector maps the [scalar types](/concepts/components/prisma-schema/d
 | `BigInt`   | `BIGINT`         |
 | `Float`    | `DOUBLE`         |                                                  |
 | `Decimal`  | `DECIMAL(65,30)` |
-| `Datetime` | `DATETIME(3)`    |                                                  |
+| `DateTime` | `DATETIME(3)`    |                                                  |
 | `Json`     | `JSON`           | Supported in MySQL 5.7+ only                     |
 | `Bytes`    | `LONGBLOB`       |
 


### PR DESCRIPTION
## Describe this PR
I used `date Datetime` for my model in schema.prisma following to docs, run `npx prisma generate` and got issue - `Type "Datetime" is neither a built-in type, nor refers to another model, custom type, or enum.`

## Changes

correct use is `date DateTime`

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

@all-contributors please add @mkarkachov for doc
