### PR TITLE
Update 150-db-push.mdx

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
@@ -23,7 +23,7 @@ The Migration Engine used by `db push` does not currently support the [MongoDB c
 
 > **Notes**: 
    * `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
-   * When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details, refer to our [Getting Started documentation](https://www.prisma.io/docs/getting-started/setup-prisma).
+   * When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details, refer to our Getting Started documentation, either [Start from scratch](/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale) or [Add to existing project](/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale) depending on your situation.
 
 </TopBlock>
 

--- a/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
@@ -23,7 +23,7 @@ The Migration Engine used by `db push` does not currently support the [MongoDB c
 
 > **Notes**: 
    * `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
-   * when working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details, refer to our [Getting Started documentation](https://www.prisma.io/docs/getting-started/setup-prisma).
+   * When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details, refer to our [Getting Started documentation](https://www.prisma.io/docs/getting-started/setup-prisma).
 
 </TopBlock>
 

--- a/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
@@ -21,7 +21,9 @@ The Migration Engine used by `db push` does not currently support the [MongoDB c
    - Throw an error
    - Require the `--accept-data-loss` option if you still want to make the changes
 
-> **Note**: `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
+> **Notes**: 
+   * `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
+   * when working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details, refer to our [Getting Started documentation](https://www.prisma.io/docs/getting-started/setup-prisma).
 
 </TopBlock>
 


### PR DESCRIPTION
Added a Note to tell users of PlanetScale that we recommend `db push` instead of `migrate`. Added a link to the Getting Started docs... but after the PlanetScale-specific docs are published, we can change that link to be more specific. And we can add more details to the upcoming Guide as well, about WHY we recommend `db push`. See [Issue #7282](https://github.com/prisma/prisma/issues/7292#issuecomment-988624732).

