### PR TITLE
docs: add more consistent table schema in 300-many-to-many-relations.mdx

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -73,6 +73,45 @@ CREATE TABLE "CategoriesOnPosts" (
 CREATE UNIQUE INDEX "CategoriesOnPosts_category_post_unique" ON "CategoriesOnPosts"("categoryId" int4_ops,"postId" int4_ops);
 ```
 
+<details><summary>Expand for a migration SQL that is generated from this schema</summary>
+
+```sql
+-- CreateTable
+CREATE TABLE "Post" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+
+    CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Category" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CategoriesOnPosts" (
+    "postId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "assignedBy" TEXT NOT NULL,
+
+    CONSTRAINT "CategoriesOnPosts_pkey" PRIMARY KEY ("postId","categoryId")
+);
+
+-- AddForeignKey
+ALTER TABLE "CategoriesOnPosts" ADD CONSTRAINT "CategoriesOnPosts_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CategoriesOnPosts" ADD CONSTRAINT "CategoriesOnPosts_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+```
+
+</details>
+
 #### Querying an explicit many-to-many
 
 The following section demonstrates how to query an explicit many-to-many relation. You can query the relation model directly (`prisma.categoriesOnPosts(...)`), or use nested queries to go from `Post` -> `CategoriesOnPosts` -> `Category` or the other way.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -57,20 +57,22 @@ CREATE TABLE "Category" (
     id SERIAL PRIMARY KEY
     name TEXT NOT NULL
 );
+
 CREATE TABLE "Post" (
     id SERIAL PRIMARY KEY
     title TEXT NOT NULL
 );
--- Relation table + indexes -------------------------------------------------------
+
+-- Relation table  -------------------------------------------------------
 CREATE TABLE "CategoriesOnPosts" (
-    "categoryId" integer NOT NULL,
-    "postId" integer NOT NULL,
-    "assignedBy" text NOT NULL
-    "assignedAt" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY ("categoryId")  REFERENCES "Category"(id),
-    FOREIGN KEY ("postId") REFERENCES "Post"(id)
+    "categoryId" INTEGER NOT NULL,
+    "postId" INTEGER NOT NULL,
+    "assignedBy" TEXT NOT NULL,    
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "CategoriesOnPosts_pkey" PRIMARY KEY ("postId", "categoryId")
 );
-CREATE UNIQUE INDEX "CategoriesOnPosts_category_post_unique" ON "CategoriesOnPosts"("categoryId" int4_ops,"postId" int4_ops);
 ```
 
 <details><summary>Expand for a migration SQL that is generated from this schema</summary>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -55,9 +55,11 @@ The underlying SQL looks like this:
 ```sql
 CREATE TABLE "Category" (
     id SERIAL PRIMARY KEY
+    name TEXT NOT NULL
 );
 CREATE TABLE "Post" (
     id SERIAL PRIMARY KEY
+    title TEXT NOT NULL
 );
 -- Relation table + indexes -------------------------------------------------------
 CREATE TABLE "CategoriesOnPosts" (


### PR DESCRIPTION
## Describe this PR

While a friend (@Xula) was reading the relationship documentation he found an SQL that didn't conform to a Prisma schema, he tell me. So I test the examples from docs, adapted this SQL and also added an expandable example of the real SQL generated in a migration from that Prisma schema.

## Changes

- Refactored SQL to fit more in Prisma schema.
- Added expandable example of real SQL generated from Prisma schema.
