### PR TITLE
fix(gatsby-remark-check-links-numberless): Clarify error message

### DIFF
--- a/plugins/gatsby-remark-check-links-numberless/index.js
+++ b/plugins/gatsby-remark-check-links-numberless/index.js
@@ -178,7 +178,7 @@ module.exports = async function plugin(
       console.error(message)
     }
   } else if (verbose) {
-    console.info('No broken links found')
+    console.info('No internal broken links found')
   }
 
   return markdownAST

--- a/plugins/gatsby-remark-check-links-numberless/index.js
+++ b/plugins/gatsby-remark-check-links-numberless/index.js
@@ -168,7 +168,7 @@ module.exports = async function plugin(
   }
 
   if (totalBrokenLinks) {
-    const message = `${totalBrokenLinks} broken links found`
+    const message = `${totalBrokenLinks} broken (or redirected) internal links found`
     if (process.env.NODE_ENV === 'production') {
       // break builds with broken links before they get deployed for reals
       throw new Error(message)


### PR DESCRIPTION
- Mention that this applies only to internal links
- Mention that this might also meant that the link is redirected (and thus considered broken)
