### PR TITLE
MongoDB: Explain when to use findRaw or aggregateRaw instead of $runCommandRaw

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -397,6 +397,49 @@ generator client {
 }
 ```
 
+### <inlinecode>$runCommandRaw</inlinecode>
+
+`$runCommandRaw` runs a raw MongoDB command against the database. For example, this query inserts two records with the same `_id`, bypassing normal document validation:
+
+```ts no-lines
+prisma.$runCommandRaw({
+  insert: 'Pets',
+  bypassDocumentValidation: true,
+  documents: [
+    {
+      _id: 1,
+      name: 'Felinecitas',
+      type: 'Cat',
+      breed: 'Russian Blue',
+      age: 12,
+    },
+    {
+      _id: 1,
+      name: 'Nao Nao',
+      type: 'Dog',
+      breed: 'Chow Chow',
+      age: 2,
+    },
+  ],
+})
+```
+
+<Admonition type="warning">
+
+Note that the `$runCommandRaw` command should not be used for queries which contain the `"find"` or `"aggregate"` commands, as you may be unable to fetch all data. This is because MongoDB returns a [cursor](https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/) that is attached to your MongoDB session, and you may not hit the same MongoDB session every time. For these queries, you should use the specialised [`findRaw`](#findraw) and [`aggregateRaw`](#aggregateraw) methods instead.
+
+</Admonition>
+
+#### Return type
+
+`$runCommandRaw` returns a `JSON` object whose shape depends on the inputs.
+
+#### Signature
+
+```ts no-lines
+$runCommandRaw(command: InputJsonObject): PrismaPromise<JsonObject>;
+```
+
 ### <inlinecode>findRaw</inlinecode>
 
 `<model>.findRaw` returns actual database records. It will find zero or more documents that match the filter on the `User` collection:
@@ -448,28 +491,3 @@ const result = await prisma.user.aggregateRaw({
 - `pipeline`: An array of aggregation stages to process and transform the document stream via the [aggregation pipeline](https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline).
 
 - `options`: Additional options to pass to the [`aggregate` command](https://docs.mongodb.com/manual/reference/command/aggregate/#command-fields).
-
-### <inlinecode>$runCommandRaw</inlinecode>
-
-`$runCommandRaw` runs any command against the database:
-
-```ts no-lines
-const result = await prisma.$runCommandRaw({
-  aggregate: 'User',
-  pipeline: [
-    { $match: { name: 'Bob' } },
-    { $project: { email: true, _id: false } },
-  ],
-  explain: false,
-})
-```
-
-#### Return type
-
-`$runCommandRaw` returns a `JSON` object whose shape depends on the inputs.
-
-#### Signature
-
-```ts no-lines
-$runCommandRaw(command: InputJsonObject): PrismaPromise<JsonObject>;
-```


### PR DESCRIPTION
## Describe this PR

Explain when and why to use `findRaw` or `aggregateRaw` instead of `$runCommandRaw`, and change example that wrongly uses `aggregate`

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #2845  

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
