### PR TITLE
Set integration testing docs' script to tear down container

### DIFF
--- a/content/300-guides/150-testing/150-integration-testing.mdx
+++ b/content/300-guides/150-testing/150-integration-testing.mdx
@@ -464,7 +464,7 @@ You can add some scripts to your projects `package.json` file which will setup t
   "scripts": {
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
-    "test": "yarn docker:up && yarn prisma migrate deploy && jest -i && yarn docker:down"
+    "test": "yarn docker:up && yarn prisma migrate deploy && jest -i; yarn docker:down"
   },
 ```
 


### PR DESCRIPTION

## Describe this PR
Using `&&` will leave the testing container hanging when `jest -i` fails. 

I think tearing down the container regardless of the results of `jest` is the expected behavior here.
