### PR TITLE
Fix typos in documentation

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1048,7 +1048,7 @@ N/A
 @id(map: String?)
 ```
 
-> **Note**: Until version 3.0.0, the signiture was:
+> **Note**: Until version 3.0.0, the signature was:
 >
 > ```prisma no-lines
 > @id
@@ -1325,7 +1325,7 @@ The name of the `fields` argument on the `@@id` attribute can be omitted:
 @@id(_ fields: FieldReference[], name: String?, map: String?)
 ```
 
-> **Note**: Until version 3.0.0, the signiture was:
+> **Note**: Until version 3.0.0, the signature was:
 >
 > ```prisma no-lines
 > @@id(_ fields: FieldReference[])


### PR DESCRIPTION

## Describe this PR
Fixes some typos in the documentation. 

## Changes

Changes `signiture` to `signature`.

## What issue does this fix?

N/A

## Any other relevant information

N/A