### PR TITLE
Fix referencing wrong scalar field

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -49,7 +49,7 @@ model Post {
 At a Prisma level, the `User` / `Post` relation is made up of:
 
 - Two [relation fields](#relation-fields): `author` and `posts`. Relation fields define connections between models at the Prisma level and **do not exist in the database**. These fields are used to generate the Prisma Client.
-- The scalar `authorId` field, which is referenced by the `@relation` attribute. This field **does exist in the database** - it is the foreign key that connects `Post` and `User`.
+- The scalar `author` field, which is referenced by the `@relation` attribute. This field **does exist in the database** - it is the foreign key that connects `Post` and `User`.
 
 At a Prisma level, a connection between two models is **always** represented by a [relation field](#relation-fields) on **each side** of the relation.
 


### PR DESCRIPTION
## Describe this PR

Scalar field is author, not authorId, just a typo in documentation.

## Changes

Changed documentation wording. 
