### PR TITLE
Add MySQL to full text search Concepts page

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -229,4 +229,4 @@ const result = await prisma.blogs.findMany({
 })
 ```
 
-However, if you try to search on `title` alone, the search will fail with the error "Cannot find a fulltext index to use for the search and the message code is P2030", because the index requires a search on both fields.
+However, if you try to search on `title` alone, the search will fail with the error "Cannot find a fulltext index to use for the search" and the message code is P2030, because the index requires a search on both fields.

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -176,7 +176,7 @@ To speed up your full-text queries, you should add an index to your database. Pr
 CREATE INDEX post_body_index ON posts USING GIN (body);
 ```
 
-For further information, see the [Postgres documentation on indexes](https://www.postgresql.org/docs/12/sql-createindex.html).
+For further information, see the [PostgreSQL documentation on indexes](https://www.postgresql.org/docs/12/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX).
 
 You can continue using Prisma Migrate as you were before, it will ignore indexes that it doesn't know about.
 

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -54,7 +54,7 @@ const result = await prisma.posts.findMany({
 
 ## Querying the database
 
-The `search` field uses the database's native querying capabilities under the hood. This means that the exact operations available will be database-specific.
+The `search` field uses the database's native querying capabilities under the hood. This means that the exact operations available are also database-specific.
 
 ### PostgreSQL
 

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Full-Text Search'
-metaTitle: 'Full-Text Search (Preview)'
+title: 'Full-text search'
+metaTitle: 'Full-text search (Preview)'
 metaDescription: 'This page explains how to search for text within a field.'
 preview: true
 ---

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -7,24 +7,27 @@ preview: true
 
 # Full-Text Search (Preview)
 
-The Prisma Client supports a full-text search API for Postgres databases. With full-text search enabled, you can add search functionality to your application by searching for text within a database column.
+The Prisma Client supports full-text search API for **PostgreSQL** and **MySQL** databases. With full-text search enabled, you can add search functionality to your application by searching for text within a database column.
 
-<Admonition type="info">
+## Enabling full-text search
 
-**Note**: Full text search can **only** be used in a Postgres database
-
-</Admonition>
-
-## Enable full-text search
-
-The full-text Search API is still in **Preview**. You can enable `fullTextSearch` in your Prisma Schema:
+The `fullTextSearch` feature is currently a Preview feature. To enable this feature, carry out the following steps:
 
 1. Update the [`previewFeatures`](/concepts/components/preview-features) block in your schema:
 
-   ```prisma
+   ```prisma file=schema.prisma
    generator client {
      provider        = "prisma-client-js"
      previewFeatures = ["fullTextSearch"]
+   }
+   ```
+
+   For MySQL, you will also need to include the `fullTextIndex` preview feature:
+
+   ```prisma file=schema.prisma highlight=3;add
+   generator client {
+     provider        = "prisma-client-js"
+     previewFeatures = ["fullTextSearch, fullTextIndex"]
    }
    ```
 
@@ -34,12 +37,29 @@ The full-text Search API is still in **Preview**. You can enable `fullTextSearch
    npx prisma generate
    ```
 
-After you regenerate your client, a new `search` field will be available on any `String` fields created on your models.
-
-### Example of new <inlinecode>search</inlinecode> field
+After you regenerate your client, a new `search` field will be available on any `String` fields created on your models. For example, the following search will return all posts that contain the word 'cat'.
 
 ```ts
-// All posts that contain the words cat or dog.
+// All posts that contain the word 'cat'.
+const result = await prisma.posts.findMany({
+  where: {
+    body: {
+      search: 'cat',
+    },
+  },
+})
+```
+
+## Querying the database
+
+The `search` field uses the database's native querying capabilities under the hood. This means that the exact operations available will be database-specific.
+
+### PostgreSQL
+
+The following examples demonstrate use of the PostgreSQL 'and' (`&`) and 'or' (`|`) operators:
+
+```ts
+// All posts that contain the words 'cat' or 'dog'.
 const result = await prisma.posts.findMany({
   where: {
     body: {
@@ -48,7 +68,7 @@ const result = await prisma.posts.findMany({
   },
 })
 
-// All drafts that contain the words cat and dog.
+// All drafts that contain the words 'cat' and 'dog'.
 const result = await prisma.posts.findMany({
   where: {
     status: 'Draft',
@@ -59,9 +79,58 @@ const result = await prisma.posts.findMany({
 })
 ```
 
-## Query Format
+To get a sense of how the query format works, consider the following text:
 
-The `search` field uses the database's native querying capabilities under the hood. This means that the Prisma Client [supports what the database supports](https://www.postgresql.org/docs/12/functions-textsearch.html).
+**"The quick brown fox jumps over the lazy dog"**
+
+Here's how the following queries would match that text:
+
+| Query                                   | Match? | Description                             |
+| :-------------------------------------- | :----- | :-------------------------------------- |
+| `fox & dog`                             | Yes    | The text contains 'fox' and 'dog'       |
+| `dog & fox`                             | Yes    | The text contains 'dog' and 'fox'       |
+| `dog & cat`                             | No     | The text contains 'dog' but not 'cat'   |
+| `!cat`                                  | Yes    | 'cat' is not in the text                |
+| <inlinecode>fox &#124; cat</inlinecode> | Yes    | The text contains 'fox' or 'cat'        |
+| <inlinecode>cat &#124; pig</inlinecode> | No     | The text doesn't contain 'cat' or 'pig' |
+| `fox <-> dog`                           | Yes    | 'dog' follows 'fox' in the text         |
+| `dog <-> fox`                           | No     | 'fox' doesn't follow 'dog' in the text  |
+
+For the full range of supported operations, see the [PostgreSQL full text search documentation](https://www.postgresql.org/docs/12/functions-textsearch.html).
+
+### MySQL
+
+The following examples demonstrate use of the MySQL 'and' (`+`) and 'not' (`-`) operators:
+
+```ts
+// All posts that contain the words 'cat' or 'dog'.
+const result = await prisma.posts.findMany({
+  where: {
+    body: {
+      search: 'cat dog',
+    },
+  },
+})
+
+// All posts that contain the words 'cat' and not 'dog'.
+const result = await prisma.posts.findMany({
+  where: {
+    body: {
+      search: '+cat -dog',
+    },
+  },
+})
+
+// All drafts that contain the words 'cat' and 'dog'.
+const result = await prisma.posts.findMany({
+  where: {
+    status: 'Draft',
+    body: {
+      search: '+cat +dog',
+    },
+  },
+})
+```
 
 To get a sense of how the query format works, consider the following text:
 
@@ -69,31 +138,78 @@ To get a sense of how the query format works, consider the following text:
 
 Here's how the following queries would match that text:
 
-| Query                                   | Match? | Description                         |
-| :-------------------------------------- | :----- | :---------------------------------- |
-| `fox & dog`                             | Yes    | The text contains fox and dog       |
-| `dog & fox`                             | Yes    | The text contains dog and fox       |
-| `dog & cat`                             | No     | The text doesn't contain cat        |
-| `!cat`                                  | Yes    | There is not cat in the text        |
-| <inlinecode>fox &#124; cat</inlinecode> | Yes    | The text contains fox or cat        |
-| <inlinecode>cat &#124; pig</inlinecode> | No     | The text doesn't contain cat or pig |
-| `fox <-> dog`                           | Yes    | dog follows fox in the text         |
-| `dog <-> fox`                           | No     | dog doesn't follow fox in the text  |
+| Query       | Match? | Description                             |
+| :---------- | :----- | :-------------------------------------- |
+| `+fox +dog` | Yes    | The text contains 'fox' and 'dog'       |
+| `+dog +fox` | Yes    | The text contains 'dog' and 'fox'       |
+| `+dog +cat` | No     | The text contains 'dog' but not 'cat'   |
+| `-cat`      | Yes    | 'cat' is not in the text                |
+| `fox dog`   | Yes    | The text contains 'fox' or 'cat'        |
+| `-cat -pig` | No     | The text doesn't contain 'cat' or 'pig' |
 
-## Adding Indexes
+For the full range of supported operations, see the [MySQL full text search documentation](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html).
 
-To speed up your full-text queries, you should add an index to your database.
-Prisma Migrate currently doesn't support adding search indices, but you can
-easily add one yourself.
+## Adding indexes
+
+### PostgreSQL
+
+To speed up your full-text queries, you should add an index to your database. Prisma Migrate currently doesn't support adding search indices in PostgreSQL, so this should be added in SQL. For example, the following SQL statement would add an index called `post_body_index` on the `posts_body_index` column of the `posts` table:
 
 ```sql
 CREATE INDEX post_body_index ON posts USING GIN (body);
 ```
 
-You can continue using Prisma Migrate as you were before, it will ignore indexes
-that it doesn't know about.
+For further information, see the [Postgres documentation on indexes](https://www.postgresql.org/docs/12/sql-createindex.html).
 
-## Limitations
+You can continue using Prisma Migrate as you were before, it will ignore indexes that it doesn't know about.
 
-- The `search` field is only supported in PostgreSQL
-- You'll need to manage indexes yourself.
+### MySQL
+
+For MySQL, it is necessary to add indexes to any columns you search using the `@@fulltext` argument in the `schema.prisma` file. To do this, the `"fullTextIndex"` preview feature must be enabled.
+
+In the following example, one full text index is added to the `content` field of the `Blog` model, and another is added to both the `content` and `title` fields together:
+
+```prisma file=schema.prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["fullTextSearch", "fullTextIndex"]
+}
+
+model Blog {
+  id      Int    @unique
+  content String
+  title   String
+
+  @@fulltext([content])
+  @@fulltext([content, title])
+}
+```
+
+The first index allows searching the `content` field for occurrences of the word 'cat':
+
+```prisma file=schema.prisma
+const result = await prisma.blogs.findMany({
+where: {
+content: {
+search: 'cat',
+},
+},
+})
+```
+
+The second index allows searching both the `content` and `title` fields for occurrences of the word 'cat' in the `content` and 'food' in the `title`:
+
+```prisma file=schema.prisma
+const result = await prisma.blogs.findMany({
+where: {
+content: {
+search: 'cat',
+},
+title: {
+search: 'food'
+}
+},
+})
+```
+
+However, if you try to search on `title` alone, the search will fail with the error "Cannot find a fulltext index to use for the search and the message code is P2030", because the index requires a search on both fields.

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -140,14 +140,29 @@ To get a sense of how the query format works, consider the following text:
 
 Here's how the following queries would match that text:
 
-| Query       | Match? | Description                             |
-| :---------- | :----- | :-------------------------------------- |
-| `+fox +dog` | Yes    | The text contains 'fox' and 'dog'       |
-| `+dog +fox` | Yes    | The text contains 'dog' and 'fox'       |
-| `+dog +cat` | No     | The text contains 'dog' but not 'cat'   |
-| `-cat`      | Yes    | 'cat' is not in the text                |
-| `fox dog`   | Yes    | The text contains 'fox' or 'cat'        |
-| `-cat -pig` | No     | The text doesn't contain 'cat' or 'pig' |
+| Query          | Match? | Description                                            |
+| :------------- | :----- | :----------------------------------------------------- |
+| `+fox +dog`    | Yes    | The text contains 'fox' and 'dog'                      |
+| `+dog +fox`    | Yes    | The text contains 'dog' and 'fox'                      |
+| `+dog -cat`    | No     | The text contains 'dog' but not 'cat'                  |
+| `-cat`         | Yes    | 'cat' is not in the text                               |
+| `fox dog`      | Yes    | The text contains 'fox' or 'cat'                       |
+| `-cat -pig`    | No     | The text does not contain 'cat' or 'pig'               |
+| `quic*`        | Yes    | The text contains a word starting with 'quic'          |
+| `quick fox @2` | Yes    | 'fox' starts within a 2 word distance of 'quick'       |
+| `fox dog @2`   | No     | 'dog' does not start within a 2 word distance of 'fox' |
+| `"jumps over"` | Yes    | The text contains the whole phrase 'jumps over'        |
+
+MySQL also has `>`, `<` and `~` operators for altering the ranking order of search results. As an example, consider the following two records:
+
+**1. "The quick brown fox jumps over the lazy dog"**
+
+**2. "The quick brown fox jumps over the lazy cat"**
+
+| Query             | Result                   | Description                                                                                             |
+| :---------------- | :----------------------- | :------------------------------------------------------------------------------------------------------ |
+| `fox ~cat`        | Return 1. first, then 2. | Return all records containing 'fox', but rank records containing 'cat' lower                            |
+| `fox (<cat >dog)` | Return 1. first, then 2. | Return all records containing 'fox', but rank records containing 'cat' lower than rows containing 'dog' |
 
 For the full range of supported operations, see the [MySQL full text search documentation](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html).
 

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -229,4 +229,4 @@ const result = await prisma.blogs.findMany({
 })
 ```
 
-However, if you try to search on `title` alone, the search will fail with the error "Cannot find a fulltext index to use for the search" and the message code is P2030, because the index requires a search on both fields.
+However, if you try to search on `title` alone, the search will fail with the error "Cannot find a fulltext index to use for the search" and the message code is `P2030`, because the index requires a search on both fields.

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -58,7 +58,7 @@ The `search` field uses the database's native querying capabilities under the ho
 
 ### PostgreSQL
 
-The following examples demonstrate use of the PostgreSQL 'and' (`&`) and 'or' (`|`) operators:
+The following examples demonstrate the use of the PostgreSQL 'and' (`&`) and 'or' (`|`) operators:
 
 ```ts
 // All posts that contain the words 'cat' or 'dog'.

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -13,9 +13,9 @@ The Prisma Client supports full-text search for **PostgreSQL** databases in vers
 
 ## Enabling full-text search
 
-The `fullTextSearch` feature is currently a Preview feature. To enable this feature, carry out the following steps:
+The full-text search API is currently a Preview feature. To enable this feature, carry out the following steps:
 
-1. Update the [`previewFeatures`](/concepts/components/preview-features) block in your schema:
+1. Update the [`previewFeatures`](/concepts/components/preview-features) block in your schema to include the `fullTextSearch` preview feature flag:
 
    ```prisma file=schema.prisma
    generator client {
@@ -24,7 +24,7 @@ The `fullTextSearch` feature is currently a Preview feature. To enable this feat
    }
    ```
 
-   For MySQL, you will also need to include the `fullTextIndex` preview feature:
+   For MySQL, you will also need to include the `fullTextIndex` preview feature flag:
 
    ```prisma file=schema.prisma highlight=3;add
    generator client {

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -5,9 +5,11 @@ metaDescription: 'This page explains how to search for text within a field.'
 preview: true
 ---
 
-# Full-Text Search (Preview)
+<TopBlock>
 
-The Prisma Client supports full-text search API for **PostgreSQL** and **MySQL** databases. With full-text search enabled, you can add search functionality to your application by searching for text within a database column.
+The Prisma Client supports full-text search for **PostgreSQL** and **MySQL** databases. With full-text search enabled, you can add search functionality to your application by searching for text within a database column.
+
+</TopBlock>
 
 ## Enabling full-text search
 

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -7,7 +7,7 @@ preview: true
 
 <TopBlock>
 
-The Prisma Client supports full-text search for **PostgreSQL** and **MySQL** databases. With full-text search enabled, you can add search functionality to your application by searching for text within a database column.
+The Prisma Client supports full-text search for **PostgreSQL** databases in versions 2.30.0 and later, and **MySQL** databases in versions 3.8.0 and later. With full-text search enabled, you can add search functionality to your application by searching for text within a database column.
 
 </TopBlock>
 

--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -189,28 +189,28 @@ model Blog {
 
 The first index allows searching the `content` field for occurrences of the word 'cat':
 
-```prisma file=schema.prisma
+```ts
 const result = await prisma.blogs.findMany({
-where: {
-content: {
-search: 'cat',
-},
-},
+  where: {
+    content: {
+      search: 'cat',
+    },
+  },
 })
 ```
 
 The second index allows searching both the `content` and `title` fields for occurrences of the word 'cat' in the `content` and 'food' in the `title`:
 
-```prisma file=schema.prisma
+```ts
 const result = await prisma.blogs.findMany({
-where: {
-content: {
-search: 'cat',
-},
-title: {
-search: 'food'
-}
-},
+  where: {
+    content: {
+      search: 'cat',
+    },
+    title: {
+      search: 'food',
+    },
+  },
 })
 ```
 

--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -59,11 +59,11 @@ Errors that can occur include:
 - A missing or inaccessible environment variable
 - The query engine binary for the current platform could not be found (`generator` block)
 
-| **Property**    | **Description**                                  |
-| :-------------- | :----------------------------------------------- |
-| `errorCode`     | A Prisma-specific error code.                    |
-| `message`       | Error message associated with [error code](#error-codes).        |
-| `clientVersion` | Version of Prisma Client (for example, `2.19.0`) |
+| **Property**    | **Description**                                           |
+| :-------------- | :-------------------------------------------------------- |
+| `errorCode`     | A Prisma-specific error code.                             |
+| `message`       | Error message associated with [error code](#error-codes). |
+| `clientVersion` | Version of Prisma Client (for example, `2.19.0`)          |
 
 ### <inlinecode>PrismaClientValidationError</inlinecode>
 
@@ -72,9 +72,9 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 - Missing field - for example, an empty `data: {}` property when creating a new record
 - Incorrect field type provided (for example, setting a `Boolean` field to `"Hello, I like cheese and gold!"`)
 
-| **Property** | **Description**                                           |
-| :----------- | :-------------------------------------------------------- |
-| `message`    | Error message. |
+| **Property** | **Description** |
+| :----------- | :-------------- |
+| `message`    | Error message.  |
 
 ## Error codes
 
@@ -294,6 +294,10 @@ Possible errors:
 #### <inlinecode>P2027</inlinecode>
 
 "Multiple errors occurred on the database during query execution: {errors}"
+
+#### <inlinecode>P2030</inlinecode>
+
+"Cannot find a fulltext index to use for the search, try adding a @@fulltext([Fields...]) to your schema"
 
 ### Prisma Migrate (Migration Engine)
 


### PR DESCRIPTION


## Describe this PR

I've added MySQL to the full text search Concepts page, which is currently PostgreSQL only. So far I've focussed just on getting the information in (from @garrensmith's [comment here](https://github.com/prisma/prisma/issues/10415#issuecomment-1005394046)). Not sure what the best way to organise the information is yet but would appreciate a review of the technical content.


## Changes

Added MySQL-specific information

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
