### PR TITLE
Add a missing comma in the example JSON object

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4356,7 +4356,7 @@ The examples in this section assumes that the value of the `pet` field is:
     "dogBreed": "Rottweiler",
     "sanctuaries": ["RSPCA", "Alley Cat Allies"],
     "treats": [
-      { "name": "Dreamies", "manufacturer": "Mars Inc"}
+      { "name": "Dreamies", "manufacturer": "Mars Inc"},
       { "name": "Treatos", "manufacturer": "The Dog People"}
     ]
   },


### PR DESCRIPTION
This PR adds a missing comma in the example JSON object that is used in the JSON filters documentation. I copied it from the page to the editor and noticed there was a syntax error.