### PR TITLE
chore: Remove all occurrences of https://www.prisma.io/docs from the docs, use internal links instead

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-referential-integrity.mdx
@@ -86,7 +86,7 @@ In the case where referential integrity is emulated in the Prisma client using t
 
 Currently Prisma only implements the referential actions. Foreign keys also create constraints, which make it impossible to manipulate data in a way that would violate these constraints: instead of executing the query, the database responds with an error. These constraints will not be created if you emulate referential integrity in the client, so if you set the referential action to [`NoAction`](/concepts/components/prisma-schema/relations/referential-actions#noaction) there will be no checks to prevent you from breaking the referential integrity.
 
-Another current limitation when emulating referential integrity in Prisma is that any [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) database queries will not trigger any of the actions, and they should be handled manually if deleting or updating records using the [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) queries.
+Another current limitation when emulating referential integrity in Prisma is that any [`raw`](/concepts/components/prisma-client/raw-database-access) database queries will not trigger any of the actions, and they should be handled manually if deleting or updating records using the [`raw`](/concepts/components/prisma-client/raw-database-access) queries.
 
 When using the `db pull` command, existing relations are kept in the data model. This has some caveats:
 
@@ -126,4 +126,4 @@ In the case where referential integrity is handled in the database using the `fo
 - ⟒ Not supported on SQL Server
 - ⟑ Not supported on MySQL/InnoDB
 
-In this mode the [`raw`](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) database queries will trigger actions accordingly.
+In this mode the [`raw`](/concepts/components/prisma-client/raw-database-access) database queries will trigger actions accordingly.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/500-troubleshooting-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/500-troubleshooting-relations.mdx
@@ -264,8 +264,8 @@ model Category {
 
 ### Problem
 
-Some cloud providers enforce the existence of primary keys in all tables. However, any relation tables (JOIN tables) created by Prisma (expressed via `@relation`) for many-tomany relations using implicit syntax do not have primary keys. 
+Some cloud providers enforce the existence of primary keys in all tables. However, any relation tables (JOIN tables) created by Prisma (expressed via `@relation`) for many-tomany relations using implicit syntax do not have primary keys.
 
 ### Solution
 
-You need to use [explicit relation syntax](https://www.prisma.io/docs/concepts/components/prisma-schema/relations/many-to-many-relations#explicit-many-to-many-relations), manually create the join model, and verify that this join model has a primary key. 
+You need to use [explicit relation syntax](/concepts/components/prisma-schema/relations/many-to-many-relations#explicit-many-to-many-relations), manually create the join model, and verify that this join model has a primary key.

--- a/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
@@ -252,7 +252,7 @@ The following constraints apply when you combine `groupBy` and `orderBy`:
 
 #### Order by aggregate group
 
-You can **order by aggregate group**. Prisma added support for using `orderBy with aggregated groups in relational databases in version [2.21.0](https://github.com/prisma/prisma/releases/2.21.0) and support for MongoDB in [3.4.0](https://github.com/prisma/prisma/releases/3.4.0). 
+You can **order by aggregate group**. Prisma added support for using `orderBy with aggregated groups in relational databases in version [2.21.0](https://github.com/prisma/prisma/releases/2.21.0) and support for MongoDB in [3.4.0](https://github.com/prisma/prisma/releases/3.4.0).
 
 The following example sorts each `city` group by the number of users in that group (largest group first):
 
@@ -334,7 +334,7 @@ The ability to count relations is available in version [2.20.0](https://github.c
 <Admonition type="tip">
 
 **For versions below 3.0.1**<br />
-You need to add the [preview feature](https://www.prisma.io/docs/concepts/components/preview-features/client-preview-features#enabling-a-prisma-client-preview-feature) `selectRelationCount` and then run `prisma generate`.
+You need to add the [preview feature](/concepts/components/preview-features/client-preview-features#enabling-a-prisma-client-preview-feature) `selectRelationCount` and then run `prisma generate`.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/03-prisma-migrate/100-legacy-migrate.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/100-legacy-migrate.mdx
@@ -105,7 +105,7 @@ prisma migrate up --experimental
 
 ##### 2. Create two new tables `Post` and `Profile` with foreign keys to `User`
 
-Add two models with [relation fields](https://www.prisma.io/docs/concepts/components/prisma-schema/relations#relation-fields) to your Prisma schema:
+Add two models with [relation fields](/concepts/components/prisma-schema/relations#relation-fields) to your Prisma schema:
 
 ```prisma
 model User {

--- a/content/200-concepts/100-components/07-prisma-data-platform.mdx
+++ b/content/200-concepts/100-components/07-prisma-data-platform.mdx
@@ -9,7 +9,7 @@ tocDepth: 2
 
 <TopBlock>
 
-The [Prisma Data Platform](https://cloud.prisma.io/) (Early Access) provides a collaborative, cloud-based environment supporting application developers who are using Prisma and other open source tools. The main features of the Platform include an [online data browser](https://www.prisma.io/blog/prisma-online-data-browser-ejgg5c8p3u4x), a query console, a [data proxy](https://www.prisma.io/docs/concepts/components/prisma-data-platform#prisma-data-proxy) (purpose-built for Prisma!), and integration with your Prisma schema and databases.
+The [Prisma Data Platform](https://cloud.prisma.io/) (Early Access) provides a collaborative, cloud-based environment supporting application developers who are using Prisma and other open source tools. The main features of the Platform include an [online data browser](https://www.prisma.io/blog/prisma-online-data-browser-ejgg5c8p3u4x), a query console, a [data proxy](/concepts/components/prisma-data-platform#prisma-data-proxy) (purpose-built for Prisma!), and integration with your Prisma schema and databases.
 
 You can access the Prisma Data Platform from [cloud.prisma.io](https://cloud.prisma.io).
 
@@ -23,7 +23,7 @@ In the current version of the platform, you can:
 - Browse your data using Data Browser and query your database directly with Query Console
 - View your Prisma schema
 - Invite users and assign roles
-- Connect your application to your database from serverless environments using [Prisma Data Proxy](https://www.prisma.io/docs/concepts/components/prisma-data-platform#prisma-data-proxy)
+- Connect your application to your database from serverless environments using [Prisma Data Proxy](/concepts/components/prisma-data-platform#prisma-data-proxy)
 
 ## User Roles
 
@@ -202,7 +202,7 @@ Usage exceeded, retry again later
 
 #### Providing the connection string to Prisma Migrate
 
-Currently, the Data Proxy can only be used to query your database with [Prisma Client](https://www.prisma.io/docs/concepts/components/prisma-client).
+Currently, the Data Proxy can only be used to query your database with [Prisma Client](/concepts/components/prisma-client).
 
 Migrations can be only be run on a direct (non-proxied) database connection. Assuming that your schema uses `env("DATABASE_URL")`, you'll need to override the `DATABASE_URL` environment variable before running `prisma migrate`. You can declare another environment variable, for example `MIGRATE_DATABASE_URL`, and use it that to override the connection:
 
@@ -226,7 +226,7 @@ Our Vercel Deployment sample repository has a [branch](https://github.com/prisma
 
 #### Deploying to Cloudflare Workers
 
-The Prisma Data Proxy allows you to deploy Prisma projects to Cloudflare Workers. To learn more, check out the [Cloudflare Workers deployment guide](https://www.prisma.io/docs/guides/deployment/deployment-guides/deploying-to-cloudflare-workers).
+The Prisma Data Proxy allows you to deploy Prisma projects to Cloudflare Workers. To learn more, check out the [Cloudflare Workers deployment guide](/guides/deployment/deployment-guides/deploying-to-cloudflare-workers).
 
 #### Connecting to a database hosted with a provider different than AWS
 

--- a/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
@@ -13,9 +13,10 @@ The following [Preview](/about/prisma/releases#preview) feature flags are availa
 - [`fullTextSearch`](/concepts/components/prisma-client/full-text-search) since release [2.30.0](https://github.com/prisma/prisma/releases/tag/2.30.0) - [Submit feedback](https://github.com/prisma/prisma/issues/8877)
 - [`referentialIntegrity`](/concepts/components/prisma-schema/relations/referential-integrity) since release [3.1.1](https://github.com/prisma/prisma/releases/tag/3.1.1) - [Submit feedback](https://github.com/prisma/prisma/issues/9380)
 - [`dataProxy`](/concepts/components/prisma-data-platform#prisma-data-proxy) since release [3.3.0](https://github.com/prisma/prisma/releases/tag/3.3.0) - [Submit feedback](https://github.com/prisma/prisma/issues/9841)
-- [`extendedIndexes`](https://www.prisma.io/docs/concepts/components/prisma-schema/indexes#index-configuration) since release [3.5.0](https://github.com/prisma/prisma/releases/tag/3.5.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10540)
-- [`fullTextIndex`](https://www.prisma.io/docs/concepts/components/prisma-schema/indexes#full-text-indexes-mysql-and-mongodb) since release [3.6.0](https://github.com/prisma/prisma/releases/tag/3.6.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10539)   
-   
+- [`extendedIndexes`](/concepts/components/prisma-schema/indexes#index-configuration) since release [3.5.0](https://github.com/prisma/prisma/releases/tag/3.5.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10540)
+- [`fullTextIndex`](/concepts/components/prisma-schema/indexes#full-text-indexes-mysql-and-mongodb) since release [3.6.0](https://github.com/prisma/prisma/releases/tag/3.6.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10539)  
+
+
 To enable a Preview feature, [add the feature flag to the `generator` block](#enabling-a-prisma-client-preview-feature) in the `schema.prisma` file. [Share your feedback on all Preview features on GitHub](https://github.com/prisma/prisma/issues/3108).
 
 </TopBlock>

--- a/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
@@ -14,8 +14,7 @@ The following [Preview](/about/prisma/releases#preview) feature flags are availa
 - [`referentialIntegrity`](/concepts/components/prisma-schema/relations/referential-integrity) since release [3.1.1](https://github.com/prisma/prisma/releases/tag/3.1.1) - [Submit feedback](https://github.com/prisma/prisma/issues/9380)
 - [`dataProxy`](/concepts/components/prisma-data-platform#prisma-data-proxy) since release [3.3.0](https://github.com/prisma/prisma/releases/tag/3.3.0) - [Submit feedback](https://github.com/prisma/prisma/issues/9841)
 - [`extendedIndexes`](/concepts/components/prisma-schema/indexes#index-configuration) since release [3.5.0](https://github.com/prisma/prisma/releases/tag/3.5.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10540)
-- [`fullTextIndex`](/concepts/components/prisma-schema/indexes#full-text-indexes-mysql-and-mongodb) since release [3.6.0](https://github.com/prisma/prisma/releases/tag/3.6.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10539)  
-
+- [`fullTextIndex`](/concepts/components/prisma-schema/indexes#full-text-indexes-mysql-and-mongodb) since release [3.6.0](https://github.com/prisma/prisma/releases/tag/3.6.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10539)
 
 To enable a Preview feature, [add the feature flag to the `generator` block](#enabling-a-prisma-client-preview-feature) in the `schema.prisma` file. [Share your feedback on all Preview features on GitHub](https://github.com/prisma/prisma/issues/3108).
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -834,7 +834,7 @@ generator client {
 }
 ```
 
-Then you can pass an async function into [$transaction](https://www.prisma.io/docs/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
+Then you can pass an async function into [$transaction](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
 
 In the example below, Alice and Bob each have $100 in their account. If they try to send more money than they have, the transfer is rejected.
 
@@ -894,7 +894,7 @@ In the example above, both `update` queries run within a database transaction. W
 
 If the application encounters an error along the way, the async function will throw an exception and automatically **rollback** the transaction.
 
-You can learn more about interactive transactions in our [Transactions and Batch Queries documentation](https://www.prisma.io/docs/concepts/components/prisma-client/transactions#interactive-transactions-in-preview).
+You can learn more about interactive transactions in our [Transactions and Batch Queries documentation](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview).
 
 <Admonition type="warning">
 

--- a/content/300-guides/150-testing/150-integration-testing.mdx
+++ b/content/300-guides/150-testing/150-integration-testing.mdx
@@ -295,7 +295,7 @@ The following tests will check if the `createOrder` function works as it should 
 - Creating an order with an existing customer
 - Show an "Out of stock" error message if a product doesn't exist
 
-Before the test suite is run the database is seeded with data. After the test suite has finished a [`deleteMany`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#deletemany) <span class="api"></span> is used to clear the database of its data.
+Before the test suite is run the database is seeded with data. After the test suite has finished a [`deleteMany`](/reference/api-reference/prisma-client-reference#deletemany) <span class="api"></span> is used to clear the database of its data.
 
 <Tip>
 

--- a/content/300-guides/200-deployment/110-deployment-guides/150-deploying-to-azure-functions.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/150-deploying-to-azure-functions.mdx
@@ -299,7 +299,7 @@ And add the following contents to it:
 
 With the `DATABASE_URL` environment variable set, you will create the database schema using the [`prisma migrate deploy`](/reference/api-reference/command-reference#migrate-deploy) command.
 
-> **Note:** The `prisma migrate deploy` command will run migration files from the `prisma/migrations` folder. The initial migration is already included in the example. To learn more about how to create migrations, check out the [Prisma Migrate](https://www.prisma.io/docs/concepts/components/prisma-migrate) docs.
+> **Note:** The `prisma migrate deploy` command will run migration files from the `prisma/migrations` folder. The initial migration is already included in the example. To learn more about how to create migrations, check out the [Prisma Migrate](/concepts/components/prisma-migrate) docs.
 
 Run the following command to create the database schema:
 

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/100-named-constraints.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/050-upgrading-to-prisma-3/100-named-constraints.mdx
@@ -88,7 +88,7 @@ Afterwards, do not forget to `prisma migrate deploy` against your production env
      name  String @id //inferred as User_pkey
      posts Post[]
    }
-
+   
    model Post {
      id         Int    @id @default(autoincrement()) //inferred as Post_pkey
      authorName String @default("Anonymous")
@@ -104,7 +104,7 @@ Afterwards, do not forget to `prisma migrate deploy` against your production env
 
    This migration renames any constraints that do not currently follow Prisma's naming convention.
 
-1. Run the [`prisma migrate deploy`](https://www.prisma.io/docs/guides/deployment/deploy-database-changes-with-prisma-migrate) command to apply the migration to your production environment:
+1. Run the [`prisma migrate deploy`](/guides/deployment/deploy-database-changes-with-prisma-migrate) command to apply the migration to your production environment:
 
    ```terminal
    npx prisma migrate deploy

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
@@ -32,13 +32,13 @@ Once you're done with that guide, you can choose **one of the following four gui
 
 On a high-level, the biggest differences between Prisma 1 and Prisma 2 are the following:
 
-- Prisma 2 doesn't require hosting a database proxy server (i.e., the [Prisma server](https://www.prisma.io/docs/1.34/prisma-server/)).
+- Prisma 2 doesn't require hosting a database proxy server (i.e., the [Prisma server](https://v1.prisma.io/docs/1.34/prisma-server/)).
 - Prisma 2 makes the features of Prisma 1 more modular and splits them into dedicated tools:
   - Prisma Client: An improved version of Prisma client 1.0
   - Prisma Migrate: Data modeling and migrations (formerly `prisma deploy`).
 - Prisma 1 datamodel and `prisma.yml` have been merged into the [Prisma schema](/concepts/components/prisma-schema).
 - Prisma 2 uses its own [modeling language](https://github.com/prisma/specs/tree/master/schema) instead of being based on GraphQL SDL.
-- Prisma 2 doesn't expose ["a GraphQL API for your database"](https://www.prisma.io/blog/prisma-and-graphql-mfl5y2r7t49c/) anymore, but only allows for _programmatic access_ via the Prisma Client API. This means Prisma 2 [doesn't support Prisma binding](https://www.prisma.io/docs/more/faq#does-prisma-client-support-graphql-schema-delegation-and-graphql-binding) any more.
+- Prisma 2 doesn't expose ["a GraphQL API for your database"](https://www.prisma.io/blog/prisma-and-graphql-mfl5y2r7t49c/) anymore, but only allows for _programmatic access_ via the Prisma Client API. This means Prisma 2 [doesn't support Prisma binding](/more/faq#does-prisma-client-support-graphql-schema-delegation-and-graphql-binding) any more.
 - More powerful introspection allows connecting Prisma 2 to any existing database
 
 ## Feature parity

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
@@ -32,13 +32,13 @@ Once you're done with that guide, you can choose **one of the following four gui
 
 On a high-level, the biggest differences between Prisma 1 and Prisma 2 are the following:
 
-- Prisma 2 doesn't require hosting a database proxy server (i.e., the [Prisma server](https://v1.prisma.io/docs/1.34/prisma-server/)).
+- Prisma 2 doesn't require hosting a database proxy server (i.e., the [Prisma server](https://www.prisma.io/docs/1.34/prisma-server/)).
 - Prisma 2 makes the features of Prisma 1 more modular and splits them into dedicated tools:
   - Prisma Client: An improved version of Prisma client 1.0
   - Prisma Migrate: Data modeling and migrations (formerly `prisma deploy`).
 - Prisma 1 datamodel and `prisma.yml` have been merged into the [Prisma schema](/concepts/components/prisma-schema).
 - Prisma 2 uses its own [modeling language](https://github.com/prisma/specs/tree/master/schema) instead of being based on GraphQL SDL.
-- Prisma 2 doesn't expose ["a GraphQL API for your database"](https://www.prisma.io/blog/prisma-and-graphql-mfl5y2r7t49c/) anymore, but only allows for _programmatic access_ via the Prisma Client API. This means Prisma 2 [doesn't support Prisma binding](/more/faq#does-prisma-client-support-graphql-schema-delegation-and-graphql-binding) any more.
+- Prisma 2 doesn't expose ["a GraphQL API for your database"](https://www.prisma.io/blog/prisma-and-graphql-mfl5y2r7t49c/) anymore, but only allows for _programmatic access_ via the Prisma Client API. This means Prisma 2 [doesn't support Prisma binding](/about/prisma/faq#does-prisma-client-support-graphql-schema-delegation-and-graphql-binding) any more.
 - More powerful introspection allows connecting Prisma 2 to any existing database
 
 ## Feature parity

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/07-upgrading-a-rest-api.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/07-upgrading-a-rest-api.mdx
@@ -6,7 +6,7 @@ metaDescription: 'Learn how to upgrade a REST API from Prisma 1 to Prisma 2.'
 
 ## Overview
 
-This upgrade guide describes how to migrate a Node.js project that's based on [Prisma 1](https://github.com/prisma/prisma1) and uses the [Prisma 1 client](https://www.prisma.io/docs/prisma-client/) to implement a REST API.
+This upgrade guide describes how to migrate a Node.js project that's based on [Prisma 1](https://github.com/prisma/prisma1) and uses the [Prisma 1 client](https://v1.prisma.io/docs/1.34/prisma-client/) to implement a REST API.
 
 The guide assumes that you already went through the [guide for upgrading the Prisma layer](/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres). This means you already:
 
@@ -124,7 +124,7 @@ app.listen(3000, () =>
 )
 ```
 
-Consider each occurrence of the Prisma client instance `prisma` and replacing with the respective usage of Prisma Client 2. You can learn more in the [API Reference](https://www.prisma.io/docs/concepts/components/prisma-client).
+Consider each occurrence of the Prisma client instance `prisma` and replacing with the respective usage of Prisma Client 2. You can learn more in the [API Reference](/concepts/components/prisma-client).
 
 ### 1.1. Adjusting the import
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4337,7 +4337,7 @@ const updatePosts = await prisma.post.updateMany({
 
 ## <inlinecode>JSON</inlinecode> filters
 
-JSON filters are currently in **[Preview](https://www.prisma.io/docs/about/prisma/platform-releases)**. To use JSON filters in your queries, you need to [enable](https://www.prisma.io/docs/guides/upgrade-guides/upgrading-to-use-preview-features#enabling-preview-features) the `filterJson` preview feature.
+JSON filters are currently in **[Preview](/about/prisma/platform-releases)**. To use JSON filters in your queries, you need to [enable](/guides/upgrade-guides/upgrading-to-use-preview-features#enabling-preview-features) the `filterJson` preview feature.
 
 For use cases and advanced examples, see: [Working with `Json` fields](/concepts/components/prisma-client/working-with-fields/working-with-json-fields) <span class="concepts"></span>
 
@@ -4356,8 +4356,8 @@ The examples in this section assumes that the value of the `pet` field is:
     "dogBreed": "Rottweiler",
     "sanctuaries": ["RSPCA", "Alley Cat Allies"],
     "treats": [
-      { "name": "Dreamies", "manufacturer": "Mars Inc"},
-      { "name": "Treatos", "manufacturer": "The Dog People"}
+      { "name": "Dreamies", "manufacturer": "Mars Inc" },
+      { "name": "Treatos", "manufacturer": "The Dog People" }
     ]
   },
   "fostered": {

--- a/content/500-support/100-help-articles/200-working-with-many-to-many-relations.mdx
+++ b/content/500-support/100-help-articles/200-working-with-many-to-many-relations.mdx
@@ -82,7 +82,7 @@ await prisma.post.update({
 
 ### Explicit relations
 
-Explicit relations mostly need to be created in cases where you need to store extra fields in the relation table or if you're [introspecting](/reference/tools-and-interfaces/introspection) an existing database that already has many-to-many relations setup. This is the same schema used above but with an explicit relation table:
+Explicit relations mostly need to be created in cases where you need to store extra fields in the relation table or if you're [introspecting](/concepts/components/introspection) an existing database that already has many-to-many relations setup. This is the same schema used above but with an explicit relation table:
 
 ```prisma
 model Post {

--- a/content/500-support/100-help-articles/200-working-with-many-to-many-relations.mdx
+++ b/content/500-support/100-help-articles/200-working-with-many-to-many-relations.mdx
@@ -82,7 +82,7 @@ await prisma.post.update({
 
 ### Explicit relations
 
-Explicit relations mostly need to be created in cases where you need to store extra fields in the relation table or if you're [introspecting](https://www.prisma.io/docs/reference/tools-and-interfaces/introspection) an existing database that already has many-to-many relations setup. This is the same schema used above but with an explicit relation table:
+Explicit relations mostly need to be created in cases where you need to store extra fields in the relation table or if you're [introspecting](/reference/tools-and-interfaces/introspection) an existing database that already has many-to-many relations setup. This is the same schema used above but with an explicit relation table:
 
 ```prisma
 model Post {

--- a/content/600-about/100-prisma/10-releases.mdx
+++ b/content/600-about/100-prisma/10-releases.mdx
@@ -76,7 +76,7 @@ Beginning with version `3.x.x`, Prisma adheres strictly to the [SemVer](https://
 
 Here is a brief overview of how Prisma's follows SemVer:
 
-- Breaking changes in stable surface (i.e. [General Availability](/about/releases#generally-available-ga)) will only be introduced in new `MAJOR` releases.
+- Breaking changes in stable surface (i.e. [General Availability](#generally-available-ga)) will only be introduced in new `MAJOR` releases.
 - Breaking changes can still be rolled out in `MINOR` but only for opt-in Preview and Early Access features that are not active by default (e.g. via a Preview feature flag or a specific opt-in option or new CLI command).
 - Opt-in breaking changes, i.e. Preview and Early Access, released in `MINOR`, will only be promoted to General Availability (no requirement for opt-in) in new `MAJOR` releases.
 

--- a/content/600-about/100-prisma/10-releases.mdx
+++ b/content/600-about/100-prisma/10-releases.mdx
@@ -76,7 +76,7 @@ Beginning with version `3.x.x`, Prisma adheres strictly to the [SemVer](https://
 
 Here is a brief overview of how Prisma's follows SemVer:
 
-- Breaking changes in stable surface (i.e. [General Availability](https://www.prisma.io/docs/about/releases#generally-available-ga)) will only be introduced in new `MAJOR` releases.
+- Breaking changes in stable surface (i.e. [General Availability](/about/releases#generally-available-ga)) will only be introduced in new `MAJOR` releases.
 - Breaking changes can still be rolled out in `MINOR` but only for opt-in Preview and Early Access features that are not active by default (e.g. via a Preview feature flag or a specific opt-in option or new CLI command).
 - Opt-in breaking changes, i.e. Preview and Early Access, released in `MINOR`, will only be promoted to General Availability (no requirement for opt-in) in new `MAJOR` releases.
 

--- a/content/600-about/100-prisma/40-faq.mdx
+++ b/content/600-about/100-prisma/40-faq.mdx
@@ -41,7 +41,7 @@ Prisma Client is not opinionated on how exactly you migrate your database schema
 
 GraphQL [schema delegation](https://www.prisma.io/blog/graphql-schema-stitching-explained-schema-delegation-4c6caf468405/) connects two GraphQL schemas by passing the [`info`](https://www.prisma.io/blog/graphql-server-basics-demystifying-the-info-argument-in-graphql-resolvers-6f26249f613a/) object from a resolver of the first GraphQL schema to a resolver of the second GraphQL schema. Schema delegation also is the foundation for [GraphQL binding](https://github.com/graphql-binding/graphql-binding).
 
-Prisma 1 officially supports both schema delegation and GraphQL binding as it exposes a GraphQL CRUD API through the [Prisma server](https://www.prisma.io/docs/prisma-server/). This API can be used to as the foundation for an application-layer GraphQL API created with GraphQL binding.
+Prisma 1 officially supports both schema delegation and GraphQL binding as it exposes a GraphQL CRUD API through the [Prisma server](https://v1.prisma.io/docs/1.34/prisma-server/). This API can be used to as the foundation for an application-layer GraphQL API created with GraphQL binding.
 
 With Prisma 2.0, Prisma's [query engine](/concepts/components/prisma-engines/query-engine) doesn't expose a [spec](https://graphql.github.io/graphql-spec/June2018/)-compliant GraphQL endpoint any more, so usage of schema delegation and GraphQL binding with Prisma 2.0 is not supported. To build GraphQL servers with Prisma 2.0, be sure to check out [GraphQL Nexus](https://nexusjs.org/). GraphQL Nexus provides a code-first and type-safe way to build GraphQL servers in a scalable way.
 
@@ -59,7 +59,7 @@ There's no lock-in when using Prisma Migrate. To stop using Prisma for your migr
 
 Each migration is represented via its own directory on your file system inside a directory called `migrations`. The name of each directory contains a timestamp so that the order of all migrations in the project history can be maintained.
 
-Each of these migration directories contain a `migration.sql` file about the respective migration. The status of the migrations is tracked in the `_prisma_migrations` table in your database/schema. See [migrate status](https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-status).
+Each of these migration directories contain a `migration.sql` file about the respective migration. The status of the migrations is tracked in the `_prisma_migrations` table in your database/schema. See [migrate status](/reference/api-reference/command-reference#migrate-status).
 
 ## Where can I get more information about the plans for Prisma?
 


### PR DESCRIPTION
This fixes all external links that could have been internal links.

Fixed a few broken/redirecting links at the same time so the build passes.