### PR TITLE
Fix typo in 060-full-text-search.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -170,7 +170,7 @@ For the full range of supported operations, see the [MySQL full text search docu
 
 ### PostgreSQL
 
-To speed up your full-text queries, you should add an index to your database. Prisma Migrate currently doesn't support adding search indices in PostgreSQL, so this should be added in SQL. For example, the following SQL statement would add an index called `post_body_index` on the `posts_body_index` column of the `posts` table:
+To speed up your full-text queries, you should add an index to your database. Prisma Migrate currently doesn't support adding search indices in PostgreSQL, so this should be added in SQL. For example, the following SQL statement would add an index called `post_body_index` on the `body` column of the `posts` table:
 
 ```sql
 CREATE INDEX post_body_index ON posts USING GIN (body);


### PR DESCRIPTION
Did you mean `body` instead of `post_body_index`?
