### PR TITLE
Update gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,6 +43,7 @@ const gatsbyRemarkPlugins = [
         '/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale',
         '/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale',
         '/getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-planetscale',
+        '/getting-started/setup-prisma/start-from-scratch/mongodb-typescript-mongodb',
       ],
     },
   },


### PR DESCRIPTION
Added an additional exception, so that we don't get broken link errors on /getting-started/setup-prisma/start-from-scratch/mongodb-typescript-mongodb.


