### PR TITLE
fix(mongodb): Remove or adjust all misleading/wrong "MongoDB is not supported" admonitions

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/125-creating-the-prisma-schema.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/125-creating-the-prisma-schema.mdx
@@ -9,13 +9,6 @@ toc: false
 
 ## Manually create the Prisma schema
 
-<Admonition type="warning">
-
-**Migrations and Introspections not supported** <br />
-Prisma does currently **not** support [Migrations](/concepts/components/prisma-migrate) or [Introspections](/concepts/components/introspection) when working with a MongoDB database.
-
-</Admonition>
-
 Open the `prisma/schema.prisma` file and replace the default configurations with the following:
 
 ```prisma file=prisma/schema.prisma

--- a/content/200-concepts/050-overview/100-what-is-prisma/100-data-modeling.mdx
+++ b/content/200-concepts/050-overview/100-what-is-prisma/100-data-modeling.mdx
@@ -238,9 +238,9 @@ Here is an overview of the main workflow:
 
 ### Using Prisma Client and Prisma Migrate
 
-When using [Prisma Migrate](/concepts/components/prisma-migrate), you define your application in the Prisma schema and use the `prisma migrate` subcommand to generate plain SQL migration files, which you can edit before applying.
+When using [Prisma Migrate](/concepts/components/prisma-migrate), you define your application in the Prisma schema and with relational databases use the `prisma migrate` subcommand to generate plain SQL migration files, which you can edit before applying. With MongoDB, you use `prisma db push` instead which applies the changes to your database directly.
 
 Here is an overview of the main workflow:
 
 1. Manually change your application models in the Prisma schema (e.g. add a new model, remove an existing one, ...)
-1. Run `prisma migrate dev` to create and apply a migration (the Prisma Client is automatically generated)
+1. Run `prisma migrate dev` to create and apply a migration or run `prisma db push` to apply the changes directly (in both cases the Prisma Client is automatically generated)

--- a/content/200-concepts/050-overview/100-what-is-prisma/100-data-modeling.mdx
+++ b/content/200-concepts/050-overview/100-what-is-prisma/100-data-modeling.mdx
@@ -238,13 +238,6 @@ Here is an overview of the main workflow:
 
 ### Using Prisma Client and Prisma Migrate
 
-<Admonition type="warning">
-
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 When using [Prisma Migrate](/concepts/components/prisma-migrate), you define your application in the Prisma schema and use the `prisma migrate` subcommand to generate plain SQL migration files, which you can edit before applying.
 
 Here is an overview of the main workflow:

--- a/content/200-concepts/050-overview/100-what-is-prisma/index.mdx
+++ b/content/200-concepts/050-overview/100-what-is-prisma/index.mdx
@@ -132,13 +132,6 @@ There are two major workflows for "getting" a data model into your Prisma schema
 - Manually writing the data model and mapping it to the database with [Prisma Migrate](/concepts/components/prisma-migrate)
 - Generating the data model by [introspecting](/concepts/components/introspection) a database
 
-<Admonition type="warning">
-
-**MongoDB not supported**<br />
-Introspection and Prisma Migrate do not yet support the MongoDB connector.
-
-</Admonition>
-
 Once the data model is defined, you can [generate Prisma Client](/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client) which will expose CRUD and more queries for the defined models. If you're using TypeScript, you'll get full type-safety for all queries (even when only retrieving the subsets of a model's fields).
 
 ### Accessing your database with Prisma Client
@@ -252,13 +245,6 @@ Note that when using TypeScript, the result of this query will be _statically ty
 ## Typical Prisma workflows
 
 As mentioned above, there are two ways for "getting" your data model into the Prisma schema. Depending on which approach you choose, your main Prisma workflow might look different.
-
-<Admonition type="warning">
-
-**MongoDB not supported**<br />
-Introspection and Prisma Migrate do not yet support the MongoDB connector. To use MongoDB while it is in Preview, you must design your Prisma schema to match the shape of your data in MongoDB.
-
-</Admonition>
 
 ### Prisma Migrate
 

--- a/content/200-concepts/100-components/03-prisma-migrate/100-supported-types-and-db-features.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/100-supported-types-and-db-features.mdx
@@ -4,13 +4,6 @@ title: Supported database types and features
 
 <TopBlock>
 
-<Admonition type="warning">
-
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 Prisma Migrate translates the model defined in your [Prisma schema](/concepts/components/prisma-schema) into features in your database.
 
 ![A diagram that shows a Prisma schema on the left (labeled: Prisma schema, models) and a database on the right (labeled: Database, tables). Two parallel arrows connect the schema and the database, showing how '@unique' maps to 'UNIQUE' and '@id' maps to 'PRIMARY KEY'.](migrate-mapping.png)

--- a/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
@@ -5,13 +5,6 @@ codeStyle: true
 
 <TopBlock>
 
-<Admonition type="warning">
-
-**MongoDB not supported** <br />
-The Migration Engine used by `db push` does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 [`db push`](/reference/api-reference/command-reference#db-push) <span class="api"></span> uses the same engine as Prisma Migrate to synchronize your Prisma schema with your database schema, and is best suited for **schema prototyping**. The `db push` command:
 
 1. Introspects the database to infer and executes the changes required to make your database schema reflect the state of your Prisma schema.
@@ -21,9 +14,10 @@ The Migration Engine used by `db push` does not currently support the [MongoDB c
    - Throw an error
    - Require the `--accept-data-loss` option if you still want to make the changes
 
-> **Notes**: 
-   * `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
-   * When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details refer to our Getting Started documentation, either [Start from scratch](/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale) or [Add to existing project](/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale) depending on your situation.
+> **Notes**:
+
+- `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
+- When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details refer to our Getting Started documentation, either [Start from scratch](/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale) or [Add to existing project](/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale) depending on your situation.
 
 </TopBlock>
 

--- a/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
@@ -15,9 +15,9 @@ codeStyle: true
    - Require the `--accept-data-loss` option if you still want to make the changes
 
 > **Notes**:
-
-- `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
-- When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details refer to our Getting Started documentation, either [Start from scratch](/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale) or [Add to existing project](/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale) depending on your situation.
+>
+> - `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
+> - When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details refer to our Getting Started documentation, either [Start from scratch](/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale) or [Add to existing project](/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale) depending on your situation.
 
 </TopBlock>
 

--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -4,14 +4,7 @@ title: Shadow database
 
 <TopBlock>
 
-<Admonition type="warning">
-
-**MongoDB does not use a shadow database** <br />
-Prisma Migrate, which uses a shadow database, is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
-Prisma Migrate uses a second, _temporary_ database when you run development-focused commands such as:
+Some development-focused commands for relational databases of Prisma Migrate use a second, _temporary_ database:
 
 - `prisma migrate dev`
 - `prisma migrate reset`
@@ -25,6 +18,8 @@ The shadow database is **created and deleted automatically**\* each time you run
 </FootNote>
 
 > **Important**: The shadow database is **not** required in production, and is not used by production-focused commands such as `prisma migrate resolve` and `prisma migrate deploy`.
+
+> **Note**: A shadow database is never used for MongoDB as these commands are not used there.
 
 </TopBlock>
 

--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -6,8 +6,8 @@ title: Shadow database
 
 <Admonition type="warning">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**MongoDB does not use a shadow database** <br />
+Prisma Migrate, which uses a shadow database, is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/200-concepts/100-components/04-introspection.mdx
+++ b/content/200-concepts/100-components/04-introspection.mdx
@@ -61,14 +61,7 @@ The typical workflow for projects that are not using Prisma Migrate, but instead
 1. Run `prisma generate` to update Prisma Client
 1. Use the updated Prisma Client in your application
 
-Note that as you evolve the application, this process can be repeated for an indefinite number of times.
-
-<Admonition type="warning">
-
-**MongoDB has a different workflow** <br />
-For now, using MongoDB introspection is meant to be done only once for initial data model. Running it repeatedly will lead to loss of data in the schema file, such as relations or comments.
-
-</Admonition>
+Note that as you evolve the application, [this process can be repeated for an indefinite number of times](#introspection-with-an-existing-schema).
 
 ![Introspection workflow](https://res.cloudinary.com/prismaio/image/upload/v1628761155/docs/ToNkpb2.png)
 
@@ -323,14 +316,9 @@ Note that you can rename the [Prisma-level](prisma-schema/relations#relation-fie
 
 ## Introspection with an existing schema
 
-<Admonition type="warning">
+Running `prisma db pull` for relational databases with an existing schema file merges manual changes made to the schema, with changes made in the database. (This functionality has been added for the first time with version 2.6.0.) For MongoDB, Introspection for now is meant to be done only once for the initial data model. Running it repeatedly will lead to loss of custom changes, as the ones listed below. <!-- TODO Remove when MongoDB Re-Introspection has been implemented -->
 
-**MongoDB only partially supported** <br />
-Introspecting _repeatedly_ with an existing schema can lead to data loss in the schema file if you modified it.
-
-</Admonition>
-
-In version 2.6.0 and later, running `prisma db pull` with an existing schema file merges manual changes made to the schema, with changes made in the database. Introspection maintains the following manual changes:
+Introspection for relational databases maintains the following manual changes:
 
 - Order of `model` blocks
 - Order of `enum` blocks

--- a/content/200-concepts/100-components/04-introspection.mdx
+++ b/content/200-concepts/100-components/04-introspection.mdx
@@ -54,13 +54,6 @@ Here's a high-level overview of the steps that `prisma db pull` performs interna
 
 ## Introspection workflow
 
-<Admonition type="warning">
-
-**MongoDB not supported** <br />
-For now, using MongoDB introspection is meant to be done only once for initial data model. Running it repeatedly will lead to loss of data in the schema file, such as relations or comments.
-
-</Admonition>
-
 The typical workflow for projects that are not using Prisma Migrate, but instead use plain SQL or another migration tool looks as follows:
 
 1. Change the database schema (e.g. using plain SQL)
@@ -69,6 +62,13 @@ The typical workflow for projects that are not using Prisma Migrate, but instead
 1. Use the updated Prisma Client in your application
 
 Note that as you evolve the application, this process can be repeated for an indefinite number of times.
+
+<Admonition type="warning">
+
+**MongoDB has a different workflow** <br />
+For now, using MongoDB introspection is meant to be done only once for initial data model. Running it repeatedly will lead to loss of data in the schema file, such as relations or comments.
+
+</Admonition>
 
 ![Introspection workflow](https://res.cloudinary.com/prismaio/image/upload/v1628761155/docs/ToNkpb2.png)
 
@@ -325,8 +325,8 @@ Note that you can rename the [Prisma-level](prisma-schema/relations#relation-fie
 
 <Admonition type="warning">
 
-**MongoDB not supported** <br />
-Introspecting _repeatedly_ with an existing schema will lead to data loss in the schema file.
+**MongoDB only partially supported** <br />
+Introspecting _repeatedly_ with an existing schema can lead to data loss in the schema file if you modified it.
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
@@ -10,7 +10,8 @@ This guide describes how to add [Prisma Migrate](/concepts/components/prisma-mig
 
 <Admonition type="info">
 
-This guide **does not apply for MongoDB**. Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
@@ -6,14 +6,13 @@ tocDepth: 2
 
 <TopBlock>
 
-<Admonition type="information">
+This guide describes how to add [Prisma Migrate](/concepts/components/prisma-migrate) to an existing project.
 
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**. Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
 
 </Admonition>
-
-This guide describes how to add [Prisma Migrate](/concepts/components/prisma-migrate) to an existing project.
 
 </TopBlock>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/050-add-prisma-migrate-to-a-project.mdx
@@ -6,10 +6,10 @@ tocDepth: 2
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 
@@ -69,9 +69,12 @@ To include [unsupported database features](include-unsupported-database-features
    ```
 
    - If the changes are significant, it can be easier to replace the entire migration file with the result of a database dump ([`mysqldump`](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html), [`pg_dump`](https://www.postgresql.org/docs/12/app-pgdump.html))
-   
+
 <Admonition type="info">
-Note that the order of the tables matters when creating all of them at once, since foreign keys are created at the same step. Therefore, either re-order them or move constraint creation to the last step after all tables are created, so you won't face `can't create constraint` errors
+  Note that the order of the tables matters when creating all of them at once,
+  since foreign keys are created at the same step. Therefore, either re-order
+  them or move constraint creation to the last step after all tables are
+  created, so you won't face `can't create constraint` errors
 </Admonition>
 
 ### Apply the initial migrations

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/150-team-development.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/150-team-development.mdx
@@ -5,13 +5,6 @@ metaDescription: How to use Prisma Migrate when collaborating on a project as a 
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 To incorporate changes from collaborators:
 
 1. Pull the changed Prisma schema and `./prisma/migrations` folder
@@ -22,6 +15,13 @@ To incorporate changes from collaborators:
    ```
 
 Migrations are **applied in the same order as they were created**. The creation date is part of the migration subfolder name - for example, `20210316081837-updated-fields` was created on `2021-03-16-08:08:37`.
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
 
 </TopBlock>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/150-team-development.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/150-team-development.mdx
@@ -5,10 +5,10 @@ metaDescription: How to use Prisma Migrate when collaborating on a project as a 
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/160-baselining.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/160-baselining.mdx
@@ -5,13 +5,6 @@ metaDescription: How to initialize a migration history for an existing database 
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate resolve` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 Baselining is the process of initializing a migration history for a database that:
 
 - ✔ Existed before you started using Prisma Migrate
@@ -22,6 +15,13 @@ Baselining tells Prisma Migrate to assume that one or more migrations have **alr
 > **Note**: We assume it is acceptable to reset and seed development databases.
 
 Baselining is part of [adding Prisma Migrate to a project with an existing database](add-prisma-migrate-to-a-project).
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate deploy`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
 
 </TopBlock>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/160-baselining.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/160-baselining.mdx
@@ -5,10 +5,10 @@ metaDescription: How to initialize a migration history for an existing database 
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate resolve` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
@@ -5,20 +5,24 @@ metaDecription: How to enable native database functions for projects that use Pr
 
 <TopBlock>
 
-<Admonition type="information">
+Some [native database functions](/concepts/components/prisma-schema/features-without-psl-equivalent#native-database-functions) <span class="concept"></span> are part of optional extensions. You cannot use the function if the extension is not installed. If your project uses [Prisma Migrate](/concepts/components/prisma-migrate), you must install the extension as part of a migration.
 
-**Does not apply for MongoDB** <br />
-The [MongoDB connector](/concepts/database-connectors/mongodb) does not require optional extensions as those do not exist for MongoDB.
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+[MongoDB](/concepts/database-connectors/mongodb) does not support optional extensions as those do not exist for MongoDB.
 
 </Admonition>
-
-Some [native database functions](/concepts/components/prisma-schema/features-without-psl-equivalent#native-database-functions) <span class="concept"></span> are part of optional extensions. You cannot use the function if the extension is not installed. If your project uses [Prisma Migrate](/concepts/components/prisma-migrate), you must install the extension as part of a migration.
 
 <Admonition type="warning">
 
 **Do not** manually install extensions - the [shadow database](/concepts/components/prisma-migrate/shadow-database) requires the same extensions, and since this database is created and deleted automatically, the only way to install extensions is to use migrations.
 
 </Admonition>
+
+</topblock>
+
+# Installing an extension as part of a migration
 
 The following example demonstrates how to install the `pgcrypto` extension as part of a migration:
 
@@ -58,5 +62,3 @@ The following example demonstrates how to install the `pgcrypto` extension as pa
    ```
 
 Each time you reset the database or add a new member to your team, all required functions are part of the migration history.
-
-</TopBlock>

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
@@ -22,7 +22,7 @@ This guide **does not apply for MongoDB**.<br />
 
 </TopBlock>
 
-# Installing an extension as part of a migration
+## Installing an extension as part of a migration
 
 The following example demonstrates how to install the `pgcrypto` extension as part of a migration:
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
@@ -5,10 +5,10 @@ metaDecription: How to enable native database functions for projects that use Pr
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+The [MongoDB connector](/concepts/database-connectors/mongodb) does not require optional extensions as those do not exist for MongoDB.
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/165-enable-native-database-functions.mdx
@@ -20,7 +20,7 @@ This guide **does not apply for MongoDB**.<br />
 
 </Admonition>
 
-</topblock>
+</TopBlock>
 
 # Installing an extension as part of a migration
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
@@ -5,10 +5,10 @@ metaDecription: How to include unsupported database features for projects that u
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
@@ -5,13 +5,6 @@ metaDecription: How to include unsupported database features for projects that u
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 Prisma Migrate uses the Prisma schema to determine what features to create in the database. However, some database features [cannot be represented in the Prisma schema](/concepts/components/prisma-schema/features-without-psl-equivalent) <span class="concept"></span>, including but not limited to:
 
 - Stored procedures
@@ -30,6 +23,17 @@ The Prisma schema is able to represent [unsupported field types](/concepts/compo
 </Tip>
 
 </Admonition>
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
+
+</TopBlock>
+
+# Customize a migration to include an unsupported feature
 
 To customize a migration to include an unsupported feature:
 
@@ -53,5 +57,3 @@ To customize a migration to include an unsupported feature:
    ```
 
 1. Commit the modified migration to source control.
-
-</TopBlock>

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
@@ -14,15 +14,11 @@ Prisma Migrate uses the Prisma schema to determine what features to create in th
 
 To add an unsupported feature to your database, you must [customize a migration](customizing-migrations) to include that feature before you apply it.
 
-<Admonition type="info">
-
 <Tip>
 
 The Prisma schema is able to represent [unsupported field types](/concepts/components/prisma-schema/features-without-psl-equivalent#unsupported-field-types) <span class="concept"></span> and [native database functions](enable-native-database-functions).
 
 </Tip>
-
-</Admonition>
 
 <Admonition type="info">
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/168-include-unsupported-database-features.mdx
@@ -29,7 +29,7 @@ Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-pus
 
 </TopBlock>
 
-# Customize a migration to include an unsupported feature
+## Customize a migration to include an unsupported feature
 
 To customize a migration to include an unsupported feature:
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
@@ -5,10 +5,10 @@ metaDescription: How to edit a migration file before applying it to avoid data l
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
@@ -5,13 +5,6 @@ metaDescription: How to edit a migration file before applying it to avoid data l
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 In some scenarios, you need to edit a migration before applying it. For example, to [change the direction of a 1-1 relation](#changing-the-direction-of-a-1-1-relation) (moving the foreign key from one side to another) without data loss, you need to move data as part of the migration - this SQL is not part of the default migration, and must be written by hand.
 
 To edit a migration file before applying it:
@@ -29,6 +22,13 @@ To edit a migration file before applying it:
    ```terminal
    npx prisma migrate dev
    ```
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
 
 </TopBlock>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/200-troubleshooting-development.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/200-troubleshooting-development.mdx
@@ -5,17 +5,17 @@ metaDescription: Troubleshooting issues with Prisma Migrate in a development env
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 This guide describes how to resolve issues with Prisma Migrate in a development environment, which often involves resetting your database. For production-focused troubleshooting, see:
 
 - [Production troubleshooting](/guides/database/production-troubleshooting)
 - [Patching / hotfixing production databases](/guides/database/patching-production)
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
 
 </TopBlock>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/200-troubleshooting-development.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/200-troubleshooting-development.mdx
@@ -5,10 +5,10 @@ metaDescription: Troubleshooting issues with Prisma Migrate in a development env
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
@@ -6,10 +6,10 @@ tocDepth: 2
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb). Use `db push` instead.
 
 </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
@@ -6,13 +6,6 @@ tocDepth: 2
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb). Use `db push` instead.
-
-</Admonition>
-
 This guide takes you through a typical **development workflow** with [Prisma Migrate](/concepts/components/prisma-migrate), from defining a schema to committing migrations to source control. This guide starts with an empty database, but you can also [add Prisma Migrate to an existing project](add-prisma-migrate-to-a-project).
 
 In a development environment, you use the `migrate dev` command to create and apply migrations:
@@ -27,6 +20,13 @@ When you are comfortable with using Prisma Migrate in development, consider the 
 
 - [How to use Prisma Migrate as a team](team-development)
 - [Advanced migration techniques](customizing-migrations)
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
 
 </TopBlock>
 

--- a/content/300-guides/050-database/400-prototyping-schema-db-push.mdx
+++ b/content/300-guides/050-database/400-prototyping-schema-db-push.mdx
@@ -5,13 +5,6 @@ metaDescription: How to use db push to prototype a new feature or an entirely ne
 
 <TopBlock>
 
-<Admonition type="warning">
-
-**MongoDB not supported** <br />
-`db push` uses the Migration Engine and does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 This guide demonstrates how to use [`db push`](/reference/api-reference/command-reference#db-push) to prototype a new schema or a new feature for an existing schema.
 
 Although `db push` and Prisma Migrate both synchronize your Prisma schema and database schema, they play [different roles in the development workflow](/concepts/components/prisma-migrate/db-push#choosing-db-push-or-prisma-migrate) and should not be used interchangeably.

--- a/content/300-guides/050-database/700-patching-production.mdx
+++ b/content/300-guides/050-database/700-patching-production.mdx
@@ -6,16 +6,16 @@ metaDescription: How to reconcile the migration history after applying a hotfix 
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
-
-</Admonition>
-
 Patching or hotfixing a database involves making an often time critical change directly in production. For example, you might add an index directly to a production database to resolve an issue with a slow-running query.
 
 Patching the production database directly results in **schema drift**: your database schema has 'drifted away' from the source of truth, and is out of sync with your migration history. You can use the `prisma migrate resolve` command to reconcile your migration history _without_ having to remove and re-apply the hotfix with `prisma migrate deploy`.
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
 
 </TopBlock>
 

--- a/content/300-guides/050-database/700-patching-production.mdx
+++ b/content/300-guides/050-database/700-patching-production.mdx
@@ -6,10 +6,10 @@ metaDescription: How to reconcile the migration history after applying a hotfix 
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -6,14 +6,14 @@ metaDescription: Troubleshooting Prisma Migrate issues in production environment
 
 <TopBlock>
 
-<Admonition type="information">
+The following guide describes issues relating to Prisma Migrate that can occur in production, and how to resolve them.
 
-**Does not apply for MongoDB** <br />
-`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate deploy`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
 
 </Admonition>
-
-The following guide describes issues relating to Prisma Migrate that can occur in production, and how to resolve them.
 
 </TopBlock>
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -6,10 +6,10 @@ metaDescription: Troubleshooting Prisma Migrate issues in production environment
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
@@ -6,18 +6,18 @@ metaDescription: 'Learn how to deploy database changes with Prisma Migrate.'
 
 <TopBlock>
 
-<Admonition type="information">
-
-**Does not apply for MongoDB** <br />
-`migrate deploy` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb). Use `db push` instead.
-
-</Admonition>
-
 To apply pending migrations to development, staging, or testing environments, run the `migrate deploy` command as part of your CI/CD pipeline:
 
 ```terminal
 npx prisma migrate deploy
 ```
+
+<Admonition type="info">
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate deploy`, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
+
+</Admonition>
 
 Exactly when to run `prisma migrate deploy` depends on your platform. For example, a simplified [Heroku](./deployment-guides/deploying-to-heroku) workflow includes:
 

--- a/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
@@ -6,10 +6,10 @@ metaDescription: 'Learn how to deploy database changes with Prisma Migrate.'
 
 <TopBlock>
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate deploy` is not used for the [MongoDB connector](/concepts/database-connectors/mongodb). Use `db push` instead.
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -805,9 +805,9 @@ Instead of `migrate dev` and related commands, [`db push`](/concepts/components/
 The `migrate dev` command updates your database using migrations during development and creates the database if it does not exist.
 
 <Admonition type="warning">
-  This command is not supported on
-  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
-  push`](/concepts/components/prisma-migrate/db-push) instead.
+
+This command is not supported on [MongoDB](/concepts/database-connectors/mongodb). Use [`db push`](/concepts/components/prisma-migrate/db-push) instead.
+
 </Admonition>
 
 See also:
@@ -852,9 +852,9 @@ prisma migrate dev --create-only
 This command deletes and recreates the database, or performs a 'soft reset' by removing all data, tables, indexes, and other artifacts.
 
 <Admonition type="warning">
-  This command is not supported on
-  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
-  push`](/concepts/components/prisma-migrate/db-push) instead.
+
+This command is not supported on [MongoDB](/concepts/database-connectors/mongodb). Use [`db push`](/concepts/components/prisma-migrate/db-push) instead.
+
 </Admonition>
 
 #### Options
@@ -887,9 +887,9 @@ The `migrate deploy` command applies all pending migrations, and creates the dat
 - Does **not** rely on a shadow database
 
 <Admonition type="warning">
-  This command is not supported on
-  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
-  push`](/concepts/components/prisma-migrate/db-push) instead.
+
+This command is not supported on [MongoDB](/concepts/database-connectors/mongodb). Use [`db push`](/concepts/components/prisma-migrate/db-push) instead.
+
 </Admonition>
 
 #### Options
@@ -915,9 +915,9 @@ prisma migrate deploy
 The `migrate resolve` command allows you to solve migration history issues in production by marking a migration as already applied (supports baselining) or rolled back.
 
 <Admonition type="warning">
-  This command is not supported on
-  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
-  push`](/concepts/components/prisma-migrate/db-push) instead.
+
+This command is not supported on [MongoDB](/concepts/database-connectors/mongodb). Use [`db push`](/concepts/components/prisma-migrate/db-push) instead.
+
 </Admonition>
 
 #### Options
@@ -951,9 +951,9 @@ prisma migrate resolve --rolled-back 20201231000000_add_users_table
 The `prisma migrate status` command looks up the migrations in `/prisma/migrations/*` folder and the entries in the `_prisma_migrations` table and compiles information about the state of the migrations in your database.
 
 <Admonition type="warning">
-  This command is not supported on
-  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
-  push`](/concepts/components/prisma-migrate/db-push) instead.
+
+This command is not supported on [MongoDB](/concepts/database-connectors/mongodb). Use [`db push`](/concepts/components/prisma-migrate/db-push) instead.
+
 </Admonition>
 
 For example:

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -791,10 +791,10 @@ Other options:
 
 Prisma Migrate changed from Preview to Generally Available (GA) in 2.19.0.
 
-<Admonition type="information">
+<Admonition type="info">
 
 **Does not apply for MongoDB** <br />
-`migrate dev` and related commands are not used for the [MongoDB connector](/concepts/database-connectors/mongodb). Use `db push` instead.
+Instead of `migrate dev` and related commands, [`db push`](/concepts/components/prisma-migrate/db-push) is used for [MongoDB](/concepts/database-connectors/mongodb).
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -791,10 +791,10 @@ Other options:
 
 Prisma Migrate changed from Preview to Generally Available (GA) in 2.19.0.
 
-<Admonition type="warning">
+<Admonition type="information">
 
-**MongoDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB connector](/concepts/database-connectors/mongodb).
+**Does not apply for MongoDB** <br />
+`migrate dev` and related commands are not used for the [MongoDB connector](/concepts/database-connectors/mongodb). Use `db push` instead.
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -494,7 +494,7 @@ The `db pull` command connects to your database and adds Prisma models to your P
 
 <Admonition type="warning">
 
-**Warning**: The command will overwrite the current `schema.prisma` file with the new schema. Some manual changes or customization can be lost. Be sure to back up your current `schema.prisma` file (or commit your current state to e.g. Git to be able to revert any changes) before running `db pull` if it contains important modifications.
+**Warning**: The command will overwrite the current `schema.prisma` file with the new schema. Some manual changes or customization can be lost. Be sure to back up your current `schema.prisma` file (or commit your current state to version control to be able to revert any changes) before running `db pull` if it contains important modifications.
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -1000,9 +1000,9 @@ This command is available in Preview in versions 3.9.0 and later.
 </Admonition>
 
 <Admonition type="warning">
-  This command is only partially supported for
-  [MongoDB](/concepts/database-connectors/mongodb). See the command options
-  below for details.
+
+This command is only partially supported for [MongoDB](/concepts/database-connectors/mongodb). See the command options below for details.
+
 </Admonition>
 
 This command compares two database schema sources and outputs a description of a migration taking the first to the state of the second.

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -490,17 +490,17 @@ Validation Error Count: 1
 
 ### <inlinecode>db pull</inlinecode>
 
-<Admonition type="info">
-
-Introspection with the `db pull` command on the [MongoDB connector](/concepts/database-connectors/mongodb) samples the data instead of reading a schema.
-
-</Admonition>
-
 The `db pull` command connects to your database and adds Prisma models to your Prisma schema that reflect the current database schema.
 
 <Admonition type="warning">
 
-**Warning**: The command will overwrite the current `schema.prisma` file with the new schema. Any manual changes or customization will be lost. Be sure to back up your current `schema.prisma` file before running `db pull` if it contains important modifications.
+**Warning**: The command will overwrite the current `schema.prisma` file with the new schema. Some manual changes or customization can be lost. Be sure to back up your current `schema.prisma` file (or commit your current state to e.g. Git to be able to revert any changes) before running `db pull` if it contains important modifications.
+
+</Admonition>
+
+<Admonition type="info">
+
+Introspection with the `db pull` command on the [MongoDB connector](/concepts/database-connectors/mongodb) samples the data instead of reading a schema.
 
 </Admonition>
 
@@ -723,7 +723,7 @@ This command is available in Preview in versions 3.9.0 and later.
 
 <Admonition type="warning">
 
-This command is currently not supported on MongoDB.
+This command is currently not supported on [MongoDB](/concepts/database-connectors/mongodb).
 
 </Admonition>
 
@@ -802,7 +802,15 @@ Instead of `migrate dev` and related commands, [`db push`](/concepts/components/
 
 **For use in development environments only, requires shadow database**
 
-The `migrate dev` command updates your database using migrations during development and creates the database if it does not exist. See also:
+The `migrate dev` command updates your database using migrations during development and creates the database if it does not exist.
+
+<Admonition type="warning">
+  This command is not supported on
+  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
+  push`](/concepts/components/prisma-migrate/db-push) instead.
+</Admonition>
+
+See also:
 
 - [Conceptual overview of Prisma Migrate](/concepts/components/prisma-migrate) <span class="concept"></span>
 - [Developing with Prisma Migrate](/guides/database/developing-with-prisma-migrate) <span class="guide"></span>
@@ -843,6 +851,12 @@ prisma migrate dev --create-only
 
 This command deletes and recreates the database, or performs a 'soft reset' by removing all data, tables, indexes, and other artifacts.
 
+<Admonition type="warning">
+  This command is not supported on
+  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
+  push`](/concepts/components/prisma-migrate/db-push) instead.
+</Admonition>
+
 #### Options
 
 | Option            | Required | Description                                             | Default |
@@ -872,6 +886,12 @@ The `migrate deploy` command applies all pending migrations, and creates the dat
 - Does **not** reset the database or generate artifacts
 - Does **not** rely on a shadow database
 
+<Admonition type="warning">
+  This command is not supported on
+  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
+  push`](/concepts/components/prisma-migrate/db-push) instead.
+</Admonition>
+
 #### Options
 
 | Option           | Required | Description               | Default |
@@ -893,6 +913,12 @@ prisma migrate deploy
 ### <inlinecode>migrate resolve</inlinecode>
 
 The `migrate resolve` command allows you to solve migration history issues in production by marking a migration as already applied (supports baselining) or rolled back.
+
+<Admonition type="warning">
+  This command is not supported on
+  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
+  push`](/concepts/components/prisma-migrate/db-push) instead.
+</Admonition>
 
 #### Options
 
@@ -922,7 +948,15 @@ prisma migrate resolve --rolled-back 20201231000000_add_users_table
 
 ### <inlinecode>migrate status</inlinecode>
 
-The `prisma migrate status` command looks up the migrations in `/prisma/migrations/*` folder and the entries in the `_prisma_migrations` table and compiles information about the state of the migrations in your database. For example:
+The `prisma migrate status` command looks up the migrations in `/prisma/migrations/*` folder and the entries in the `_prisma_migrations` table and compiles information about the state of the migrations in your database.
+
+<Admonition type="warning">
+  This command is not supported on
+  [MongoDB](/concepts/database-connectors/mongodb). Use [`db
+  push`](/concepts/components/prisma-migrate/db-push) instead.
+</Admonition>
+
+For example:
 
 ```
 Status
@@ -966,9 +1000,9 @@ This command is available in Preview in versions 3.9.0 and later.
 </Admonition>
 
 <Admonition type="warning">
-
-This command is only partially supported in MongoDB. See the command options below for details.
-
+  This command is only partially supported for
+  [MongoDB](/concepts/database-connectors/mongodb). See the command options
+  below for details.
 </Admonition>
 
 This command compares two database schema sources and outputs a description of a migration taking the first to the state of the second.


### PR DESCRIPTION
This PR removes all the misleading or wrong "MongoDB is not supported" admonitions we have scattered through our docs. Some are just deleted, other are reworded, repositioned and styled differently to present the situation more appropriately.

Quite a few changes, so use Percy to look at the diffs visually. I also comment on all the relevant changes why they were made.