### PR TITLE
missing name in Prisma object creation example

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/03-prisma-and-mongoose.mdx
+++ b/content/200-concepts/300-more/400-comparisons/03-prisma-and-mongoose.mdx
@@ -187,6 +187,7 @@ const posts = await Post.find({
 ```ts
 const user = await prisma.user.create({
   data: {
+    name: 'Alice',
     email: 'alice@prisma.io',
   },
 })


### PR DESCRIPTION
Mongoose created the object with the name `Alice` and that was missing in the Prisma example.