### PR TITLE
Fix typo 050-prisma-client-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -2702,7 +2702,7 @@ A nested `createMany` query adds a new set of records to a parent record. See: [
 
 - `createMany` is available as a nested query when you `create` (`prisma.user.create(...)`) a new parent record or `update` (`prisma.user.update(...)`) an existing parent record.
 - Available in the context of a has-many relation - for example, you can `prisma.user.create(...)` a user and use a nested `createMany` to create multiple posts (posts have one user).
-- **Not** available in the context of a many-to-many relation - for example, you **cannot** you can `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
+- **Not** available in the context of a many-to-many relation - for example, you **cannot** `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
 - Does not support nesting additional relations - you cannot nest an additional `create` or `createMany`.
 - Allows setting foreign keys directly - for example, setting the `categoryId` on a post.
 


### PR DESCRIPTION
Remove the "you can" from "...you **cannot** *you can* `prisma.post.create(...)` a post..."

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
