### PR TITLE
Replace `integer` with `bigint` for PostgreSQL in default BigInt type mappings (#2690)

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -550,7 +550,7 @@ True or false value.
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
-| PostgreSQL    | `integer`       |
+| PostgreSQL    | `bigint`        |
 | Microsoft SQL | `int`           |
 | MySQL         | `INT`           |
 | MongoDB       | `Long`          |


### PR DESCRIPTION
Fixes #2690
