### PR TITLE
add mention of the Platform as an option for getting started

### DIFF
--- a/content/100-getting-started/index.mdx
+++ b/content/100-getting-started/index.mdx
@@ -12,13 +12,17 @@ Welcome to the Prisma getting started section! 👋 Prisma is an [open source](h
 - [**Prisma Migrate**](/concepts/components/prisma-migrate): Migration tool to easily evolve your database schema from prototyping to production
 - [**Prisma Studio**](/concepts/components/prisma-studio): GUI to view and edit data in your database
 
+Prisma is also available on the [Prisma Data Platform](cloud.prisma.io), a cloud-based, collaborative enviroment for teams and organizations to develop type-safe applications. The platform focuses on developer productivity with GitHub integration for your code and schema, a visual data browser, an online query console, and an optional data proxy for handling database connections. For more information, refer to the Prisma Data Platform [documentation](/concepts/components/prisma-data-platform).
+
 For a more detailed breakdown of what problems Prisma solves, and why it's **built to make you more productive**, see the [Why Prisma](/concepts/overview/why-prisma) section.
 
 </TopBlock>
 
 ## Which tutorial is right for me?
 
-The **easiest** way to get up and running with Prisma is through our [Quickstart guide](./quickstart). It makes no assumptions about your knowledge level and offers the **fastest** way from install to query!
+If you want to jump straight into Prisma, try out the [Data Platform](cloud.prisma.io), create a new project, invite team members, and get right to work developing your application.
+
+To get up and running with Prisma in your local environment, follow our [Quickstart guide](./quickstart). It makes no assumptions about your knowledge level and offers the **fastest** way from install to query!
 
 <ButtonLink color="dark" type="primary" href="./getting-started/quickstart">
   Quickstart

--- a/content/100-getting-started/index.mdx
+++ b/content/100-getting-started/index.mdx
@@ -12,7 +12,7 @@ Welcome to the Prisma getting started section! 👋 Prisma is an [open source](h
 - [**Prisma Migrate**](/concepts/components/prisma-migrate): Migration tool to easily evolve your database schema from prototyping to production
 - [**Prisma Studio**](/concepts/components/prisma-studio): GUI to view and edit data in your database
 
-Prisma is also available on the [Prisma Data Platform](cloud.prisma.io), a cloud-based, collaborative enviroment for teams and organizations to develop type-safe applications. The platform focuses on developer productivity with GitHub integration for your code and schema, a visual data browser, an online query console, and an optional data proxy for handling database connections. For more information, refer to the Prisma Data Platform [documentation](/concepts/components/prisma-data-platform).
+Prisma is also available on the [Prisma Data Platform](https://cloud.prisma.io), a cloud-based, collaborative enviroment for teams and organizations to develop type-safe applications. The platform focuses on developer productivity with GitHub integration for your code and schema, a visual data browser, an online query console, and an optional data proxy for handling database connections. For more information, refer to the Prisma Data Platform [documentation](/concepts/components/prisma-data-platform).
 
 For a more detailed breakdown of what problems Prisma solves, and why it's **built to make you more productive**, see the [Why Prisma](/concepts/overview/why-prisma) section.
 
@@ -20,7 +20,7 @@ For a more detailed breakdown of what problems Prisma solves, and why it's **bui
 
 ## Which tutorial is right for me?
 
-If you want to jump straight into Prisma, try out the [Data Platform](cloud.prisma.io), create a new project, invite team members, and get right to work developing your application.
+If you want to jump straight into Prisma, try out the [Data Platform](https://cloud.prisma.io), create a new project, invite team members, and get right to work developing your application.
 
 To get up and running with Prisma in your local environment, follow our [Quickstart guide](./quickstart). It makes no assumptions about your knowledge level and offers the **fastest** way from install to query!
 


### PR DESCRIPTION
I aded two new sections, to introduce the Platform as a way to quickly get started with Prisma.