### PR TITLE
Update GiraphQL name to Pothos

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
@@ -75,5 +75,5 @@ The following is a list of community created generators. If you want to create y
 - [`prisma-erd-generator`](https://github.com/keonik/prisma-erd-generator): Generates an entity relationship diagram
 - [`prisma-class-generator`](https://github.com/kimjbstar/prisma-class-generator): Generates classes from your Prisma Schema that can be used as DTO, Swagger Response, TypeGraphQL and so on.
 - [`zod-prisma`](https://github.com/CarterGrimmeisen/zod-prisma): Creates Zod schemas from your Prisma models.
-- [`prisma-giraphql-types`](https://github.com/hayes/giraphql/tree/main/packages/plugin-prisma): Makes it easier to define Prisma-based object types, and helps solve n+1 queries for relations. It also has integrations for the Relay plugin to make defining nodes and connections easy and efficient.
+- [`prisma-pothos-types`](https://github.com/hayes/pothos/tree/main/packages/plugin-prisma): Makes it easier to define Prisma-based object types, and helps solve n+1 queries for relations. It also has integrations for the Relay plugin to make defining nodes and connections easy and efficient.
 - [`graphql-schema-generator`](https://github.com/prisma-korea/graphql-schema-generator): Generates GraphQL schema from Prisma schema so that you can use any GraphQL tool you want.


### PR DESCRIPTION
## Describe this PR

GiraphQL recently changed name to Pothos GraphQL.

## Changes

Updated the documentation in the generators section to reflect this change.

## What issue does this fix?

Updates the name to the new correct name.