### PR TITLE
fix(homepage): Remove trailing slash from URL of Getting Started button

### DIFF
--- a/config.js
+++ b/config.js
@@ -74,7 +74,7 @@ const config = {
       buttons: [
         {
           text: 'Getting started',
-          url: 'getting-started/',
+          url: 'getting-started',
           special: true,
           icon: 'DoubleArrow',
         },


### PR DESCRIPTION
No more trailng slash on this button: 
![image](https://user-images.githubusercontent.com/183673/149151189-df3bfb5d-54c2-478b-ae7a-e0c8247f3c3f.png)
