### PR TITLE
Fix typo in Migrations docs

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -213,7 +213,7 @@ The following scenario simulates a change that creates a seemingly harmless inco
 
 1. Prisma Migrate generates a new migration to change the value back to `550`, because the end state of the migration history should match the Prisma schema.
 
-1. From now on, when you use `prisma migrate deploy` to deploy migrations to production and test environments, Prisma Migrate will always **warn you** that migration histories do not match (and continue to warn you each time you run the command ) - even though the schema end states match:
+1. From now on, when you use `prisma migrate deploy` to deploy migrations to production and test environments, Prisma Migrate will always **warn you** that migration histories do not match (and continue to warn you each time you run the command ) - even though the schema and states match:
 
    ```bash
    6 migrations found in prisma/migrations


### PR DESCRIPTION
## Describe this PR

Fix typo in migrations docs.

## Changes

From:

    even though the schema *end* states match

To:

    even though the schema *and* states match

## What issue does this fix?

None.

## Any other relevant information

None.
