### PR TITLE
Updated remark for createMany method

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -2702,7 +2702,7 @@ A nested `createMany` query adds a new set of records to a parent record. See: [
 
 - `createMany` is available as a nested query when you `create` (`prisma.user.create(...)`) a new parent record or `update` (`prisma.user.update(...)`) an existing parent record.
 - Available in the context of a has-many relation - for example, you can `prisma.user.create(...)` a user and use a nested `createMany` to create multiple posts (posts have one user).
-- **Not** available in the context of a many-to-many relation - for example, you **cannot** you can `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
+- **Not** available in the context of a many-to-many relation - for example, you **cannot** `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
 - Does not support nesting additional relations - you cannot nest an additional `create` or `createMany`.
 - Allows setting foreign keys directly - for example, setting the `categoryId` on a post.
 


### PR DESCRIPTION
Updated Remarks section for createMany method in PrismaClient Reference.
The sentence didn't sound correct, Please have a look if it makes sense to remove the *you can* part from the bullet point.

## Describe this PR

Remark point is updated. Sentence `You cannot you can` didn't sound correct. It seems it should just be `You cannot`.

## Changes

Removed part of the sentence 

## Any other relevant information

<img width="706" alt="Screenshot 2022-02-17 at 1 29 05 PM" src="https://user-images.githubusercontent.com/13049676/154431204-1aa8fade-d614-4a43-b06d-e4109f0c4137.png">


