### PR TITLE
feat: Scalar Types Reference

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -350,245 +350,27 @@ model User {
 The _data source connector_ determines what _native database type_ each of Prisma scalar type maps to. Similarly, the _generator_ determines what _type in the target programming language_ each of these types map to.
 
 Prisma models also have [model field types](/concepts/components/prisma-schema/relations) <span class="concept"></span> that define relations between models.
+TODO This sentence is super weird as "model field types" does not match the link.
 
 ### <inlinecode>String</inlinecode>
 
 Variable length text.
 
-#### Default type mappings
-
-| Connector     | Default mapping  |
-| ------------- | ---------------- |
-| PostgreSQL    | `text`           |
-| Microsoft SQL | `nvarchar(1000)` |
-| MySQL         | `varchar(191)`   |
-| MongoDB       | `String`         |
-| SQLite        | `TEXT`           |
-
-#### PostgreSQL
-
-| Native database type | Native database type attribute | Notes                                                                                                                                                                |
-| :------------------- | :----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `text`               | `@db.Text`                     |                                                                                                                                                                      |
-| `char`               | `@db.Char(x)`                  |
-| `varchar`            | `@db.VarChar(n)`               |
-| `bit`                | `@db.Bit(x)`                   |
-| `varbit`             | `@db.VarBit`                   |
-| `uuid`               | `@db.Uuid`                     |
-| `xml`                | `@db.Xml`                      |
-| `inet`               | `@db.Inet`                     |
-| `citext`             | `@db.Citext`                   | Only available if [Citext extension is enabled](/concepts/components/prisma-schema/features-without-psl-equivalent#enable-extensions-for-native-database-functions). |
-
-#### MySQL
-
-| Native database type | Native database type attribute | Notes |
-| :------------------- | :----------------------------- | ----- |
-| `VARCHAR`            | `@db.VarChar(X)`               |       |
-| `TEXT`               | `@db.Text`                     |
-| `CHAR`               | `@db.Char(X)`                  |
-| `TINYTEXT`           | `@db.TinyText`                 |
-| `MEDIUMTEXT`         | `@db.MediumText`               |
-| `LONGTEXT`           | `@db.LongText`                 |
-
-You can use Prisma Migrate to map `@db.Bit(1)` to `String`:
-
-```prisma
-model Model {
-  /* ... */
-  myField String @db.Bit(1)
-}
-```
-
-#### MongoDB (Preview)
-
-`String`
-
-| Native database type attribute | Notes                                                                             |
-| :----------------------------- | :-------------------------------------------------------------------------------- |
-| `@db.String`                   |                                                                                   |
-| `@db.ObjectId`                 | Required if the underlying BSON type is `OBJECT_ID` (ID fields, relation scalars) |
-
-#### Microsoft SQL Server
-
-| Native database type | Native database type attribute | Notes |
-| :------------------- | :----------------------------- | ----- |
-| `char`               | `@db.Char(X)`                  |
-| `nchar`              | `@db.NChar(X)`                 |
-| `varchar`            | `@db.VarChar(X)`               |
-| `nvarchar`           | `@db.NVarChar(X)`              |       |
-| `text`               | `@db.Text`                     |
-| `ntext`              | `@db.NText`                    |
-| `xml`                | `@db.Xml`                      |
-| `uniqueidentifier`   | `@db.UniqueIdentifier`         |
-
-#### SQLite
-
-`TEXT`
-
-#### Clients
-
-| Prisma Client JS |
-| ---------------- |
-| `string`         |
+See more details about the [`String` scalar type in the Scalar Type reference](/reference/api-reference/prisma-scalar-types-reference#string) <span class="api"></span>
 
 ### <inlinecode>Boolean</inlinecode>
 
 True or false value.
 
-#### Default type mappings
-
-| Connector     | Default mapping |
-| ------------- | --------------- |
-| PostgreSQL    | `boolean`       |
-| Microsoft SQL | `tinyint`       |
-| MySQL         | `TINYINT(1)`    |
-| MongoDB       | `Bool`          |
-| SQLite        | `INTEGER`       |
-
-#### PostgreSQL
-
-| Native database types | Native database type attribute | Notes |
-| :-------------------- | :----------------------------- | ----- |
-| `boolean`             | `@db.Boolean`                  |       |
-
-#### MySQL
-
-| Native database types | Native database type attribute | Notes                                                                                                                                                     |
-| --------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TINYINT(1)`          | `@db.TinyInt(1)`               | `TINYINT` maps to `Int` if the max length is greater than 1 (for example, `TINYINT(2)`) _or_ the default value is anything other than `1`, `0`, or `NULL` |
-| `BIT(1)`              | `@db.Bit`                      |
-
-#### MongoDB (Preview)
-
-`Bool`
-
-#### Microsoft SQL Server
-
-| Native database types | Native database type attribute | Notes |
-| :-------------------- | :----------------------------- | ----- |
-| `bit`                 | `@db.Bit`                      |       |
-
-#### SQLite
-
-`INTEGER`
-
-#### Clients
-
-| Prisma Client JS |
-| ---------------- |
-| `boolean`        |
-
-### <inlinecode>Int</inlinecode>
-
-#### Default type mappings
-
-| Connector     | Default mapping |
-| ------------- | --------------- |
-| PostgreSQL    | `integer`       |
-| Microsoft SQL | `int`           |
-| MySQL         | `INT`           |
-| MongoDB       | `Int`           |
-| SQLite        | `INTEGER`       |
-
-#### PostgreSQL
-
-| Native database types      | Native database type attribute           | Notes |
-| -------------------------- | ---------------------------------------- | ----- |
-| `integer` \| `int`, `int4` | `@db.Integer`                            |       |
-| `smallint` \| `int2`       | `@db.SmallInt`                           |       |
-| `smallserial` \| `serial2` | `@db.SmallInt @default(autoincrement())` |
-| `serial` \| `serial4`      | `@db.Int @default(autoincrement())`      |
-| `oid`                      | `@db.Oid`                                |
-
-#### MySQL
-
-| Native database types | Native database type attribute | Notes                                                                                                                                                                                      |
-| :-------------------- | :----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `INT`                 | `@db.Int`                      |                                                                                                                                                                                            |
-| `INT UNSIGNED`        | `@db.UnsignedInt`              |                                                                                                                                                                                            |
-| `SMALLINT`            | `@db.SmallInt`                 |
-| `SMALLINT UNSIGNED`   | `@db.UnsignedSmallInt`         |
-| `MEDIUMINT`           | `@db.MediumInt`                |
-| `MEDIUMINT UNSIGNED`  | `@db.UnsignedMediumInt`        |
-| `TINYINT`             | `@db.TinyInt`                  | `TINYINT` maps to `Int` if the max length is greater than 1 (for example, `TINYINT(2)`) _or_ the default value is anything other than `1`, `0`, or `NULL`. `TINYINT(1)` maps to `Boolean`. |
-| `TINYINT UNSIGNED`    | `@db.UnsignedTinyInt`          | `TINYINT(1) UNSIGNED` maps to `Int`, not `Boolean`                                                                                                                                         |
-| `YEAR`                | `@db.Year`                     |
-
-#### MongoDB (Preview)
-
-`Int`
-
-| Native database type attribute | Notes |
-| :----------------------------- | :---- |
-| `@db.Int`                      |       |
-| `@db.Long`                     |       |
-
-#### Microsoft SQL Server
-
-| Native database types | Native database type attribute | Notes |
-| --------------------- | ------------------------------ | ----- |
-| `int`                 | `@db.Int`                      |       |
-| `smallint`            | `@db.SmallInt`                 |       |
-| `tinyint`             | `@db.TinyInt`                  |       |
-| `bit`                 | `@db.Bit`                      |
-
-#### SQLite
-
-`INTEGER`
-
-#### Clients
-
-| Prisma Client JS |
-| ---------------- |
-| `number`         |
+See more details about the [`Boolean` scalar type in the Scalar Type reference](/reference/api-reference/prisma-scalar-types-reference#boolean) <span class="api"></span>
 
 ### <inlinecode>BigInt</inlinecode>
 
+TODO definition of type
+
 `BigInt` is available in version [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later.
 
-#### Default type mappings
-
-| Connector     | Default mapping |
-| ------------- | --------------- |
-| PostgreSQL    | `integer`       |
-| Microsoft SQL | `int`           |
-| MySQL         | `INT`           |
-| MongoDB       | `Long`          |
-| SQLite        | `INTEGER`       |
-
-#### PostgreSQL
-
-| Native database types    | Native database type attribute         | Notes |
-| ------------------------ | -------------------------------------- | ----- |
-| `bigint` \| `int8`       | `@db.BigInt`                           |       |
-| `bigserial` \| `serial8` | `@db.BigInt @default(autoincrement())` |       |
-
-#### MySQL
-
-| Native database types | Native database type attribute                 | Notes |
-| --------------------- | ---------------------------------------------- | ----- |
-| `BIGINT`              | `@db.BigInt`                                   |       |
-| `SERIAL`              | `@db.UnsignedBigInt @default(autoincrement())` |       |
-
-#### MongoDB (Preview)
-
-`Long`
-
-#### Microsoft SQL Server
-
-| Native database types | Native database type attribute | Notes |
-| --------------------- | ------------------------------ | ----- |
-| `bigint`              | `@db.BigInt`                   |       |
-
-#### SQLite
-
-`INTEGER`
-
-#### Clients
-
-| Client           | Type                                                                                                | Description                                                                                                         |
-| :--------------- | :-------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
-| Prisma Client JS | [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) | See [examples of working with `BigInt`](/concepts/components/prisma-client/working-with-fields#working-with-bigint) |
+See more details about the [`BigInt` scalar type in the Scalar Type reference](/reference/api-reference/prisma-scalar-types-reference#bigint) <span class="api"></span>
 
 ### <inlinecode>Float</inlinecode>
 

--- a/content/400-reference/200-api-reference/150-prisma-scalar-types-reference.mdx
+++ b/content/400-reference/200-api-reference/150-prisma-scalar-types-reference.mdx
@@ -1,0 +1,571 @@
+---
+title: 'Prisma Scalar Types reference'
+metaTitle: 'Prisma Scalar Types API (Reference)'
+metaDescription: 'API reference documentation for the Prisma Scalar Types.'
+tocDepth: 2
+toc: true
+---
+
+### <inlinecode>String</inlinecode>
+
+Variable length text.
+
+#### Default type mappings
+
+| Connector     | Default mapping  |
+| ------------- | ---------------- |
+| PostgreSQL    | `text`           |
+| Microsoft SQL | `nvarchar(1000)` |
+| MySQL         | `varchar(191)`   |
+| MongoDB       | `String`         |
+| SQLite        | `TEXT`           |
+
+#### PostgreSQL
+
+| Native database type | Native database type attribute | Notes                                                                                                                                                                |
+| :------------------- | :----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`               | `@db.Text`                     |                                                                                                                                                                      |
+| `char`               | `@db.Char(x)`                  |
+| `varchar`            | `@db.VarChar(n)`               |
+| `bit`                | `@db.Bit(x)`                   |
+| `varbit`             | `@db.VarBit`                   |
+| `uuid`               | `@db.Uuid`                     |
+| `xml`                | `@db.Xml`                      |
+| `inet`               | `@db.Inet`                     |
+| `citext`             | `@db.Citext`                   | Only available if [Citext extension is enabled](/concepts/components/prisma-schema/features-without-psl-equivalent#enable-extensions-for-native-database-functions). |
+
+#### MySQL
+
+| Native database type | Native database type attribute | Notes |
+| :------------------- | :----------------------------- | ----- |
+| `VARCHAR`            | `@db.VarChar(X)`               |       |
+| `TEXT`               | `@db.Text`                     |
+| `CHAR`               | `@db.Char(X)`                  |
+| `TINYTEXT`           | `@db.TinyText`                 |
+| `MEDIUMTEXT`         | `@db.MediumText`               |
+| `LONGTEXT`           | `@db.LongText`                 |
+
+You can use Prisma Migrate to map `@db.Bit(1)` to `String`:
+
+```prisma
+model Model {
+  /* ... */
+  myField String @db.Bit(1)
+}
+```
+
+#### MongoDB (Preview)
+
+`String`
+
+| Native database type attribute | Notes                                                                             |
+| :----------------------------- | :-------------------------------------------------------------------------------- |
+| `@db.String`                   |                                                                                   |
+| `@db.ObjectId`                 | Required if the underlying BSON type is `OBJECT_ID` (ID fields, relation scalars) |
+
+#### Microsoft SQL Server
+
+| Native database type | Native database type attribute | Notes |
+| :------------------- | :----------------------------- | ----- |
+| `char`               | `@db.Char(X)`                  |
+| `nchar`              | `@db.NChar(X)`                 |
+| `varchar`            | `@db.VarChar(X)`               |
+| `nvarchar`           | `@db.NVarChar(X)`              |       |
+| `text`               | `@db.Text`                     |
+| `ntext`              | `@db.NText`                    |
+| `xml`                | `@db.Xml`                      |
+| `uniqueidentifier`   | `@db.UniqueIdentifier`         |
+
+#### SQLite
+
+`TEXT`
+
+#### Clients
+
+| Prisma Client JS |
+| ---------------- |
+| `string`         |
+
+### <inlinecode>Boolean</inlinecode>
+
+True or false value.
+
+#### Default type mappings
+
+| Connector     | Default mapping |
+| ------------- | --------------- |
+| PostgreSQL    | `boolean`       |
+| Microsoft SQL | `tinyint`       |
+| MySQL         | `TINYINT(1)`    |
+| MongoDB       | `Bool`          |
+| SQLite        | `INTEGER`       |
+
+#### PostgreSQL
+
+| Native database types | Native database type attribute | Notes |
+| :-------------------- | :----------------------------- | ----- |
+| `boolean`             | `@db.Boolean`                  |       |
+
+#### MySQL
+
+| Native database types | Native database type attribute | Notes                                                                                                                                                     |
+| --------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TINYINT(1)`          | `@db.TinyInt(1)`               | `TINYINT` maps to `Int` if the max length is greater than 1 (for example, `TINYINT(2)`) _or_ the default value is anything other than `1`, `0`, or `NULL` |
+| `BIT(1)`              | `@db.Bit`                      |
+
+#### MongoDB (Preview)
+
+`Bool`
+
+#### Microsoft SQL Server
+
+| Native database types | Native database type attribute | Notes |
+| :-------------------- | :----------------------------- | ----- |
+| `bit`                 | `@db.Bit`                      |       |
+
+#### SQLite
+
+`INTEGER`
+
+#### Clients
+
+| Prisma Client JS |
+| ---------------- |
+| `boolean`        |
+
+### <inlinecode>Int</inlinecode>
+
+#### Default type mappings
+
+| Connector     | Default mapping |
+| ------------- | --------------- |
+| PostgreSQL    | `integer`       |
+| Microsoft SQL | `int`           |
+| MySQL         | `INT`           |
+| MongoDB       | `Int`           |
+| SQLite        | `INTEGER`       |
+
+#### PostgreSQL
+
+| Native database types      | Native database type attribute           | Notes |
+| -------------------------- | ---------------------------------------- | ----- |
+| `integer` \| `int`, `int4` | `@db.Integer`                            |       |
+| `smallint` \| `int2`       | `@db.SmallInt`                           |       |
+| `smallserial` \| `serial2` | `@db.SmallInt @default(autoincrement())` |
+| `serial` \| `serial4`      | `@db.Int @default(autoincrement())`      |
+| `oid`                      | `@db.Oid`                                |
+
+#### MySQL
+
+| Native database types | Native database type attribute | Notes                                                                                                                                                                                      |
+| :-------------------- | :----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `INT`                 | `@db.Int`                      |                                                                                                                                                                                            |
+| `INT UNSIGNED`        | `@db.UnsignedInt`              |                                                                                                                                                                                            |
+| `SMALLINT`            | `@db.SmallInt`                 |
+| `SMALLINT UNSIGNED`   | `@db.UnsignedSmallInt`         |
+| `MEDIUMINT`           | `@db.MediumInt`                |
+| `MEDIUMINT UNSIGNED`  | `@db.UnsignedMediumInt`        |
+| `TINYINT`             | `@db.TinyInt`                  | `TINYINT` maps to `Int` if the max length is greater than 1 (for example, `TINYINT(2)`) _or_ the default value is anything other than `1`, `0`, or `NULL`. `TINYINT(1)` maps to `Boolean`. |
+| `TINYINT UNSIGNED`    | `@db.UnsignedTinyInt`          | `TINYINT(1) UNSIGNED` maps to `Int`, not `Boolean`                                                                                                                                         |
+| `YEAR`                | `@db.Year`                     |
+
+#### MongoDB (Preview)
+
+`Int`
+
+| Native database type attribute | Notes |
+| :----------------------------- | :---- |
+| `@db.Int`                      |       |
+| `@db.Long`                     |       |
+
+#### Microsoft SQL Server
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `int`                 | `@db.Int`                      |       |
+| `smallint`            | `@db.SmallInt`                 |       |
+| `tinyint`             | `@db.TinyInt`                  |       |
+| `bit`                 | `@db.Bit`                      |
+
+#### SQLite
+
+`INTEGER`
+
+#### Clients
+
+| Prisma Client JS |
+| ---------------- |
+| `number`         |
+
+### <inlinecode>BigInt</inlinecode>
+
+`BigInt` is available in version [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later.
+
+#### Default type mappings
+
+| Connector     | Default mapping |
+| ------------- | --------------- |
+| PostgreSQL    | `integer`       |
+| Microsoft SQL | `int`           |
+| MySQL         | `INT`           |
+| MongoDB       | `Long`          |
+| SQLite        | `INTEGER`       |
+
+#### PostgreSQL
+
+| Native database types    | Native database type attribute         | Notes |
+| ------------------------ | -------------------------------------- | ----- |
+| `bigint` \| `int8`       | `@db.BigInt`                           |       |
+| `bigserial` \| `serial8` | `@db.BigInt @default(autoincrement())` |       |
+
+#### MySQL
+
+| Native database types | Native database type attribute                 | Notes |
+| --------------------- | ---------------------------------------------- | ----- |
+| `BIGINT`              | `@db.BigInt`                                   |       |
+| `SERIAL`              | `@db.UnsignedBigInt @default(autoincrement())` |       |
+
+#### MongoDB (Preview)
+
+`Long`
+
+#### Microsoft SQL Server
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `bigint`              | `@db.BigInt`                   |       |
+
+#### SQLite
+
+`INTEGER`
+
+#### Clients
+
+| Client           | Type                                                                                                | Description                                                                                                         |
+| :--------------- | :-------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| Prisma Client JS | [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) | See [examples of working with `BigInt`](/concepts/components/prisma-client/working-with-fields#working-with-bigint) |
+
+### <inlinecode>Float</inlinecode>
+
+Floating point number.
+
+> `Float` maps to `Double` in [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later - see [release notes](https://github.com/prisma/prisma/releases/tag/2.17.0) and [Video: Changes to the default mapping of Float in Prisma 2.17.0](https://www.youtube.com/watch?v=OsuGP_xNHco&amp%3Bab_channel=Prisma) for more information about this change.
+
+#### Default type mappings
+
+| Connector     | Default mapping    |
+| ------------- | ------------------ |
+| PostgreSQL    | `double precision` |
+| Microsoft SQL | `float(53)`        |
+| MySQL         | `DOUBLE`           |
+| MongoDB       | `Double`           |
+| SQLite        | `REAL`             |
+
+#### PostgreSQL
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `double precision`    | `@db.DoublePrecision`          |
+| `real`                | `@db.Real`                     |
+
+#### MySQL
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `FLOAT`               | `@db.Float`                    |
+| `DOUBLE`              | `@db.Double`                   |
+
+#### MongoDB (Preview)
+
+`Double`
+
+#### Microsoft SQL Server
+
+| Native database types | Native database type attribute |
+| --------------------- | ------------------------------ |
+| `float`               | `@db.Float`                    |
+| `money`               | `@db.Money`                    |
+| `smallmoney`          | `@db.SmallMoney`               |
+| `real`                | `@db.Real`                     |
+
+#### SQLite connector
+
+`REAL`
+
+#### Clients
+
+| Prisma Client JS |
+| ---------------- |
+| `number`         |
+
+### <inlinecode>Decimal</inlinecode>
+
+#### Default type mappings
+
+| Connector     | Default mapping  |
+| ------------- | ---------------- |
+| PostgreSQL    | `decimal(65,30)` |
+| Microsoft SQL | `decimal(32,16)` |
+| MySQL         | `DECIMAL(65,30)` |
+| MongoDB       | `Decimal`        |
+| SQLite        | `DECIMAL`        |
+
+#### PostgreSQL
+
+| Native database types  | Native database type attribute | Notes |
+| ---------------------- | ------------------------------ | ----- |
+| `decimal` \| `numeric` | `@db.Decimal(p, s)`†           |       |
+| `money`                | `@db.Money`                    |
+
+- † `p` (precision), the maximum total number of decimal digits to be stored. `s` (scale), the number of decimal digits that are stored to the right of the decimal point.
+
+#### MySQL
+
+| Native database types  | Native database type attribute | Notes |
+| ---------------------- | ------------------------------ | ----- |
+| `DECIMAL` \| `NUMERIC` | `@db.Decimal(p, s)`†           |       |
+
+- † `p` (precision), the maximum total number of decimal digits to be stored. `s` (scale), the number of decimal digits that are stored to the right of the decimal point.
+
+#### MongoDB (Preview)
+
+`Decimal`
+
+#### Microsoft SQL Server
+
+| Native database types  | Native database type attribute | Notes |
+| ---------------------- | ------------------------------ | ----- |
+| `decimal` \| `numeric` | `@db.Decimal(p, s)`†           |       |
+
+- † `p` (precision), the maximum total number of decimal digits to be stored. `s` (scale), the number of decimal digits that are stored to the right of the decimal point.
+
+#### SQLite
+
+`DECIMAL` (changed from `REAL` in 2.17.0)
+
+#### Clients
+
+| Client           | Type                                               | Description                                                                                                           |
+| :--------------- | :------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
+| Prisma Client JS | [`Decimal`](https://mikemcl.github.io/decimal.js/) | See [examples of working with `Decimal`](/concepts/components/prisma-client/working-with-fields#working-with-decimal) |
+
+### <inlinecode>DateTime</inlinecode>
+
+#### Remarks
+
+- Prisma Client returns all `DateTime` as ISO 8601-formatted strings.
+
+#### Default type mappings
+
+| Connector     | Default mapping |
+| ------------- | --------------- |
+| PostgreSQL    | `timestamp(3)`  |
+| Microsoft SQL | `datetime2`     |
+| MySQL         | `DATETIME(3)`   |
+| MongoDB       | `Timestamp`     |
+| SQLite        | `NUMERIC`       |
+
+#### PostgreSQL
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `timestamp`           | `@db.Timestamp(x)`             |       |
+| `timestamptz`         | `@db.Timestamptz(x)`           |
+| `date`                | `@db.Date`                     |
+| `time`                | `@db.Time(x)`                  |
+| `timetz`              | `@db.Timetz(x)`                |
+
+#### MySQL
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `DATETIME(x)`         | `@db.DateTime(x)`              |       |
+| `DATE(x)`             | `@db.Date(x)`                  |
+| `TIME(x)`             | `@db.Time(x)`                  |
+| `TIMESTAMP(x)`        | `@db.Timestamp(x)`             |
+
+You can also use MySQL's `YEAR` type with `Int`:
+
+```prisma
+yearField     Int    @db.Year
+```
+
+#### MongoDB (Preview)
+
+`Timestamp`
+
+#### Microsoft SQL Server
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `date`                | `@db.Date`                     |
+| `time`                | `@db.Time`                     |
+| `datetime`            | `@db.DateTime`                 |
+| `datetime2`           | `@db.DateTime2`                |       |
+| `smalldatetime`       | `@db.SmallDateTime`            |
+| `datetimeoffset`      | `@db.DateTimeOffset`           |
+
+#### SQLite
+
+`NUMERIC` or `STRING`. If the underlying data type is `STRING`, you must use one of the following formats:
+
+- [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) (`1996-12-19T16:39:57-08:00`)
+- [RFC 2822](https://tools.ietf.org/html/rfc2822#section-3.3) (`Tue, 1 Jul 2003 10:52:37 +0200`)
+
+#### Clients
+
+| Prisma Client JS |
+| ---------------- |
+| `Date`           |
+
+### <inlinecode>Json</inlinecode>
+
+A JSON object.
+
+#### Default type mappings
+
+| Connector     | Default mapping                                                                                          |
+| ------------- | -------------------------------------------------------------------------------------------------------- |
+| PostgreSQL    | `jsonb`                                                                                                  |
+| Microsoft SQL | `nvarchar(1000)`                                                                                         |
+| MySQL         | `JSON`                                                                                                   |
+| MongoDB       | [A valid `BSON` object (Relaxed mode)](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) |
+| SQLite        | Not supported                                                                                            |
+
+#### PostgreSQL
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `json`                | `@db.Json`                     |
+| `jsonb`               | `@db.JsonB`                    |       |
+
+#### MySQL
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `JSON`                | `@db.Json`                     |
+
+#### MongoDB (Preview)
+
+[A valid `BSON` object (Relaxed mode)](https://docs.mongodb.com/manual/reference/mongodb-extended-json/)
+
+#### Microsoft SQL Server
+
+Microsoft SQL Server does not have a specific data type for JSON - however, there are a number of [built-in functions for reading and modifying JSON](https://docs.microsoft.com/en-us/sql/relational-databases/json/json-data-sql-server?view=sql-server-ver15#extract-values-from-json-text-and-use-them-in-queries).
+
+| Native database types | Native database type attribute |
+| --------------------- | ------------------------------ |
+| `JSON`                | `@db.NVarChar`                 |
+
+#### SQLite
+
+Not supported
+
+#### Clients
+
+| Prisma Client JS |
+| ---------------- |
+| `object`         |
+
+### <inlinecode>Bytes</inlinecode>
+
+`Bytes` is available in version [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later.
+
+#### Default type mappings
+
+| Connector     | Default mapping |
+| ------------- | --------------- |
+| PostgreSQL    | `bytea`         |
+| Microsoft SQL | `varbinary`     |
+| MySQL         | `LONGBLOB`      |
+| MongoDB       | `BinData`       |
+| SQLite        | Not supported   |
+
+#### PostgreSQL
+
+| Native database types | Native database type attribute |
+| --------------------- | ------------------------------ |
+| `bytea`               | `@db.ByteA`                    |
+
+#### MySQL
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `LONGBLOB`            | `@db.LongBlob`                 |       |
+| `BINARY`              | `@db.Binary`                   |
+| `VARBINARY`           | `@db.VarBinary`                |
+| `TINYBLOB`            | `@db.TinyBlob`                 |
+| `BLOB`                | `@db.Blob`                     |
+| `MEDIUMBLOB`          | `@db.MediumBlob`               |
+| `BIT`                 | `@db.Bit`                      |
+
+#### MongoDB (Preview)
+
+`BinData`
+
+| Native database type attribute | Notes                                                                             |
+| :----------------------------- | :-------------------------------------------------------------------------------- |
+| `@db.ObjectId`                 | Required if the underlying BSON type is `OBJECT_ID` (ID fields, relation scalars) |
+| `@db.BinData`                  |                                                                                   |
+
+#### Microsoft SQL Server
+
+| Native database types | Native database type attribute | Notes |
+| --------------------- | ------------------------------ | ----- |
+| `binary`              | `@db.Binary`                   |
+| `varbinary`           | `@db.VarBinary`                |       |
+| `image`               | `@db.Image`                    |
+
+#### SQLite
+
+Not supported
+
+#### Clients
+
+| Client           | Type                                           | Description                                                                                                        |
+| :--------------- | :--------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| Prisma Client JS | [`Buffer`](https://nodejs.org/api/buffer.html) | See [examples of working with `Buffer`](/concepts/components/prisma-client/working-with-fields#working-with-bytes) |
+
+### <inlinecode>Unsupported</inlinecode>
+
+<Admonition type="warning">
+
+**Not supported by MongoDB** <br />
+The [MongoDB connector](/concepts/database-connectors/mongodb) does not currently support the `Unsupported` type.
+
+</Admonition>
+
+The `Unsupported` type was introduced in [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and allows you to represent data types in the Prisma schema that are not supported by the Prisma Client. `Unsupported` fields can be introspected with `prisma db pull` or created with Prisma Migrate or `db push`.
+
+#### Remarks
+
+- Fields with `Unsupported` types are not available in the generated client.
+- If a model contains a **mandatory** `Unsupported` type, `prisma.model.create(..)` and `prisma.model.update(...)` are not available in the client.
+- Prisma will always warn that your schema contains unsupported types when you `introspect`:
+
+  ```
+  *** WARNING ***
+
+  These fields are not supported by the Prisma Client, because Prisma does not currently support their types.
+  * Model "Post", field: "circle", original data type: "circle"
+  ```
+
+#### Examples
+
+<TabbedContent tabs={[<FileWithIcon text="Relational databases only" icon="database"/>]}>
+<tab>
+
+```prisma
+model Star {
+  id       Int                    @id @default(autoincrement())
+  position Unsupported("circle")?
+  example1 Unsupported("circle")
+  circle   Unsupported("circle")? @default(dbgenerated("'<(10,4),11>'::circle"))
+}
+```
+
+</tab>
+<tab>
+</tab>
+
+</TabbedContent>

--- a/content/400-reference/200-api-reference/150-prisma-scalar-types-reference.mdx
+++ b/content/400-reference/200-api-reference/150-prisma-scalar-types-reference.mdx
@@ -6,7 +6,11 @@ tocDepth: 2
 toc: true
 ---
 
+<TopBlock>
+
 TODO Introduction that describes scalar types and puts them into the bigger, Prisma schema, context.
+
+</TopBlock>
 
 ## <inlinecode>String</inlinecode>
 

--- a/content/400-reference/200-api-reference/150-prisma-scalar-types-reference.mdx
+++ b/content/400-reference/200-api-reference/150-prisma-scalar-types-reference.mdx
@@ -1,16 +1,18 @@
 ---
-title: 'Prisma Scalar Types reference'
-metaTitle: 'Prisma Scalar Types API (Reference)'
+title: 'Prisma scalar types reference'
+metaTitle: 'Prisma scalar types API (Reference)'
 metaDescription: 'API reference documentation for the Prisma Scalar Types.'
 tocDepth: 2
 toc: true
 ---
 
-### <inlinecode>String</inlinecode>
+TODO Introduction that describes scalar types and puts them into the bigger, Prisma schema, context.
+
+## <inlinecode>String</inlinecode>
 
 Variable length text.
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping  |
 | ------------- | ---------------- |
@@ -20,7 +22,7 @@ Variable length text.
 | MongoDB       | `String`         |
 | SQLite        | `TEXT`           |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database type | Native database type attribute | Notes                                                                                                                                                                |
 | :------------------- | :----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -34,7 +36,7 @@ Variable length text.
 | `inet`               | `@db.Inet`                     |
 | `citext`             | `@db.Citext`                   | Only available if [Citext extension is enabled](/concepts/components/prisma-schema/features-without-psl-equivalent#enable-extensions-for-native-database-functions). |
 
-#### MySQL
+### MySQL
 
 | Native database type | Native database type attribute | Notes |
 | :------------------- | :----------------------------- | ----- |
@@ -54,7 +56,7 @@ model Model {
 }
 ```
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `String`
 
@@ -63,7 +65,7 @@ model Model {
 | `@db.String`                   |                                                                                   |
 | `@db.ObjectId`                 | Required if the underlying BSON type is `OBJECT_ID` (ID fields, relation scalars) |
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database type | Native database type attribute | Notes |
 | :------------------- | :----------------------------- | ----- |
@@ -76,21 +78,21 @@ model Model {
 | `xml`                | `@db.Xml`                      |
 | `uniqueidentifier`   | `@db.UniqueIdentifier`         |
 
-#### SQLite
+### SQLite
 
 `TEXT`
 
-#### Clients
+### Clients
 
 | Prisma Client JS |
 | ---------------- |
 | `string`         |
 
-### <inlinecode>Boolean</inlinecode>
+## <inlinecode>Boolean</inlinecode>
 
 True or false value.
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
@@ -100,42 +102,42 @@ True or false value.
 | MongoDB       | `Bool`          |
 | SQLite        | `INTEGER`       |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types | Native database type attribute | Notes |
 | :-------------------- | :----------------------------- | ----- |
 | `boolean`             | `@db.Boolean`                  |       |
 
-#### MySQL
+### MySQL
 
 | Native database types | Native database type attribute | Notes                                                                                                                                                     |
 | --------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `TINYINT(1)`          | `@db.TinyInt(1)`               | `TINYINT` maps to `Int` if the max length is greater than 1 (for example, `TINYINT(2)`) _or_ the default value is anything other than `1`, `0`, or `NULL` |
 | `BIT(1)`              | `@db.Bit`                      |
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `Bool`
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database types | Native database type attribute | Notes |
 | :-------------------- | :----------------------------- | ----- |
 | `bit`                 | `@db.Bit`                      |       |
 
-#### SQLite
+### SQLite
 
 `INTEGER`
 
-#### Clients
+### Clients
 
 | Prisma Client JS |
 | ---------------- |
 | `boolean`        |
 
-### <inlinecode>Int</inlinecode>
+## <inlinecode>Int</inlinecode>
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
@@ -145,7 +147,7 @@ True or false value.
 | MongoDB       | `Int`           |
 | SQLite        | `INTEGER`       |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types      | Native database type attribute           | Notes |
 | -------------------------- | ---------------------------------------- | ----- |
@@ -155,7 +157,7 @@ True or false value.
 | `serial` \| `serial4`      | `@db.Int @default(autoincrement())`      |
 | `oid`                      | `@db.Oid`                                |
 
-#### MySQL
+### MySQL
 
 | Native database types | Native database type attribute | Notes                                                                                                                                                                                      |
 | :-------------------- | :----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -169,7 +171,7 @@ True or false value.
 | `TINYINT UNSIGNED`    | `@db.UnsignedTinyInt`          | `TINYINT(1) UNSIGNED` maps to `Int`, not `Boolean`                                                                                                                                         |
 | `YEAR`                | `@db.Year`                     |
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `Int`
 
@@ -178,7 +180,7 @@ True or false value.
 | `@db.Int`                      |       |
 | `@db.Long`                     |       |
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
@@ -187,21 +189,23 @@ True or false value.
 | `tinyint`             | `@db.TinyInt`                  |       |
 | `bit`                 | `@db.Bit`                      |
 
-#### SQLite
+### SQLite
 
 `INTEGER`
 
-#### Clients
+### Clients
 
 | Prisma Client JS |
 | ---------------- |
 | `number`         |
 
-### <inlinecode>BigInt</inlinecode>
+## <inlinecode>BigInt</inlinecode>
+
+TODO description
 
 `BigInt` is available in version [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later.
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
@@ -211,47 +215,47 @@ True or false value.
 | MongoDB       | `Long`          |
 | SQLite        | `INTEGER`       |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types    | Native database type attribute         | Notes |
 | ------------------------ | -------------------------------------- | ----- |
 | `bigint` \| `int8`       | `@db.BigInt`                           |       |
 | `bigserial` \| `serial8` | `@db.BigInt @default(autoincrement())` |       |
 
-#### MySQL
+### MySQL
 
 | Native database types | Native database type attribute                 | Notes |
 | --------------------- | ---------------------------------------------- | ----- |
 | `BIGINT`              | `@db.BigInt`                                   |       |
 | `SERIAL`              | `@db.UnsignedBigInt @default(autoincrement())` |       |
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `Long`
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
 | `bigint`              | `@db.BigInt`                   |       |
 
-#### SQLite
+### SQLite
 
 `INTEGER`
 
-#### Clients
+### Clients
 
 | Client           | Type                                                                                                | Description                                                                                                         |
 | :--------------- | :-------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
 | Prisma Client JS | [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) | See [examples of working with `BigInt`](/concepts/components/prisma-client/working-with-fields#working-with-bigint) |
 
-### <inlinecode>Float</inlinecode>
+## <inlinecode>Float</inlinecode>
 
 Floating point number.
 
 > `Float` maps to `Double` in [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later - see [release notes](https://github.com/prisma/prisma/releases/tag/2.17.0) and [Video: Changes to the default mapping of Float in Prisma 2.17.0](https://www.youtube.com/watch?v=OsuGP_xNHco&amp%3Bab_channel=Prisma) for more information about this change.
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping    |
 | ------------- | ------------------ |
@@ -261,25 +265,25 @@ Floating point number.
 | MongoDB       | `Double`           |
 | SQLite        | `REAL`             |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
 | `double precision`    | `@db.DoublePrecision`          |
 | `real`                | `@db.Real`                     |
 
-#### MySQL
+### MySQL
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
 | `FLOAT`               | `@db.Float`                    |
 | `DOUBLE`              | `@db.Double`                   |
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `Double`
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database types | Native database type attribute |
 | --------------------- | ------------------------------ |
@@ -288,19 +292,19 @@ Floating point number.
 | `smallmoney`          | `@db.SmallMoney`               |
 | `real`                | `@db.Real`                     |
 
-#### SQLite connector
+### SQLite connector
 
 `REAL`
 
-#### Clients
+### Clients
 
 | Prisma Client JS |
 | ---------------- |
 | `number`         |
 
-### <inlinecode>Decimal</inlinecode>
+## <inlinecode>Decimal</inlinecode>
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping  |
 | ------------- | ---------------- |
@@ -310,7 +314,7 @@ Floating point number.
 | MongoDB       | `Decimal`        |
 | SQLite        | `DECIMAL`        |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types  | Native database type attribute | Notes |
 | ---------------------- | ------------------------------ | ----- |
@@ -319,7 +323,7 @@ Floating point number.
 
 - † `p` (precision), the maximum total number of decimal digits to be stored. `s` (scale), the number of decimal digits that are stored to the right of the decimal point.
 
-#### MySQL
+### MySQL
 
 | Native database types  | Native database type attribute | Notes |
 | ---------------------- | ------------------------------ | ----- |
@@ -327,11 +331,11 @@ Floating point number.
 
 - † `p` (precision), the maximum total number of decimal digits to be stored. `s` (scale), the number of decimal digits that are stored to the right of the decimal point.
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `Decimal`
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database types  | Native database type attribute | Notes |
 | ---------------------- | ------------------------------ | ----- |
@@ -339,23 +343,23 @@ Floating point number.
 
 - † `p` (precision), the maximum total number of decimal digits to be stored. `s` (scale), the number of decimal digits that are stored to the right of the decimal point.
 
-#### SQLite
+### SQLite
 
 `DECIMAL` (changed from `REAL` in 2.17.0)
 
-#### Clients
+### Clients
 
 | Client           | Type                                               | Description                                                                                                           |
 | :--------------- | :------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
 | Prisma Client JS | [`Decimal`](https://mikemcl.github.io/decimal.js/) | See [examples of working with `Decimal`](/concepts/components/prisma-client/working-with-fields#working-with-decimal) |
 
-### <inlinecode>DateTime</inlinecode>
+## <inlinecode>DateTime</inlinecode>
 
-#### Remarks
+### Remarks
 
 - Prisma Client returns all `DateTime` as ISO 8601-formatted strings.
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
@@ -365,7 +369,7 @@ Floating point number.
 | MongoDB       | `Timestamp`     |
 | SQLite        | `NUMERIC`       |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
@@ -375,7 +379,7 @@ Floating point number.
 | `time`                | `@db.Time(x)`                  |
 | `timetz`              | `@db.Timetz(x)`                |
 
-#### MySQL
+### MySQL
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
@@ -390,11 +394,11 @@ You can also use MySQL's `YEAR` type with `Int`:
 yearField     Int    @db.Year
 ```
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `Timestamp`
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
@@ -405,24 +409,24 @@ yearField     Int    @db.Year
 | `smalldatetime`       | `@db.SmallDateTime`            |
 | `datetimeoffset`      | `@db.DateTimeOffset`           |
 
-#### SQLite
+### SQLite
 
 `NUMERIC` or `STRING`. If the underlying data type is `STRING`, you must use one of the following formats:
 
 - [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) (`1996-12-19T16:39:57-08:00`)
 - [RFC 2822](https://tools.ietf.org/html/rfc2822#section-3.3) (`Tue, 1 Jul 2003 10:52:37 +0200`)
 
-#### Clients
+### Clients
 
 | Prisma Client JS |
 | ---------------- |
 | `Date`           |
 
-### <inlinecode>Json</inlinecode>
+## <inlinecode>Json</inlinecode>
 
 A JSON object.
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping                                                                                          |
 | ------------- | -------------------------------------------------------------------------------------------------------- |
@@ -432,24 +436,24 @@ A JSON object.
 | MongoDB       | [A valid `BSON` object (Relaxed mode)](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) |
 | SQLite        | Not supported                                                                                            |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
 | `json`                | `@db.Json`                     |
 | `jsonb`               | `@db.JsonB`                    |       |
 
-#### MySQL
+### MySQL
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
 | `JSON`                | `@db.Json`                     |
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 [A valid `BSON` object (Relaxed mode)](https://docs.mongodb.com/manual/reference/mongodb-extended-json/)
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 Microsoft SQL Server does not have a specific data type for JSON - however, there are a number of [built-in functions for reading and modifying JSON](https://docs.microsoft.com/en-us/sql/relational-databases/json/json-data-sql-server?view=sql-server-ver15#extract-values-from-json-text-and-use-them-in-queries).
 
@@ -457,21 +461,21 @@ Microsoft SQL Server does not have a specific data type for JSON - however, ther
 | --------------------- | ------------------------------ |
 | `JSON`                | `@db.NVarChar`                 |
 
-#### SQLite
+### SQLite
 
 Not supported
 
-#### Clients
+### Clients
 
 | Prisma Client JS |
 | ---------------- |
 | `object`         |
 
-### <inlinecode>Bytes</inlinecode>
+## <inlinecode>Bytes</inlinecode>
 
 `Bytes` is available in version [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later.
 
-#### Default type mappings
+### Default type mappings
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
@@ -481,13 +485,13 @@ Not supported
 | MongoDB       | `BinData`       |
 | SQLite        | Not supported   |
 
-#### PostgreSQL
+### PostgreSQL
 
 | Native database types | Native database type attribute |
 | --------------------- | ------------------------------ |
 | `bytea`               | `@db.ByteA`                    |
 
-#### MySQL
+### MySQL
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
@@ -499,7 +503,7 @@ Not supported
 | `MEDIUMBLOB`          | `@db.MediumBlob`               |
 | `BIT`                 | `@db.Bit`                      |
 
-#### MongoDB (Preview)
+### MongoDB (Preview)
 
 `BinData`
 
@@ -508,7 +512,7 @@ Not supported
 | `@db.ObjectId`                 | Required if the underlying BSON type is `OBJECT_ID` (ID fields, relation scalars) |
 | `@db.BinData`                  |                                                                                   |
 
-#### Microsoft SQL Server
+### Microsoft SQL Server
 
 | Native database types | Native database type attribute | Notes |
 | --------------------- | ------------------------------ | ----- |
@@ -516,17 +520,17 @@ Not supported
 | `varbinary`           | `@db.VarBinary`                |       |
 | `image`               | `@db.Image`                    |
 
-#### SQLite
+### SQLite
 
 Not supported
 
-#### Clients
+### Clients
 
 | Client           | Type                                           | Description                                                                                                        |
 | :--------------- | :--------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
 | Prisma Client JS | [`Buffer`](https://nodejs.org/api/buffer.html) | See [examples of working with `Buffer`](/concepts/components/prisma-client/working-with-fields#working-with-bytes) |
 
-### <inlinecode>Unsupported</inlinecode>
+## <inlinecode>Unsupported</inlinecode>
 
 <Admonition type="warning">
 
@@ -537,7 +541,7 @@ The [MongoDB connector](/concepts/database-connectors/mongodb) does not currentl
 
 The `Unsupported` type was introduced in [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and allows you to represent data types in the Prisma schema that are not supported by the Prisma Client. `Unsupported` fields can be introspected with `prisma db pull` or created with Prisma Migrate or `db push`.
 
-#### Remarks
+### Remarks
 
 - Fields with `Unsupported` types are not available in the generated client.
 - If a model contains a **mandatory** `Unsupported` type, `prisma.model.create(..)` and `prisma.model.update(...)` are not available in the client.
@@ -550,7 +554,7 @@ The `Unsupported` type was introduced in [2.17.0](https://github.com/prisma/pris
   * Model "Post", field: "circle", original data type: "circle"
   ```
 
-#### Examples
+### Examples
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases only" icon="database"/>]}>
 <tab>


### PR DESCRIPTION
Proof of concept of an idea to split out the scalar types details into its own page that is just linked from the schema reference instead.

Relevant previews:

- [/docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types](https://deploy-preview-2887--prisma2-docs.netlify.app/docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types)
- [/docs/reference/api-reference/prisma-scalar-types-reference](https://deploy-preview-2887--prisma2-docs.netlify.app/docs/reference/api-reference/prisma-scalar-types-reference)
