### PR TITLE
Primitives guide for failed migrations

### DIFF
--- a/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
@@ -9,23 +9,27 @@ To use a Preview CLI feature, [use the `--preview-feature` flag](./) when you ru
 
 </TopBlock>
 
-## Prisma migrate diff
+## <inlinecode> prisma migrate diff </inlinecode>
 
-This commands examines two database schema sources to create a migration taking the first to the state of the second.
+This command examines two database schema sources to create a migration taking the first to the state of the second.
 The supported types of sources are:
 
 - live databases
 - migration histories
-- Prisma datamodels
+- Prisma data models
 - an empty schema
+
+The format of the command is:
 
 ```terminal
 npx prisma migrate diff --preview-feature --from-empty --to-url $PROD_DATABASE
 ```
 
-## Prisma db execute
+## <inlinecode> prisma db execute </inlinecode>
 
-Applies a SQL script to the database without interacting with the Prisma migrations table. The script can be passed via a file path or stdin.
+This command applies a SQL script to the database without interacting with the Prisma migrations table. The script can be passed via a file path or stdin.
+
+The format of the command is:
 
 ```terminal
 npx prisma db execute --preview-feature --url $PROD_DATABASE --file script.sql

--- a/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
@@ -7,18 +7,26 @@ metaDescription: Prisma CLI features that are currently in preview.
 
 To use a Preview CLI feature, [use the `--preview-feature` flag](./) when you run the command. [Share your feedback on all Preview features on GitHub](https://github.com/prisma/prisma/issues/3108).
 
-<Admonition type="info">
-
-There are currently no Preview CLI features.
-
-</Admonition>
-
 </TopBlock>
 
-<!-- ## Enabling a Prisma CLI preview feature
+## Prisma migrate diff
 
-To use a Prisma CLI Preview feature, append the `--preview-feature` flag each time you run the command:
+This commands examines two database schema sources to create a migration taking the first to the state of the second.
+The supported types of sources are:
+
+- live databases
+- migration histories
+- Prisma datamodels
+- an empty schema
 
 ```terminal
-npx prisma db seed --preview-feature
-``` -->
+npx prisma migrate diff --preview-feature --from-empty --to-url $PROD_DATABASE
+```
+
+## Prisma db execute
+
+Applies a SQL script to the database without interacting with the Prisma migrations table. The script can be passed via a file path or stdin.
+
+```terminal
+npx prisma db execute --preview-feature --url $PROD_DATABASE --file script.sql
+```

--- a/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
@@ -25,6 +25,12 @@ The format of the command is:
 npx prisma migrate diff --preview-feature --from-empty --to-url $PROD_DATABASE
 ```
 
+For details of the available flags for this command, run:
+
+```terminal
+npx prisma migrate diff --help
+```
+
 ## <inlinecode> prisma db execute </inlinecode>
 
 This command applies a SQL script to the database without interacting with the Prisma migrations table. The script can be passed via a file path or stdin.
@@ -33,4 +39,10 @@ The format of the command is:
 
 ```terminal
 npx prisma db execute --preview-feature --url $PROD_DATABASE --file script.sql
+```
+
+For details of the available flags for this command, run:
+
+```terminal
+npx prisma db execute --help
 ```

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -72,11 +72,11 @@ The following example demonstrates how to manually complete the steps of a migra
 
 ## Fixing failed migrations with <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
 
-Starting with 3.9 we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations.
+In versions 3.9.0 and later, we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations.
 
 <Admonition type="warning">
 
-These commands are currently in preview.
+The `migrate diff` and `db execute` commands are currently a [Preview feature](/concepts/components/preview-features/cli-preview-features). To use these commands, you will need to add the `--preview-feature` flag.
 
 </Admonition>
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -74,6 +74,12 @@ The following example demonstrates how to manually complete the steps of a migra
 
 Starting with 3.9 we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations.
 
+<Admonition type="warning">
+
+These commands are currently in preview.
+
+</Admonition>
+
 ### New commands `migrate diff` and `db execute`
 
 The two new commands that we provide are:

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -100,7 +100,7 @@ model User {
 
 At this point, your schemas in sync, but the data in the two environments is different.
 
-You then decide to make changes to your datamodel, adding another `Post` model and making the name field on `User` unique:
+You then decide to make changes to your datamodel, adding another `Post` model and making the `name` field on `User` unique:
 
 ```prisma file=schema.prisma
 model User {
@@ -115,19 +115,26 @@ model Post {
 }
 ```
 
-You create a migration called 'Unique' with `prisma migrate dev` which is saved in your local migrations history. Applying the migration succeeds in your dev environment and now it is time to release to production. Unfortunately, the operation fails, since there is non-unique data in your production database (e.g. two users with the same name).
+You create a migration called 'Unique' with `prisma migrate dev` which is saved in your local migrations history. Applying the migration succeeds in your dev environment and now it is time to release to production.
 
-Migrate returns the error directly from the database which lets you know about the violation of the unique constraint.
+Unfortunately this migration can only be partially executed. Creating the `Post` model and adding the `email` column succeeds, but making the `name` field unique fails with the following error:
 
 ```bash
 ERROR 1062 (23000): Duplicate entry 'paul' for key 'User_name_key'
 ```
 
-You now need to recover manually from the partially executed migration ("partially" as creating the `Post` model and adding the `email` column succeeded). Until you recover from the failed state, further migrations using `prisma migrate deploy` are impossible.
+This is because there is non-unique data in your production database (e.g. two users with the same name).
+
+You now need to recover manually from the partially executed migration. Until you recover from the failed state, further migrations using `prisma migrate deploy` are impossible.
+
+At this point there are two options, depending on what you decide to do with the non-unique data:
+
+- You realize that non-unique data is valid and you cannot move forward with your current development work. You want to roll back the complete migration. To do this, see [Moving backwards and reverting all changes](#moving-backwards-and-reverting-all-changes)
+- The existence of non-unique data in your database is unintentional and you want to fix that. After fixing, you want to go ahead with the rest of the migration. To do this, see [Moving forwards and applying missing changes](#moving-forwards-and-applying-missing-changes)
 
 #### Moving backwards and reverting all changes
 
-You realize that non-unique data is valid and you cannot move forward with your current development work. You want to roll back the complete migration. For this you need to create a migration that takes your production database to the state of your datamodel before the last migration.
+In this case, you need to create a migration that takes your production database to the state of your data model before the last migration.
 
 - First you need your migration history at the time before the failed migration. You can either get this from your git history, or locally delete the folder of the last failed migration in your migration history.
 - You now want to take your production environment from its current failed state back to the state specified in your local migrations history:
@@ -158,12 +165,12 @@ You realize that non-unique data is valid and you cannot move forward with your 
 
 Your local migration history now yields the same result as the state your production database is in. You can now modify the datamodel again to create a migration that suits your new understanding of the feature you're working on (with non-unique names).
 
-#### Moving forward and applying missing changes
+#### Moving forwards and applying missing changes
 
-The existence of non-unique data in your database is unintentional and you want to fix that. Once fixed, you are able to go ahead with the migration as planned:
+In this case, you need to fix the non-unique data and then go ahead with the rest of the migration as planned:
 
 - The error message from trying to deploy the migration to production already told you there was duplicate data in the column `name`. You need to either alter or delete the offending rows.
-- Continue applying the rest of the failed migration to get to the datamodel defined in your prisma.schema:
+- Continue applying the rest of the failed migration to get to the data model defined in your prisma.schema:
 
   - Run the following `prisma migrate diff` command:
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -70,7 +70,7 @@ The following example demonstrates how to manually complete the steps of a migra
    prisma migrate resolve --applied "20201127134938_my_migration"
    ```
 
-## Fixing failed migrations with migrate diff and db execute
+## Fixing failed migrations with <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
 
 Starting with 3.9 we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations.
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -98,7 +98,7 @@ model User {
 }
 ```
 
-At this point, your schemas in sync, but the data in the two environments is different.
+At this point, your schemas are in sync, but the data in the two environments is different.
 
 You then decide to make changes to your data model, adding another `Post` model and making the `name` field on `User` unique:
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -100,7 +100,7 @@ model User {
 
 At this point, your schemas in sync, but the data in the two environments is different.
 
-You then decide to make changes to your datamodel, adding another `Post` model and making the `name` field on `User` unique:
+You then decide to make changes to your data model, adding another `Post` model and making the `name` field on `User` unique:
 
 ```prisma file=schema.prisma
 model User {
@@ -115,7 +115,7 @@ model Post {
 }
 ```
 
-You create a migration called 'Unique' with `prisma migrate dev` which is saved in your local migrations history. Applying the migration succeeds in your dev environment and now it is time to release to production.
+You create a migration called 'Unique' with the command `prisma migrate dev -n Unique` which is saved in your local migrations history. Applying the migration succeeds in your dev environment and now it is time to release to production.
 
 Unfortunately this migration can only be partially executed. Creating the `Post` model and adding the `email` column succeeds, but making the `name` field unique fails with the following error:
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -33,7 +33,7 @@ There are two ways to deal with failed migrations in a production environment:
 - Roll back, optionally fix issues, and re-deploy
 - Manually complete the migration steps and resolve the migration
 
-#### Option 1: Mark the migration as rolled back and re-deploy
+### Option 1: Mark the migration as rolled back and re-deploy
 
 The following example demonstrates how to roll back a migration, optionally make changes to fix the issue, and re-deploy:
 
@@ -69,6 +69,76 @@ The following example demonstrates how to manually complete the steps of a migra
    ```terminal
    prisma migrate resolve --applied "20201127134938_my_migration"
    ```
+
+## Fixing failed migrations with migrate diff and db execute
+
+Starting with 3.9 we are offering two new commands in preview that can be used to fix failed migrations.
+
+### New commands `migrate diff` and `db execute`
+
+The two new commands we are using to fix the scenario from above are:
+`prisma migrate diff` which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
+`prisma db execute` which applies a SQL script to the database without interacting with the Prisma migrations table.
+
+### Example of a failed migration
+
+Imagine the following scenario: Your local development environment and your production database schema are in sync. But of course the data in both environments is different.
+
+```
+model User {
+  id    Int     @id
+  name  String
+ }
+```
+
+You then decide to make changes to your datamodel, adding another model and making the name field on User unique:
+
+```
+model User {
+  id    Int     @id
+  name  String  @unique
+  email String?
+}
+
+model Post {
+  id    Int    @id
+  title String
+}
+```
+
+You created a migration called 'Unique' with `prisma migrate dev` which was saved in your local migrations history. Applying the migration succeeded in your dev environment and now it is time to release to production. Unfortunately, the operation fails, since there is non-unique data in your production database (e.g. two users with the same name).
+
+Migrate returned the error directly from the database which lets you know about the violation of the unique constraint.
+
+```bash
+ERROR 1062 (23000): Duplicate entry 'paul' for key 'User_name_key'
+```
+
+You now need to recover manually from the partially executed migration ("partially" as creating the Post model and adding the email column succeeded). Before you are able to recover from the failed state further migrations using `prisma migrate deploy` are impossible.
+
+#### Moving forward and applying missing changes
+
+The existence of non-unique data in your database is unintentional and you want to fix that. Once fixed, you are able to go ahead with the migration as planned:
+
+- The error message from trying to deploy the migration to production already told you there was duplicate data in the column 'name'. You need to either alter or delete the offending rows.
+- Continue applying the rest of the failed migration to get to the datamodel defined in your prisma.schema:
+  - Run **npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-schema-datamodel schema.prisma --script > forward.sql** which will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined in your prisma.schema.
+  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file forward.sql** which apply the changes in the sql script against the target database without interacting with the migrations table.
+  - Run **npx prisma migrate resolve --applied Unique** which will mark the failed migration called 'Unique' in the migrations table on your production environment as applied.
+
+Your local migration history now yields the same result as the state your production environment is in. You can now continue using the already known `migrate dev` /`migrate deploy` workflow.
+
+#### Moving backwards and reverting all changes
+
+You realize that non-unique data is valid and you cannot move forward with your current development work. You want to roll back the complete migration. For this you need to create a migration that takes your prod db to the state of your datamodel before the last migration.
+
+- First you need your migration history at the time before the failed migration. You can either get this from your git history, or locally delete the folder of the last failed migration in your miggration history.
+- You now want to take your production environment from its current failed state back to the state specified in your local migrations history:
+  - Run **npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql** which will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
+  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file backward.sql** which apply the changes in the sql script against the target database without interacting with the migrations table.
+  - Run **npx prisma migrate resolve --rolled-back Unique** which will mark the failed migration called 'Unique' in the migrations table on your production environment as rolled back.
+
+Your local migration history now yields the same result as the state your prod db is in. You can now modify the datamodel again to create a migration that suits your new understanding of the feature you're working on (with non-unique names).
 
 ## Migration history conflicts
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -72,13 +72,14 @@ The following example demonstrates how to manually complete the steps of a migra
 
 ## Fixing failed migrations with migrate diff and db execute
 
-Starting with 3.9 we are offering two new commands in preview that can be used to fix failed migrations.
+Starting with 3.9 we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations.
 
 ### New commands `migrate diff` and `db execute`
 
-The two new commands we are using to fix the scenario from above are:
-`prisma migrate diff` which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
-`prisma db execute` which applies a SQL script to the database without interacting with the Prisma migrations table.
+The two new commands that we provide are:
+
+- `prisma migrate diff` which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
+- `prisma db execute` which applies a SQL script to the database without interacting with the Prisma migrations table.
 
 ### Example of a failed migration
 
@@ -114,7 +115,19 @@ Migrate returned the error directly from the database which lets you know about 
 ERROR 1062 (23000): Duplicate entry 'paul' for key 'User_name_key'
 ```
 
-You now need to recover manually from the partially executed migration ("partially" as creating the Post model and adding the email column succeeded). Before you are able to recover from the failed state further migrations using `prisma migrate deploy` are impossible.
+You now need to recover manually from the partially executed migration ("partially" as creating the Post model and adding the email column succeeded). Until you recover from the failed state further migrations using `prisma migrate deploy` are impossible.
+
+#### Moving backwards and reverting all changes
+
+You realize that non-unique data is valid and you cannot move forward with your current development work. You want to roll back the complete migration. For this you need to create a migration that takes your production database to the state of your datamodel before the last migration.
+
+- First you need your migration history at the time before the failed migration. You can either get this from your git history, or locally delete the folder of the last failed migration in your migration history.
+- You now want to take your production environment from its current failed state back to the state specified in your local migrations history:
+  - Run **npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql** which will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
+  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file backward.sql** which applies the changes in the sql script against the target database without interacting with the migrations table.
+  - Run **npx prisma migrate resolve --rolled-back Unique** which will mark the failed migration called 'Unique' in the migrations table on your production environment as rolled back.
+
+Your local migration history now yields the same result as the state your production database is in. You can now modify the datamodel again to create a migration that suits your new understanding of the feature you're working on (with non-unique names).
 
 #### Moving forward and applying missing changes
 
@@ -123,22 +136,10 @@ The existence of non-unique data in your database is unintentional and you want 
 - The error message from trying to deploy the migration to production already told you there was duplicate data in the column 'name'. You need to either alter or delete the offending rows.
 - Continue applying the rest of the failed migration to get to the datamodel defined in your prisma.schema:
   - Run **npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-schema-datamodel schema.prisma --script > forward.sql** which will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined in your prisma.schema.
-  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file forward.sql** which apply the changes in the sql script against the target database without interacting with the migrations table.
+  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file forward.sql** which applies the changes in the sql script against the target database without interacting with the migrations table.
   - Run **npx prisma migrate resolve --applied Unique** which will mark the failed migration called 'Unique' in the migrations table on your production environment as applied.
 
 Your local migration history now yields the same result as the state your production environment is in. You can now continue using the already known `migrate dev` /`migrate deploy` workflow.
-
-#### Moving backwards and reverting all changes
-
-You realize that non-unique data is valid and you cannot move forward with your current development work. You want to roll back the complete migration. For this you need to create a migration that takes your prod db to the state of your datamodel before the last migration.
-
-- First you need your migration history at the time before the failed migration. You can either get this from your git history, or locally delete the folder of the last failed migration in your miggration history.
-- You now want to take your production environment from its current failed state back to the state specified in your local migrations history:
-  - Run **npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql** which will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
-  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file backward.sql** which apply the changes in the sql script against the target database without interacting with the migrations table.
-  - Run **npx prisma migrate resolve --rolled-back Unique** which will mark the failed migration called 'Unique' in the migrations table on your production environment as rolled back.
-
-Your local migration history now yields the same result as the state your prod db is in. You can now modify the datamodel again to create a migration that suits your new understanding of the feature you're working on (with non-unique names).
 
 ## Migration history conflicts
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -80,7 +80,7 @@ These commands are currently in preview.
 
 </Admonition>
 
-### New commands `migrate diff` and `db execute`
+### New commands <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
 
 The two new commands that we provide are:
 
@@ -89,18 +89,20 @@ The two new commands that we provide are:
 
 ### Example of a failed migration
 
-Imagine the following scenario: Your local development environment and your production database schema are in sync. But of course the data in both environments is different.
+Imagine that you have the following `User` model in your schema, in both your local development environment and your production environment:
 
-```
+```prisma file=schema.prisma
 model User {
-  id    Int     @id
-  name  String
- }
+  id   Int    @id
+  name String
+}
 ```
 
-You then decide to make changes to your datamodel, adding another model and making the name field on User unique:
+At this point, your schemas in sync, but the data in the two environments is different.
 
-```
+You then decide to make changes to your datamodel, adding another `Post` model and making the name field on `User` unique:
+
+```prisma file=schema.prisma
 model User {
   id    Int     @id
   name  String  @unique
@@ -113,15 +115,15 @@ model Post {
 }
 ```
 
-You created a migration called 'Unique' with `prisma migrate dev` which was saved in your local migrations history. Applying the migration succeeded in your dev environment and now it is time to release to production. Unfortunately, the operation fails, since there is non-unique data in your production database (e.g. two users with the same name).
+You create a migration called 'Unique' with `prisma migrate dev` which is saved in your local migrations history. Applying the migration succeeds in your dev environment and now it is time to release to production. Unfortunately, the operation fails, since there is non-unique data in your production database (e.g. two users with the same name).
 
-Migrate returned the error directly from the database which lets you know about the violation of the unique constraint.
+Migrate returns the error directly from the database which lets you know about the violation of the unique constraint.
 
 ```bash
 ERROR 1062 (23000): Duplicate entry 'paul' for key 'User_name_key'
 ```
 
-You now need to recover manually from the partially executed migration ("partially" as creating the Post model and adding the email column succeeded). Until you recover from the failed state further migrations using `prisma migrate deploy` are impossible.
+You now need to recover manually from the partially executed migration ("partially" as creating the `Post` model and adding the `email` column succeeded). Until you recover from the failed state, further migrations using `prisma migrate deploy` are impossible.
 
 #### Moving backwards and reverting all changes
 
@@ -129,9 +131,30 @@ You realize that non-unique data is valid and you cannot move forward with your 
 
 - First you need your migration history at the time before the failed migration. You can either get this from your git history, or locally delete the folder of the last failed migration in your migration history.
 - You now want to take your production environment from its current failed state back to the state specified in your local migrations history:
-  - Run **npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql** which will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
-  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file backward.sql** which applies the changes in the sql script against the target database without interacting with the migrations table.
-  - Run **npx prisma migrate resolve --rolled-back Unique** which will mark the failed migration called 'Unique' in the migrations table on your production environment as rolled back.
+
+  - Run the following `prisma migrate diff` command:
+
+    ```bash
+     npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql**
+    ```
+
+    This will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
+
+  - Run the following `prisma db execute` command:
+
+    ```bash
+     npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file backward.sql
+    ```
+
+    This applies the changes in the SQL script against the target database without interacting with the migrations table.
+
+  - Run the following `prisma migrate resolve` command:
+
+    ```bash
+     npx prisma migrate resolve --rolled-back Unique
+    ```
+
+    This will mark the failed migration called 'Unique' in the migrations table on your production environment as rolled back.
 
 Your local migration history now yields the same result as the state your production database is in. You can now modify the datamodel again to create a migration that suits your new understanding of the feature you're working on (with non-unique names).
 
@@ -139,11 +162,34 @@ Your local migration history now yields the same result as the state your produc
 
 The existence of non-unique data in your database is unintentional and you want to fix that. Once fixed, you are able to go ahead with the migration as planned:
 
-- The error message from trying to deploy the migration to production already told you there was duplicate data in the column 'name'. You need to either alter or delete the offending rows.
+- The error message from trying to deploy the migration to production already told you there was duplicate data in the column `name`. You need to either alter or delete the offending rows.
 - Continue applying the rest of the failed migration to get to the datamodel defined in your prisma.schema:
-  - Run **npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-schema-datamodel schema.prisma --script > forward.sql** which will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined in your prisma.schema.
-  - Run **npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file forward.sql** which applies the changes in the sql script against the target database without interacting with the migrations table.
-  - Run **npx prisma migrate resolve --applied Unique** which will mark the failed migration called 'Unique' in the migrations table on your production environment as applied.
+
+  - Run the following `prisma migrate diff` command:
+
+    ```bash
+
+    npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-schema-datamodel schema.prisma --script > forward.sql
+
+    ```
+
+    This will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined in your `prisma.schema`file.
+
+  - Run the following `prisma db execute` command:
+
+    ```bash
+    npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file forward.sql
+    ```
+
+    This applies the changes in the SQL script against the target database without interacting with the migrations table.
+
+  - Run the following `prisma migrate resolve` command:
+
+    ```bash
+    npx prisma migrate resolve --applied Unique
+    ```
+
+    This will mark the failed migration called 'Unique' in the migrations table on your production environment as applied.
 
 Your local migration history now yields the same result as the state your production environment is in. You can now continue using the already known `migrate dev` /`migrate deploy` workflow.
 


### PR DESCRIPTION
Adds a guide how to use the new migrate primitives to fix failed migrations. 