### PR TITLE
Add `--transpile-only` flag to seed script

### DIFF
--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -46,6 +46,7 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
 
 Example:
 `"seed": "ts-node --transpile-only prisma/seed.ts"`
+
 This can be useful to reduce memory usage (RAM) and increase execution speed of the seed script.
 
 </Admonition>  

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -25,6 +25,17 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
   "seed": "ts-node prisma/seed.ts"
 },
 ```
+  
+<Admonition type="info">
+
+`ts-node` does transpiling and typechecking by default; typechecking can be disabled with the following flag `--transpile-only`.
+
+Example:
+`"seed": "ts-node --transpile-only prisma/seed.ts"`
+
+This can be useful to reduce memory usage (RAM) and increase execution speed of the seed script.
+
+</Admonition>   
 
 </tab>
 
@@ -38,18 +49,7 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
 
 </tab>
 
-</TabbedContent>
-
-<Admonition type="info">
-
-`ts-node` does transpiling and typechecking by default, typechecking can be disabled with the following flag `--transpile-only`.
-
-Example:
-`"seed": "ts-node --transpile-only prisma/seed.ts"`
-
-This can be useful to reduce memory usage (RAM) and increase execution speed of the seed script.
-
-</Admonition>  
+</TabbedContent> 
 
 ## Integrated seeding with Prisma Migrate
 

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -43,6 +43,9 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
 <Admonition type="info">
 
 `ts-node` does transpiling and typechecking by default, typechecking can be disabled with the following flag `--transpile-only`.
+
+Example:
+`"seed": "ts-node --transpile-only prisma/seed.ts"`
 This can be useful to reduce memory usage (RAM) and increase execution speed of the seed script.
 
 </Admonition>  

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -28,7 +28,7 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
   
 <Admonition type="info">
 
-`ts-node` does transpiling and typechecking by default; typechecking can be disabled with the following flag `--transpile-only`.
+With TypeScript,`ts-node` does transpiling and typechecking by default; typechecking can be disabled with the following flag `--transpile-only`.
 
 Example:
 `"seed": "ts-node --transpile-only prisma/seed.ts"`

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -22,7 +22,7 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
 
 ```json
 "prisma": {
-  "seed": "ts-node prisma/seed.ts"
+  "seed": "ts-node --transpile-only prisma/seed.ts"
 },
 ```
 

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -42,7 +42,8 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
 
 <Admonition type="info">
 
-When using containers with limited RAM, consider using the `--transpile-only` flag to avoid potential performance issues. The process of typechecking the seed script(s), in addition to transpiling them, can consume large amounts of RAM.
+`ts-node` does transpiling and typechecking by default, typechecking can be disabled with the following flag `--transpile-only`.
+This can be useful to reduce memory usage (RAM) and increase execution speed of the seed script.
 
 </Admonition>  
 

--- a/content/300-guides/050-database/300-seed-database.mdx
+++ b/content/300-guides/050-database/300-seed-database.mdx
@@ -22,7 +22,7 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
 
 ```json
 "prisma": {
-  "seed": "ts-node --transpile-only prisma/seed.ts"
+  "seed": "ts-node prisma/seed.ts"
 },
 ```
 
@@ -39,6 +39,12 @@ Prisma's integrated seeding functionality expects a command in the `"seed"` key 
 </tab>
 
 </TabbedContent>
+
+<Admonition type="info">
+
+When using containers with limited RAM, consider using the `--transpile-only` flag to avoid potential performance issues. The process of typechecking the seed script(s), in addition to transpiling them, can consume large amounts of RAM.
+
+</Admonition>  
 
 ## Integrated seeding with Prisma Migrate
 


### PR DESCRIPTION
Failing to use the `--transpile-only` flag in this context is a catastrophic mistake that consumes massive amounts of RAM when typechecking the seed script(s) unnecessarily, in addition to transpiling them, thereby completely crashing Node in any container with limited RAM i.e. Docker, Heroku, etc. when trying to seed.

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
