### PR TITLE
Fix grammar

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2416,7 +2416,7 @@ Defines meta information about the relation. [Learn more](/concepts/components/p
 
 ##### MongoDB
 
-- If your model's primary key is of type `ObjectId` in the underlying database, both the primary key _and_ the foreign key must be have the `@db.ObjectId` attribute
+- If your model's primary key is of type `ObjectId` in the underlying database, both the primary key _and_ the foreign key must have the `@db.ObjectId` attribute
 
 #### Arguments
 


### PR DESCRIPTION
- Bad grammar: Change "... the foreign key **must be have** the `@db.ObjectId` attribute ..." to "the foreign key *must have* the `@db.ObjectId` attribute"