### PR TITLE
Remove absolute link

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
@@ -143,7 +143,7 @@ model User {
 }
 ```
 
-You are now ready to push your new schema to your database. Connect to your `main` branch using the instructions in [Connect your database](https://www.prisma.io/docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale/)<!-- Absolute external link as otherwise the link checker reports this link as broken even it should be valid -->.
+You are now ready to push your new schema to your database. Connect to your `main` branch using the instructions in [Connect your database](/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale)
 
 Now use the `db push` CLI command to push to the `main` branch:
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
@@ -143,7 +143,7 @@ model User {
 }
 ```
 
-You are now ready to push your new schema to your database. Connect to your `main` branch using the instructions in [Connect your database](/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale)
+You are now ready to push your new schema to your database. Connect to your `main` branch using the instructions in [Connect your database](/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale).
 
 Now use the `db push` CLI command to push to the `main` branch:
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -41,6 +41,7 @@ const gatsbyRemarkPlugins = [
         '/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres',
         '/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale',
         '/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale',
+        '/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale',
       ],
     },
   },


### PR DESCRIPTION
Remove absolute link to tech switcher content that was triggering a broken link error, and add to gatsby-config ignore list

## Describe this PR



## Changes



## What issue does this fix?




## Any other relevant information


