### PR TITLE
Fixed Redirection issue in queryRaw, executeRaw and runCommandRaw

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4854,17 +4854,17 @@ See [middleware examples](/concepts/components/prisma-client/middleware#examples
 <!-- prettier-ignore -->
 ### <inlinecode>$executeRaw()</inlinecode>
 
-See: [Raw database access (`$executeRaw()`)](/concepts/components/prisma-client/raw-database-access#executeRaw).
+See: [Raw database access (`$executeRaw()`)](/concepts/components/prisma-client/raw-database-access#executeraw).
 
 <!-- prettier-ignore -->
 ### <inlinecode>$queryRaw()</inlinecode>
 
-See: [Raw database access (`$queryRaw()`)](/concepts/components/prisma-client/raw-database-access#queryRaw).
+See: [Raw database access (`$queryRaw()`)](/concepts/components/prisma-client/raw-database-access#queryraw).
 
 <!-- prettier-ignore -->
 ### <inlinecode>$runCommandRaw()</inlinecode>
 
-See: [Raw database access (`$runCommandRaw()`)](/concepts/components/prisma-client/raw-database-access#runCommandRaw).
+See: [Raw database access (`$runCommandRaw()`)](/concepts/components/prisma-client/raw-database-access#runCommandraw).
 
 <!-- prettier-ignore -->
 ### <inlinecode>$transaction()</inlinecode>

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4864,7 +4864,7 @@ See: [Raw database access (`$queryRaw()`)](/concepts/components/prisma-client/ra
 <!-- prettier-ignore -->
 ### <inlinecode>$runCommandRaw()</inlinecode>
 
-See: [Raw database access (`$runCommandRaw()`)](/concepts/components/prisma-client/raw-database-access#runCommandraw).
+See: [Raw database access (`$runCommandRaw()`)](/concepts/components/prisma-client/raw-database-access#runcommandraw).
 
 <!-- prettier-ignore -->
 ### <inlinecode>$transaction()</inlinecode>


### PR DESCRIPTION
## Describe this PR

Fixed Redirection Issue caused by incorrect link in PrismaClient API reference section

## Changes

Changed uppercase `R` in Raw to lowercase `r` to make links working

## What issue does this fix?

- #2893 

