### PR TITLE
Fix typo at refential action docs

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -31,7 +31,7 @@ If you do not specify a referential action, Prisma [uses a default](#referential
 
 <Admonition type="alert">
 
-If you upgrade from a version earlier than 2.26.0: 
+If you upgrade from a version earlier than 2.26.0:
 It is extremely important that you check the [upgrade paths for referential actions](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) section if you upgrade from a version before 2.26.0. Prisma support of referential actions **removes the safety net in Prisma Client that prevents cascading deletes at runtime**. If you use the feature _without upgrading your database_, the [old default action](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions#prisma-2x-default-referential-actions) - `ON DELETE CASCADE` - becomes active. This may result in cascading deletes that you did not expect.
 
 </Admonition>
@@ -368,7 +368,7 @@ When running a [Migration](../../../prisma-migrate) (or the [`prisma db push`](.
 
 <Admonition type="info">
 
-Unlike when you run an Introspect for the first time, the new referential actions clause and property, will **not** automatically be addded to your prisma schema by the Prisma VSCode extension.
+Unlike when you run an Introspect for the first time, the new referential actions clause and property, will **not** automatically be added to your prisma schema by the Prisma VSCode extension.
 You will have to manually add them if you wish to use anything other than the new defaults.
 
 </Admonition>


### PR DESCRIPTION
## Describe this PR

There is a tiny typo fixed.

## Changes

There is a tiny typo fixed.

`addded` word fixed => `added`