### PR TITLE
fix(prisma-migrate): Add details to reset explanation

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -281,8 +281,8 @@ This command:
 
 1. Drops the database/schema¹ if possible, or performs a soft reset if the environment does not allow deleting databases/schemas¹
 1. Creates a new database/schema¹ with the same name if the database/schema¹ was dropped
-3. Applies all migrations
-4. Runs seed scripts
+1. Applies all migrations
+1. Runs seed scripts
 
 ¹ For MySQL and MongoDB this refers to the database, for PostgreSQL and SQL Server to the schema, and for SQLite to the database file.
 

--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -263,13 +263,13 @@ The `migrate dev` command will prompt you to reset the database in the following
 - Migration history conflicts caused by [modified or missing migrations](#do-not-edit-or-delete-migrations-that-have-been-applied)
 - The database schema has drifted away from the end-state of the migration history
 
+### Reset the development database
+
 You can also `reset` the database yourself to undo manual changes or `db push` experiments by running:
 
 ```terminal
 npx prisma migrate reset
 ```
-
-### Reset the development database
 
 <Admonition type="alert">
 
@@ -279,10 +279,12 @@ npx prisma migrate reset
 
 This command:
 
-1. Drops the database if possible, or performs a soft reset if the environment does not allow deleting databases
-1. Creates a new database with the same name if the database was dropped
-1. Applies all migrations
-1. Runs seed scripts
+1. Drops the database/schema¹ if possible, or performs a soft reset if the environment does not allow deleting databases/schemas¹
+1. Creates a new database/schema¹ with the same name if the database/schema¹ was dropped
+3. Applies all migrations
+4. Runs seed scripts
+
+¹ For MySQL and MongoDB this refers to the database, for PostgreSQL and SQL Server to the schema, and for SQLite to the database file.
 
 > **Note**: For a simple and integrated way to re-create data in your development database as often as needed, check out our [seeding guide](/guides/database/seed-database).
 


### PR DESCRIPTION
- Adds a footnote about what _exactly_ this means per provider
- Moves the introduction under the headline
- Changes list to be dynamic numbering