### PR TITLE
Update 050-prisma-client-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4085,7 +4085,7 @@ const setTags = await prisma.post.update({
 
 #### Remarks
 
-- Available for PostgreSQL only.
+- Available for PostgreSQL and MongoDB only.
 - You cannot push a list of values - only a single value.
 
 #### Examples


### PR DESCRIPTION
Updated the remark to say that `push is available for MongoDB (in addition to PostgreSQL).

