### PR TITLE
Add Remix to docs for prisma-in-your-stack/01-rest

### DIFF
--- a/content/200-concepts/050-overview/300-prisma-in-your-stack/01-rest.md
+++ b/content/200-concepts/050-overview/300-prisma-in-your-stack/01-rest.md
@@ -30,6 +30,7 @@ Here's a non-exhaustive list of libraries and frameworks you can use with Prisma
 - [Polka](https://github.com/lukeed/polka)
 - [Micro](https://github.com/zeit/micro)
 - [Feathers](https://feathersjs.com/)
+- [Remix](https://remix.run/)
 
 ## REST API server example
 


### PR DESCRIPTION
## Describe this PR

This PR includes the [Remix](https://remix.run/) framework into Prisma's supported libraries list. Since Prisma is being used a lot in conjunction with this framework I think it's a good idea to showcase it in the docs so newcomers to Prisma know that it's easy to setup with Remix.

## Changes

Included Remix framework into the docs under the supported libraries list.

## What issue does this fix?

None.

## Any other relevant information

Here are some examples on how Prisma is being used in the Remix community.

https://www.fullstackfish.com/posts/2021-12-31-remix-prisma-sqlite/
https://dev.to/aaronksaunders/working-with-remix-prisma-and-sqlite-to-save-data-using-forms-1b3j
https://portal.gitnation.org/contents/server-side-auth-with-remix-prisma-and-the-web-platform
