### PR TITLE
Wrong variable name with TRUNCATE example in MySQL

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -966,7 +966,7 @@ const tablenames = await prisma.$queryRaw<
   Array<{ tablename: string }>
 >`SELECT TABLE_NAME from information_schema.TABLES WHERE TABLE_SCHEMA = 'tests';`
 
-for (const { tablename } of tablenames) {
+for (const { TABLE_NAME } of tablenames) {
   if (tablename !== '_prisma_migrations') {
     try {
       transactions.push(prisma.$executeRawUnsafe(`TRUNCATE ${tablename};`))


### PR DESCRIPTION
## Describe this PR

The example regarding how to truncate tables is wrong in MySQL. The deconstructed variable doesn't match the name of the column that's being selected in the SQL query.

## Changes


- Fixed the deconstruction in mySQL truncate example

## What issue does this fix?

## Any other relevant information

@all-contributors please add @Exilz for doc