### PR TITLE
Fix plural form in Prisma/TypeORM comparison doc

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/01-prisma-and-typeorm.mdx
+++ b/content/200-concepts/300-more/400-comparisons/01-prisma-and-typeorm.mdx
@@ -302,7 +302,7 @@ export class Post {
 While each object in the returned `publishedPosts` array only carries the selected `id` and `title` properties at runtime, the TypeScript compiler doesn't have any knowledge of this. It will allow you to access any other properties defined on the `Post` entity after the query, for example:
 
 ```ts
-const post = publishedPost[0]
+const post = publishedPosts[0]
 
 // The TypeScript compiler has no issue with this
 if (post.content.length > 0) {


### PR DESCRIPTION
## Describe this PR

Just fixed a plural form in a exemple in TypeORM vs Prisma, in Type Safety section.

## Changes

It has a example as follows: 

```ts
const postRepository = getManager().getRepository(Post)
const publishedPosts: Post[] = await postRepository.find({
  where: { published: true },
  select: ['id', 'title'],
})
```

after that, it's called a,

```ts
const post = publishedPost[0]
```

as it was defined as publishedPosts before, I made such a change.

```ts
const post = publishedPosts[0]
```


## What issue does this fix?

This change just correct the name of the variable used in example on the documentation.
