### PR TITLE
Working with scalar lists: fix typo on default array value

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/200-working-with-scalar-lists-arrays.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/200-working-with-scalar-lists-arrays.mdx
@@ -163,4 +163,4 @@ The query does not return:
 
 - ✘ `NULL` arrays, even though they could be considered empty
 
-To work around this issue, you can set the default value of array fields to `{}` at a database level (Prisma schema does not currently support default values for arrays.)
+To work around this issue, you can set the default value of array fields to `[]` at a database level (Prisma schema does not currently support default values for arrays.)


### PR DESCRIPTION
## Describe this PR

On the [Working with scalar lists](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-scalar-lists-arrays) page, the default array value was set to `{}` instead of `[]`. I fixed the typo.