### PR TITLE
Remove Github Issue note from Static IP

### DIFF
--- a/content/200-concepts/100-components/07-prisma-data-platform.mdx
+++ b/content/200-concepts/100-components/07-prisma-data-platform.mdx
@@ -40,7 +40,7 @@ In order to add users, you need to use their GitHub username and they need to ha
 
 The Prisma Data Platform provides a static IP address that you can add to an allowlist in order to connect to your database through our Data Browser. Please note this feature is currently not supported in the Data Proxy.
 
-You can [create an issue](https://github.com/prisma/studio/issues/new?assignees=&labels=topic%3A+hosted+data+browser&template=hosted-data-browser-bug-report.md&title=) with your request and we will enable it for you. Please note that while this is a feature that will be part of a paid plan in the future, it is currently offered for free while we are in Early Access.
+You can send us a message via Intercom, from inside the Prisma Data Platform, with your request and we will enable it for you. Please note that while this is a feature that will be part of a paid plan in the future, it is currently offered for free while we are in Early Access.
 
 ## Prisma Data Proxy
 
@@ -156,35 +156,46 @@ Please note that the Prisma Data Proxy public interface is not stable yet. The l
 </Admonition>
 
 #### P5000
+
 This request could not be understood by the server
 
 #### P5001
+
 This request must be retried
 
 #### P5002
+
 The datasource provided is invalid:
-* Could not parse the URL
-* Datasource URL should use the `prisma://` protocol
-* No valid API key found
+
+- Could not parse the URL
+- Datasource URL should use the `prisma://` protocol
+- No valid API key found
 
 #### P5003
+
 Requested resource does not exist
 
 #### P5004
+
 The feature is not yet implemented:
-* `beforeExit` event is not yet supported
-* Interactive transactions are not yet supported
+
+- `beforeExit` event is not yet supported
+- Interactive transactions are not yet supported
 
 #### P5005
+
 Schema needs to be uploaded
 
 #### P5006
+
 Unknown server error
 
 #### P5007
+
 Unauthorized, check your connection string
 
 #### P5008
+
 Usage exceeded, retry again later
 
 ### Important Considerations about the Data Proxy


### PR DESCRIPTION
We've been seeing some messages in our now deprecated (for PDP purposes) [Studio repo](https://github.com/prisma/studio/issues) and just realized that we actively suggest them to do that in our Data Platform concept page 😅.

I'm changing that instruction in the Docs with a suggestion to create a new Intercom message.