### PR TITLE
rearranged content, added new section

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -75,8 +75,8 @@ The following bulk operations run as transactions:
 
 The `$transaction` API can be used in two ways:
 
-- sequential operations: pass an array of Prisma Client operations that will be executed sequentially
-- interactive transactions (in Preview): pass a function in which you can perform a set of (interactive) transactions
+  - `$transaction<R>(queries: PrismaPromise<R>[]): Promise<R[]>`: Pass an array of Prisma Client queries to be executed sequentially inside of a transaction.
+  - `$transaction<R>(fn: (prisma: PrismaClient) => R): R`: Pass a function that can contain user code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction.
 
 ### Sequential Prisma Client operations
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -20,7 +20,7 @@ Prisma provides the following options for using transactions:
 - **Nested writes**: to write relational data on one or more related records to your database in a single transaction.
 - **Batch / bulk transactions**: to process one or more operations in bulk via `updateMany`, `deleteMany`, and `createMany`.
 - **The `$transaction` calls**:
-  - pass an array of Prisma Client queries to be executed sequentially inside a transaction
+  - `$transaction<R>(queries: PrismaPromise<R>[]): Promise<R[]>`: Pass an array of Prisma Client queries to be executed sequentially inside of a transaction.
     OR
   - pass a function that can contain arbitrary code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction.
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -22,7 +22,7 @@ Prisma provides the following options for using transactions:
 - **The `$transactions` API call**: use this call to either:
   - pass an array of Prisma Client operations to be executed sequentially
     OR
-  - pass a function in which you can perform one transaction that contains a set of [(interactive) transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview), including multiple Prisma Client queries and optionally control flow and non-Prisma queries.
+  - pass a function in which you can perform one transaction, a function that executes a set of [(interactive) transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview), such as Prisma Client queries, non-Prisma queries, and other code.
 
 ## Nested writes
 
@@ -77,7 +77,7 @@ The following bulk operations run as transactions:
 The `$transaction` API can be used in two ways:
 
 - sequential operations: pass an array of Prisma Client operations that will be executed sequentially
-- interactive transactions (in Preview): pass a function in which you can perform a random set of (interactive) transactions
+- interactive transactions (in Preview): pass a function in which you can perform a set of (interactive) transactions
 
 ### Sequential Prisma Client operations
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -19,7 +19,7 @@ Prisma provides the following options for using transactions:
 
 - **Nested writes**: to write relational data on one or more related records to your database in a single transaction.
 - **Batch / bulk transactions**: to process one or more operations in bulk via `updateMany`, `deleteMany`, and `createMany`.
-- **The `$transactions` API call**: use this call to either:
+- **The `$transaction` calls**:
   - pass an array of Prisma Client queries to be executed sequentially inside a transaction
     OR
   - pass a function that can contain arbitrary code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction.

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -21,7 +21,7 @@ Prisma provides the following options for using transactions:
 - **Batch / bulk transactions**: to process one or more operations in bulk via `updateMany`, `deleteMany`, and `createMany`.
 - **The `$transaction` calls**:
   - `$transaction<R>(queries: PrismaPromise<R>[]): Promise<R[]>`: Pass an array of Prisma Client queries to be executed sequentially inside of a transaction.
-  - pass a function that can contain arbitrary code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction.
+  - `$transaction<R>(fn: (prisma: PrismaClient) => R): R`: Pass a function that can contain user code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction.
 
 ## Nested writes
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -22,7 +22,7 @@ Prisma provides the following options for using transactions:
 - **The `$transactions` API call**: use this call to either:
   - pass an array of Prisma Client operations to be executed sequentially
     OR
-  - pass a function in which you can perform a random set of [(interactive) transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview)
+  - pass a function in which you can perform one transaction that contains a set of [(interactive) transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview), including multiple Prisma Client queries and optionally control flow and non-Prisma queries.
 
 ## Nested writes
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -17,12 +17,12 @@ A database transaction refers to a sequence of read/write operations that are _g
 
 Prisma provides the following options for using transactions:
 
-- **Nested writes**: use the Prisma Client API to process a transaction on one or more related records.
-- **Batch/bulk transactions**: for transactions on more than two records at a time, use the bulk operations `updateMany`, `deleteMany`, and `createMany`.
+- **Nested writes**: use the Prisma Client API to process multiple operations on one or more related records inside the same transaction.
+- **Batch/bulk transactions**: to process one or more operations in bulk at a time, use the bulk operations `updateMany`, `deleteMany`, and `createMany`.
 - **The `$transactions` API call**: use this call to either:
-  - pass an array of Prisma Client operations to be executed sequentially
+  - pass an array of Prisma Client queries to be executed sequentially inside a transaction
     OR
-  - pass a function in which you can perform one transaction, a function that executes a set of [(interactive) transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview), such as Prisma Client queries, non-Prisma queries, and other code.
+  - pass a function that can contain arbitrary code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction.
 
 ## Nested writes
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -21,7 +21,6 @@ Prisma provides the following options for using transactions:
 - **Batch / bulk transactions**: to process one or more operations in bulk via `updateMany`, `deleteMany`, and `createMany`.
 - **The `$transaction` calls**:
   - `$transaction<R>(queries: PrismaPromise<R>[]): Promise<R[]>`: Pass an array of Prisma Client queries to be executed sequentially inside of a transaction.
-    OR
   - pass a function that can contain arbitrary code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction.
 
 ## Nested writes

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -18,7 +18,7 @@ A database transaction refers to a sequence of read/write operations that are _g
 Prisma provides the following options for using transactions:
 
 - **Nested writes**: to write relational data on one or more related records to your database in a single transaction.
-- **Batch/bulk transactions**: to process one or more operations in bulk at a time, use the bulk operations `updateMany`, `deleteMany`, and `createMany`.
+- **Batch / bulk transactions**: to process one or more operations in bulk via `updateMany`, `deleteMany`, and `createMany`.
 - **The `$transactions` API call**: use this call to either:
   - pass an array of Prisma Client queries to be executed sequentially inside a transaction
     OR

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -74,7 +74,7 @@ The following bulk operations run as transactions:
 
 ## The <inlinecode>$transaction</inlinecode> API
 
-The `$transactions` API can be used in two ways:
+The `$transaction` API can be used in two ways:
 
 - sequential operations: pass an array of Prisma Client operations that will be executed sequentially
 - interactive transactions (in Preview): pass a function in which you can perform a random set of (interactive) transactions

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -17,7 +17,7 @@ A database transaction refers to a sequence of read/write operations that are _g
 
 Prisma provides the following options for using transactions:
 
-- **Nested writes**: use the Prisma Client API to process multiple operations on one or more related records inside the same transaction.
+- **Nested writes**: to write relational data on one or more related records to your database in a single transaction.
 - **Batch/bulk transactions**: to process one or more operations in bulk at a time, use the bulk operations `updateMany`, `deleteMany`, and `createMany`.
 - **The `$transactions` API call**: use this call to either:
   - pass an array of Prisma Client queries to be executed sequentially inside a transaction

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -13,6 +13,17 @@ A database transaction refers to a sequence of read/write operations that are _g
 
 </TopBlock>
 
+## About transactions in Prisma
+
+Prisma provides the following options for using transactions:
+
+- **Nested writes**: use the Prisma Client API to process a transaction on one or more related records.
+- **Batch/bulk transactions**: for transactions on more than two records at a time, use the bulk operations `updateMany`, `deleteMany`, and `createMany`.
+- **The `$transactions` API call**: use this call to either:
+  - pass an array of Prisma Client operations to be executed sequentially
+    OR
+  - pass a function in which you can perform a random set of [(interactive) transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview)
+
 ## Nested writes
 
 A [nested write](relation-queries#nested-writes) lets you perform a single Prisma Client API call with multiple _operations_ that touch multiple [_related_](/concepts/components/prisma-schema/relations) records. For example, creating a _user_ together with a _post_ or updating an _order_ together with an _invoice_. Prisma Client ensures that all operations succeed or fail as a whole.
@@ -63,6 +74,13 @@ The following bulk operations run as transactions:
 
 ## The <inlinecode>$transaction</inlinecode> API
 
+The `$transactions` API can be used in two ways:
+
+- sequential operations: pass an array of Prisma Client operations that will be executed sequentially
+- interactive transactions (in Preview): pass a function in which you can perform a random set of (interactive) transactions
+
+### Sequential Prisma Client operations
+
 The following query returns all posts that match the provided filter as well as a count of all posts:
 
 ```ts
@@ -102,7 +120,7 @@ generator client {
 
 Then you can pass an async function into [`$transaction`](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
 
-#### Example
+Let's look at an example:
 
 Imagine that you are building an online banking system. One of the actions to perform is to send money from one person to another.
 
@@ -220,7 +238,6 @@ Transaction isolation level is not currently configurable at a Prisma level and 
 - [Default transaction isolation level in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
 - [Default transaction isolation level in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
 - [Default transaction isolation level in MySQL](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
-
 
 ## Join the Conversation on GitHub
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -17,7 +17,7 @@ A database transaction refers to a sequence of read/write operations that are _g
 
 Prisma provides the following options for using transactions:
 
-- **Nested writes**: to write relational data on one or more related records to your database in a single transaction.
+- **Nested writes**: use the Prisma Client API to process multiple operations on one or more related records inside the same transaction.
 - **Batch / bulk transactions**: to process one or more operations in bulk via `updateMany`, `deleteMany`, and `createMany`.
 - **The `$transaction` calls**:
   - `$transaction<R>(queries: PrismaPromise<R>[]): Promise<R[]>`: Pass an array of Prisma Client queries to be executed sequentially inside of a transaction.


### PR DESCRIPTION
Added a new Intro section and a few other tweaks to clarify what options Prisma has for Transactions. This work started out with the need to clarify that one of the Examples was specifically for interactive transactions, but morphed into a heavier rewrite.