### PR TITLE
fix: undo prisma#2619 and remove down from test

### DIFF
--- a/content/300-guides/150-testing/150-integration-testing.mdx
+++ b/content/300-guides/150-testing/150-integration-testing.mdx
@@ -464,7 +464,7 @@ You can add some scripts to your projects `package.json` file which will setup t
   "scripts": {
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
-    "test": "yarn docker:up && yarn prisma migrate deploy && jest -i; yarn docker:down"
+    "test": "yarn docker:up && yarn prisma migrate deploy && jest -i"
   },
 ```
 


### PR DESCRIPTION
Since it's explained that "test" does 1,2,3 steps and doesn't include down and even says explicitly "Once you are satisfied you can run `yarn docker:down` to destroy the container, its database and any test data."
I would prefer another approach but removing down here seems good in this context.
