### PR TITLE
fix(data-model, native database type attributes): Reorder, clarify and add link

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -440,6 +440,8 @@ Type attributes are:
 
 Furthermore, during [Introspection](/concepts/components/introspection) type attributes are _only_ added to the schema if the underlying native type is **not the default type**. For example, if you are using the PostgreSQL provider, `String` fields where the underlying native type is `text` will not have a type attribute.
 
+See [complete list of native database type attributes per scalar type and provider](/reference/api-reference/prisma-schema-reference#model-field-scalar-types) <span class="api"></span>.
+
 #### Benefits and workflows
 
 - Control **the exact native type** that [Prisma Migrate](/concepts/components/prisma-migrate) creates in the database - for example, a `String` can be `@db.VarChar(200)` or `@db.Char(50)`

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -422,7 +422,7 @@ Refer to the [relations documentation](relations) for more examples and informat
 
 ### Native types mapping
 
-Version [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later supports **native database type attributes** (type attributes) that describe the underlying database type:
+Version [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later support **native database type attributes** (type attributes) that describe the underlying database type:
 
 ```prisma highlight=3;normal
 model Post {
@@ -432,13 +432,13 @@ model Post {
 }
 ```
 
-Type attributes are _only_ added to the schema if the underlying native type is **not the default type**. For example, if you are using the PostgreSQL provider, `String` fields where the underlying native type is `text` will not have a type attribute.
-
-Furthermore, type attributes are:
+Type attributes are:
 
 - Specific to the underlying provider - for example, PostgreSQL uses `@db.Boolean` for `Boolean` whereas MySQL uses `@db.TinyInt(1)`
 - Written in PascalCase (for example, `VarChar` or `Text`)
 - Prefixed by `@db`, where `db` is the name of the `datasource` block in your schema
+
+Furthermore, during [Introspection](/concepts/components/introspection) type attributes are _only_ added to the schema if the underlying native type is **not the default type**. For example, if you are using the PostgreSQL provider, `String` fields where the underlying native type is `text` will not have a type attribute.
 
 #### Benefits and workflows
 


### PR DESCRIPTION
- Reorder to list properties first, then Introspection specific information
- Clarify that rendering of native database type attributes is only Introspection specific
- And make that more accessible by adding a link
- Also add link to list of types (although that list is terribly hard to understand right now)