### PR TITLE
Typo Fix

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/index.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/index.mdx
@@ -123,7 +123,7 @@ Next, set up your Prisma project by creating your [Prisma schema](/concepts/comp
 npx prisma init
 ```
 
-This command created a new directory called `prisma` which contains a file named `schema.prisma` and a `.env` file in the root of the project. `schema.prisma` contains the Prisma schema with your database connection and the Prisma Client generator.
+This command creates a new directory called `prisma` which contains a file named `schema.prisma` and a `.env` file in the root of the project. `schema.prisma` contains the Prisma schema with your database connection and the Prisma Client generator.
 `.env` is a [dotenv](https://github.com/motdotla/dotenv) file for defining environment variables (used for your database connection).
 
 <SwitchTech technologies={['node', 'postgresql']}>


### PR DESCRIPTION
Spotted a type on the documentation.

## Describe this PR

grammatical typo in the documentation

## Changes

changed the word "created" in the sentence "This command created" to "creates"

## What issue does this fix?

Documentation puts you off slightly while reading if you see this typo!

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
