### PR TITLE
Missing underscore in `_count`

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
@@ -313,7 +313,7 @@ const getActiveUsers = await prisma.user.findMany({
   take: 10,
   orderBy: {
     posts: {
-      count: 'desc',
+      _count: 'desc',
     },
   },
 })


### PR DESCRIPTION
## Describe this PR

I noticed there was a missing underscore for `_count` in the docs under the Sort by relation aggregate value section.

## Changes

I added the underscore to the docs.

## What issue does this fix?

People who read the docs won't be confused if they copy the code verbatim.

## Any other relevant information

Prisma rocks!
