### PR TITLE
Docs pr2629

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Special rules for referential actions in SQL Server and MongoB'
+title: 'Special rules for referential actions in SQL Server'
 metaTitle: 'Special rules for referential actions in SQL Server and MongoDB'
 metaDescription: 'Circular references or multiple cascade paths can cause validation errors on Microsoft SQL Server and MongoDB. Since the database does not handle these situations out of the box, learn how to solve this problem.'
 tocDepth: 2
@@ -14,7 +14,7 @@ Some databases have specific requirements to consider if you are using referenti
 
 To avoid these potential issues, be sure to set your referential actions on the foreign key to `NoAction`.
 
-If the referential actions on the foreign key are set to something other than `NO ACTION`, the server will check for cycles or multiple cascade paths and return an error when executing the SQL.
+If the referential actions on the foreign key are set to something other than `NoAction`, the server will check for cycles or multiple cascade paths and return an error when executing the SQL.
 
 Given the SQL:
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
@@ -9,12 +9,9 @@ tocDepth: 2
 
 Some databases have specific requirements that you should consider if you are using referential actions.
 
-- Microsoft SQL Server doesn't allow cascading [referential actions](./) on a foreign key, if the relation chain causes a cycle or multiple cascade paths.
-- MongoDB requires that for any data model with self-referential relations or cycles between three models, you must set the referential action of `NoAction` to prevent the referential action emulations from looping infinitely. Be aware that by default, the `referentialIntegrity = "prisma"` mode is used for MongoDB, which means that Prisma manages [referential integrity](/concepts/components/prisma-schema/relations/referential-integrity)
+- Microsoft SQL Server doesn't allow cascading [referential actions](./) on a foreign key, if the relation chain causes a cycle or multiple cascade paths. If the referential actions on the foreign key are set to something other than `NO ACTION` (or `NoAction` if Prisma is managing referential integrity), the server will check for cycles or multiple cascade paths and return an error when executing the SQL.
 
-To avoid these potential issues, be sure to set your referential actions on the foreign key to `NoAction`.
-
-If the referential actions on the foreign key are set to something other than `NoAction`, the server will check for cycles or multiple cascade paths and return an error when executing the SQL.
+- with MongoDB, using referential actions in Prisma requires that for any data model with self-referential relations or cycles between three models, you must set the referential action of `NoAction` to prevent the referential action emulations from looping infinitely. Be aware that by default, the `referentialIntegrity = "prisma"` mode is used for MongoDB, which means that Prisma manages [referential integrity](/concepts/components/prisma-schema/relations/referential-integrity)
 
 Given the SQL:
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
@@ -10,7 +10,7 @@ tocDepth: 2
 Some databases have specific requirements that you should consider if you are using referential actions.
 
 - Microsoft SQL Server doesn't allow cascading [referential actions](./) on a foreign key, if the relation chain causes a cycle or multiple cascade paths.
-- MongoDB requires that for any data model with self-referential relations or cycles between three models, you must set the referential action of `NoAction` to prevent the referential action emulations from looping infinitely.
+- MongoDB requires that for any data model with self-referential relations or cycles between three models, you must set the referential action of `NoAction` to prevent the referential action emulations from looping infinitely. Be aware that by default, the `referentialIntegrity = "prisma"` mode is used for MongoDB, which means that Prisma manages [referential integrity](/concepts/components/prisma-schema/relations/referential-integrity)
 
 To avoid these potential issues, be sure to set your referential actions on the foreign key to `NoAction`.
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
@@ -7,7 +7,7 @@ tocDepth: 2
 
 <TopBlock>
 
-Some databases have specific requirements to consider if you are using referential actions.
+Some databases have specific requirements that you should consider if you are using referential actions.
 
 - Microsoft SQL Server doesn't allow cascading [referential actions](./) on a foreign key, if the relation chain causes a cycle or multiple cascade paths.
 - MongoDB requires that for any data model with self-referential relations or cycles between three models, you must set the referential action of `NoAction` to prevent the referential action emulations from looping infinitely.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/100-special-rules-for-referential-actions.mdx
@@ -1,13 +1,18 @@
 ---
-title: 'Special rules for referential actions in SQL Server'
-metaTitle: 'Special rules for referential actions in SQL Server'
-metaDescription: 'Circular references or multiple cascade paths can cause validation errors on Microsoft SQL Server. Since the database does not handle these situations out of the box, learn how to solve this problem.'
+title: 'Special rules for referential actions in SQL Server and MongoB'
+metaTitle: 'Special rules for referential actions in SQL Server and MongoDB'
+metaDescription: 'Circular references or multiple cascade paths can cause validation errors on Microsoft SQL Server and MongoDB. Since the database does not handle these situations out of the box, learn how to solve this problem.'
 tocDepth: 2
 ---
 
 <TopBlock>
 
-Microsoft SQL Server doesn't allow cascading [referential actions](./) on a foreign key, if the relation chain causes a cycle or multiple cascade paths. Most SQL databases handle these references out of the box.
+Some databases have specific requirements to consider if you are using referential actions.
+
+- Microsoft SQL Server doesn't allow cascading [referential actions](./) on a foreign key, if the relation chain causes a cycle or multiple cascade paths.
+- MongoDB requires that for any data model with self-referential relations or cycles between three models, you must set the referential action of `NoAction` to prevent the referential action emulations from looping infinitely.
+
+To avoid these potential issues, be sure to set your referential actions on the foreign key to `NoAction`.
 
 If the referential actions on the foreign key are set to something other than `NO ACTION`, the server will check for cycles or multiple cascade paths and return an error when executing the SQL.
 
@@ -36,7 +41,7 @@ In more complicated data models, finding the cascade paths can get complex. Ther
 
 </TopBlock>
 
-## Self-relation
+## Self-relation (SQL Server and MongoDB)
 
 The following model describes a self-relation where an `Employee` can have a manager and managees, referencing entries of the same model.
 
@@ -74,7 +79,7 @@ model Employee {
 }
 ```
 
-## Cyclic relation between three tables
+## Cyclic relation between three tables (SQL Server and MongoDB)
 
 The following models describe a cyclic relation between a `Chicken`, an `Egg` and a `Fox`, where each model references the other.
 
@@ -157,7 +162,7 @@ model Fox {
 }
 ```
 
-## Multiple cascade paths between two models
+## Multiple cascade paths between two models (SQL Server only)
 
 The data model describes two different paths between same models, with both relations triggering cascading referential actions.
 


### PR DESCRIPTION
Added information about MongoDB requiring that referential actions be set to `NoAction` in order to avoid looping.

I editing the existing page about "Special rules for referential actions in SQL Server" and added info about MongoDB, instead of creating a separate page just for MongoDB. I am hoping this can work, in order to reduce redundancy.
