### PR TITLE
Fix intra-page navigation for $executeRaw

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -200,9 +200,7 @@ const result = await prisma.$queryRawUnsafe(
 
 > **Note**: Using `%$2` as an argument would not work
 
-<h2 id="executeraw">
-  <inlinecode>$executeRaw</inlinecode>
-</h2>
+### <inlinecode>$executeRaw</inlinecode>
 
 `$executeRaw` returns the _number of rows affected by a database operation_, such as `UPDATE` or `DELETE`. This function does **not** return database records. The following query updates records in the database and returns a count of the number of records that were updated:
 


### PR DESCRIPTION
## Describe this PR

Fix intra-page navigation for $executeRaw

Without this change $executeRaw doesn't appear in the sidebar nav and is not clickable either.

### Before:
https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access#executeraw

![imagen](https://user-images.githubusercontent.com/7707306/152840156-ccc4839e-e9fa-42bf-bfcc-5bc816723d8e.png)

### After:
https://deploy-preview-2826--prisma2-docs.netlify.app/docs/concepts/components/prisma-client/raw-database-access#executeraw

![imagen](https://user-images.githubusercontent.com/7707306/152843757-8c80a6e1-00f4-498c-8ec4-f6b4b557e91e.png)


@all-contributors please add @aganoza for doc
