### PR TITLE
docs: add missing definition

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
@@ -38,6 +38,7 @@ Here's a short explanation of each component:
 
 - `USER`: The name of your database user
 - `PASSWORD`: The password for your database user
+- `HOST`: The name of your host name (for the local environment, it is `localhost`)
 - `PORT`: The port where your database server is running (typically `5432` for PostgreSQL)
 - `DATABASE`: The name of the [database](https://www.postgresql.org/docs/12/manage-ag-overview.html)
 - `SCHEMA`: The name of the [schema](https://www.postgresql.org/docs/12/ddl-schemas.html) inside the database


### PR DESCRIPTION
All entries of the connection URL were described beside the HOST name.

I've added the missing definition.