### PR TITLE
Regenerate errors in Error Reference page

### DIFF
--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -90,19 +90,13 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 
 #### <inlinecode>P1002</inlinecode>
 
-"The database server at `{database_host}`:`{database_port}` was reached but timed out. Please try again. Please make sure your database server is running at `{database_host}`:`{database_port}`. "
+"The database server at `{database_host}`:`{database_port}` was reached but timed out. Please try again. Please make sure your database server is running at `{database_host}`:`{database_port}`. Context: {context} "
 
 #### <inlinecode>P1003</inlinecode>
 
-"Database {database_file_name} does not exist at {database_file_path}"
-
-"Database `{database_name}.{database_schema_name}` does not exist on the database server at `{database_host}:{database_port}`."
-
-"Database `{database_name}` does not exist on the database server at `{database_host}:{database_port}`."
-
 #### <inlinecode>P1008</inlinecode>
 
-"Operations timed out after `{time}`"
+"Operations timed out after `{time}`. Context: {context}"
 
 #### <inlinecode>P1009</inlinecode>
 
@@ -121,45 +115,6 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 "{full_error}"
 
 Possible errors:
-
-- "Argument `{}` is missing."
-- "Function `{}` takes {} arguments, but received {}."
-- "Argument `{}` is missing in attribute `@{}`."
-- "Argument `{}` is missing in data source block `{}`."
-- "Argument `{}` is missing in generator block `{}`."
-- "Error parsing attribute `@{}`: {}"
-- "Attribute `@{}` is defined twice."
-- "The model with database name `{}` could not be defined because another model with this name exists: `{}`"
-- "`{}` is a reserved scalar type name and can not be used."
-- "The {} `{}` cannot be defined because a {} with that name already exists."
-- "Key `{}` is already defined in {}."
-- "Argument `{}` is already specified as unnamed argument."
-- "Argument `{}` is already specified."
-- "No such argument.""
-- "Field `{}` is already defined on model `{}`."
-- "Field `{}` in model `{}` can't be a list. The current connector does not support lists of primitive types."
-- "The index name `{}` is declared multiple times. With the current connector index names have to be globally unique."
-- "Value `{}` is already defined on enum `{}`."
-- "Attribute not known: `@{}`."
-- "Function not known: `{}`."
-- "Datasource provider not known: `{}`."
-- "shadowDatabaseUrl is the same as url for datasource `{}`. Please specify a different database as shadow database."
-- "The preview feature `{}` is not known. Expected one of: {}"
-- "`{}` is not a valid value for {}."
-- "Type `{}` is neither a built-in type, nor refers to another model, custom type, or enum."
-- "Type `{}` is not a built-in type."
-- "Unexpected token. Expected one of: {}"
-- "{}"
-- "{}"
-- "{}"
-- "Environment variable not found: {}."
-- "Expected a {} value, but received {} value `{}`."
-- "Expected a {} value, but failed while parsing `{}`: {}."
-- "Error validating model `{}`: {}"
-- "Error validating field `{}` in model `{}`: {}"
-- "Error validating datasource `{datasource}`: {message}""
-- "Error validating enum `{}`: {}"
-- "Error validating: {}"
 
 #### <inlinecode>P1013</inlinecode>
 
@@ -180,6 +135,14 @@ Possible errors:
 #### <inlinecode>P1017</inlinecode>
 
 "Server has closed the connection."
+
+#### <inlinecode>P1018</inlinecode>
+
+"{message}"
+
+#### <inlinecode>P1019</inlinecode>
+
+"{message}"
 
 ### Prisma Client (Query Engine)
 
@@ -281,7 +244,7 @@ Possible errors:
 
 #### <inlinecode>P2024</inlinecode>
 
-"Timed out fetching a new connection from the connection pool. (More info: [http://pris.ly/d/connection-pool](http://pris.ly/d/connection-pool), Current connection limit: {connection_limit})"
+"Timed out fetching a new connection from the connection pool. More info: http://pris.ly/d/connection-pool (Current connection pool timeout: {timeout}, connection limit: {connection_limit})"
 
 #### <inlinecode>P2025</inlinecode>
 
@@ -295,9 +258,25 @@ Possible errors:
 
 "Multiple errors occurred on the database during query execution: {errors}"
 
+#### <inlinecode>P2028</inlinecode>
+
+"Transaction API error: {error}"
+
+#### <inlinecode>P2029</inlinecode>
+
+"Query parameter limit exceeded error: {message}."
+
 #### <inlinecode>P2030</inlinecode>
 
 "Cannot find a fulltext index to use for the search, try adding a @@fulltext([Fields...]) to your schema"
+
+#### <inlinecode>P2031</inlinecode>
+
+"Prisma needs to perform transactions, which requires your MongoDB server to be run as a replica set. https://pris.ly/d/mongodb-replica-set"
+
+#### <inlinecode>P2032</inlinecode>
+
+"Error converting field \"{field}\" of expected non-nullable type \"{expected_type}\" found incompatible value of \"{found}\"."
 
 ### Prisma Migrate (Migration Engine)
 
@@ -315,7 +294,7 @@ Possible errors:
 
 #### <inlinecode>P3003</inlinecode>
 
-"The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: [https://pris.ly/d/migrate](https://pris.ly/d/migrate)"
+"The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: https://pris.ly/d/migrate"
 
 #### <inlinecode>P3004</inlinecode>
 
@@ -323,7 +302,7 @@ Possible errors:
 
 #### <inlinecode>P3005</inlinecode>
 
-"The database schema for `{database_name}` is not empty. Read more about how to baseline an existing production database: [https://pris.ly/d/migrate-baseline](https://pris.ly/d/migrate-baseline)"
+"The database schema is not empty. Read more about how to baseline an existing production database: https://pris.ly/d/migrate-baseline"
 
 #### <inlinecode>P3006</inlinecode>
 
@@ -339,7 +318,7 @@ Possible errors:
 
 #### <inlinecode>P3009</inlinecode>
 
-"migrate found failed migrations in the target database, new migrations will not be applied. Read more about how to resolve migration issues in a production database: [https://pris.ly/d/migrate-resolve](https://pris.ly/d/migrate-resolve)<br />{details}"
+"migrate found failed migrations in the target database, new migrations will not be applied. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve<br />{details}"
 
 #### <inlinecode>P3010</inlinecode>
 
@@ -355,11 +334,11 @@ Possible errors:
 
 #### <inlinecode>P3013</inlinecode>
 
-"Datasource provider arrays are no longer supported in migrate. Please change your datasource to use a single provider. Read more at [https://pris.ly/multi-provider-deprecation](https://pris.ly/multi-provider-deprecation)"
+"Datasource provider arrays are no longer supported in migrate. Please change your datasource to use a single provider. Read more at https://pris.ly/multi-provider-deprecation"
 
 #### <inlinecode>P3014</inlinecode>
 
-"Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. More info: [https://pris.ly/d/migrate-shadow](https://pris.ly/d/migrate-shadow). Original error: {error_code}<br />{inner_error}"
+"Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. Read more about the shadow database (and workarounds) at https://pris.ly/d/migrate-shadow<br /><br />Original error: {error_code}<br />{inner_error}"
 
 #### <inlinecode>P3015</inlinecode>
 
@@ -375,11 +354,11 @@ Possible errors:
 
 #### <inlinecode>P3018</inlinecode>
 
-"A migration failed to apply. New migrations can not be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve<br /><br />Migration name: {migration_name}<br /><br />Database error code: {database_error_code}<br /><br />Database error:<br />{database_error} "
+"A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve<br /><br />Migration name: {migration_name}<br /><br />Database error code: {database_error_code}<br /><br />Database error:<br />{database_error} "
 
 #### <inlinecode>P3019</inlinecode>
 
-"The datasource provider `{provider}` specified in your schema does not match the one specified in the migration_lock.toml, `{expected_provider}`. Please remove your current migration directory and start a new migration history with prisma migrate dev. Read more: [https://pris.ly/d/migrate-provider-switch](https://pris.ly/d/migrate-provider-switch)"
+"The datasource provider `{provider}` specified in your schema does not match the one specified in the migration_lock.toml, `{expected_provider}`. Please remove your current migration directory and start a new migration history with prisma migrate dev. Read more: https://pris.ly/d/migrate-provider-switch"
 
 #### <inlinecode>P3020</inlinecode>
 

--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -90,9 +90,15 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 
 #### <inlinecode>P1002</inlinecode>
 
-"The database server at `{database_host}`:`{database_port}` was reached but timed out. Please try again. Please make sure your database server is running at `{database_host}`:`{database_port}`. Context: {context} "
+"The database server at `{database_host}`:`{database_port}` was reached but timed out. Please try again. Please make sure your database server is running at `{database_host}`:`{database_port}`. Context: `{context}` "
 
 #### <inlinecode>P1003</inlinecode>
+
+"Database `{database_file_name}` does not exist at {database_file_path}"
+
+"Database `{database_name}.{database_schema_name}` does not exist on the database server at `{database_host}:{database_port}`."
+
+"Database `{database_name}` does not exist on the database server at `{database_host}:{database_port}`."
 
 #### <inlinecode>P1008</inlinecode>
 
@@ -115,6 +121,42 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 "{full_error}"
 
 Possible errors:
+
+- "Argument `{}` is missing."
+- "Function `{}` takes {} arguments, but received {}."
+- "Argument `{}` is missing in attribute `@{}`."
+- "Argument `{}` is missing in data source block `{}`."
+- "Argument `{}` is missing in generator block `{}`."
+- "Error parsing attribute `@{}`: {}"
+- "Attribute `@{}` is defined twice."
+- "The model with database name `{}` could not be defined because another model with this name exists: `{}`"
+- "`{}` is a reserved scalar type name and can not be used."
+- "The {} `{}` cannot be defined because a {} with that name already exists."
+- "Key `{}` is already defined in {}."
+- "Argument `{}` is already specified as unnamed argument."
+- "Argument `{}` is already specified."
+- "No such argument.""
+- "Field `{}` is already defined on model `{}`."
+- "Field `{}` in model `{}` can't be a list. The current connector does not support lists of primitive types."
+- "The index name `{}` is declared multiple times. With the current connector index names have to be globally unique."
+- "Value `{}` is already defined on enum `{}`."
+- "Attribute not known: `@{}`."
+- "Function not known: `{}`."
+- "Datasource provider not known: `{}`."
+- "shadowDatabaseUrl is the same as url for datasource `{}`. Please specify a different database as shadow database."
+- "The preview feature `{}` is not known. Expected one of: {}"
+- "`{}` is not a valid value for {}."
+- "Type `{}` is neither a built-in type, nor refers to another model, custom type, or enum."
+- "Type `{}` is not a built-in type."
+- "Unexpected token. Expected one of: {}"
+- "Environment variable not found: {}."
+- "Expected a {} value, but received {} value `{}`."
+- "Expected a {} value, but failed while parsing `{}`: {}."
+- "Error validating model `{}`: {}"
+- "Error validating field `{}` in model `{}`: {}"
+- "Error validating datasource `{datasource}`: {message}""
+- "Error validating enum `{}`: {}"
+- "Error validating: {}"
 
 #### <inlinecode>P1013</inlinecode>
 
@@ -244,7 +286,7 @@ Possible errors:
 
 #### <inlinecode>P2024</inlinecode>
 
-"Timed out fetching a new connection from the connection pool. More info: http://pris.ly/d/connection-pool (Current connection pool timeout: {timeout}, connection limit: {connection_limit})"
+"Timed out fetching a new connection from the connection pool. (More info: [http://pris.ly/d/connection-pool](http://pris.ly/d/connection-pool), Current connection limit: {connection_limit})"
 
 #### <inlinecode>P2025</inlinecode>
 
@@ -276,7 +318,7 @@ Possible errors:
 
 #### <inlinecode>P2032</inlinecode>
 
-"Error converting field \"{field}\" of expected non-nullable type \"{expected_type}\" found incompatible value of \"{found}\"."
+"Error converting field "{field}" of expected non-nullable type "{expected_type}" found incompatible value of "{found}"."
 
 ### Prisma Migrate (Migration Engine)
 
@@ -294,7 +336,7 @@ Possible errors:
 
 #### <inlinecode>P3003</inlinecode>
 
-"The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: https://pris.ly/d/migrate"
+"The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: [https://pris.ly/d/migrate](https://pris.ly/d/migrate)"
 
 #### <inlinecode>P3004</inlinecode>
 
@@ -302,7 +344,7 @@ Possible errors:
 
 #### <inlinecode>P3005</inlinecode>
 
-"The database schema is not empty. Read more about how to baseline an existing production database: https://pris.ly/d/migrate-baseline"
+"The database schema for `{database_name}` is not empty. Read more about how to baseline an existing production database: [https://pris.ly/d/migrate-baseline](https://pris.ly/d/migrate-baseline)"
 
 #### <inlinecode>P3006</inlinecode>
 
@@ -318,7 +360,7 @@ Possible errors:
 
 #### <inlinecode>P3009</inlinecode>
 
-"migrate found failed migrations in the target database, new migrations will not be applied. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve<br />{details}"
+"migrate found failed migrations in the target database, new migrations will not be applied. Read more about how to resolve migration issues in a production database: [https://pris.ly/d/migrate-resolve](https://pris.ly/d/migrate-resolve)<br />{details}"
 
 #### <inlinecode>P3010</inlinecode>
 
@@ -334,11 +376,11 @@ Possible errors:
 
 #### <inlinecode>P3013</inlinecode>
 
-"Datasource provider arrays are no longer supported in migrate. Please change your datasource to use a single provider. Read more at https://pris.ly/multi-provider-deprecation"
+"Datasource provider arrays are no longer supported in migrate. Please change your datasource to use a single provider. Read more at [https://pris.ly/multi-provider-deprecation](https://pris.ly/multi-provider-deprecation)"
 
 #### <inlinecode>P3014</inlinecode>
 
-"Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. Read more about the shadow database (and workarounds) at https://pris.ly/d/migrate-shadow<br /><br />Original error: {error_code}<br />{inner_error}"
+"Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. More info: [https://pris.ly/d/migrate-shadow](https://pris.ly/d/migrate-shadow). Original error: {error_code}<br />{inner_error}"
 
 #### <inlinecode>P3015</inlinecode>
 
@@ -358,7 +400,7 @@ Possible errors:
 
 #### <inlinecode>P3019</inlinecode>
 
-"The datasource provider `{provider}` specified in your schema does not match the one specified in the migration_lock.toml, `{expected_provider}`. Please remove your current migration directory and start a new migration history with prisma migrate dev. Read more: https://pris.ly/d/migrate-provider-switch"
+"The datasource provider `{provider}` specified in your schema does not match the one specified in the migration_lock.toml, `{expected_provider}`. Please remove your current migration directory and start a new migration history with prisma migrate dev. Read more: [https://pris.ly/d/migrate-provider-switch](https://pris.ly/d/migrate-provider-switch)"
 
 #### <inlinecode>P3020</inlinecode>
 


### PR DESCRIPTION
Update with latest output from [error_code_parser.py script](https://github.com/mhwelander/doc-tools/blob/master/error_code_parser.py)

This seems to delete text from some errors (e.g. P1003, P1012) so probably needs tweaking a bit

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
