### PR TITLE
chore: add missing quotation marks

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -29,7 +29,7 @@ The full-text search API is currently a Preview feature. To enable this feature,
    ```prisma file=schema.prisma highlight=3;add
    generator client {
      provider        = "prisma-client-js"
-     previewFeatures = ["fullTextSearch, fullTextIndex"]
+     previewFeatures = ["fullTextSearch", "fullTextIndex"]
    }
    ```
 


### PR DESCRIPTION
This PR fixes the example by adding the missing " characters. Without them the user is adding the preview feature `fullTextSearch, fullTextIndex`