### PR TITLE
fix(sidebar): stop the confusion between cli and client (#2691)

### DIFF
--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -212,7 +212,9 @@ const TreeNode = ({
   }, [isCollapsed])
 
   const isCurrent =
-    location && slug && location.pathname.includes(urlGenerator(slug).replace('/index', ''))
+    location &&
+    slug &&
+    (location.pathname + '/').includes(urlGenerator(slug).replace(/\/index$/, '') + '/')
 
   return url === '/' ? null : (
     <ListItem className={calculatedClassName}>


### PR DESCRIPTION
## Describe this PR

Fixes #2691

## Changes

Updated `isCurrent` logic to include path separators as well