### PR TITLE
Add `--exit-code` flag to `migrate diff`

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -1071,11 +1071,12 @@ One of the following `--to-...` options is required:
 
 Other options:
 
-| Options                 | Required | Description                                                         | Notes                                                           |
-| :---------------------- | :------- | :------------------------------------------------------------------ | :-------------------------------------------------------------- |
-| `--shadow-database-url` | No       | URL for the shadow database                                         | Only required if using `--to-migrations` or `--from-migrations` |
-| `--script`              | No       | Outputs a SQL script instead of the default human-readable summary. | Not supported in MongoDB                                        |
-| `--help`                | No       | Displays the help message.                                          |                                                                 |
+| Options                 | Required | Description                                                                                            | Notes                                                           |
+| :---------------------- | :------- | :----------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
+| `--shadow-database-url` | No       | URL for the shadow database                                                                            | Only required if using `--to-migrations` or `--from-migrations` |
+| `--script`              | No       | Outputs a SQL script instead of the default human-readable summary                                     | Not supported in MongoDB                                        |
+| `--exit-code`           | No       | Change the exit code behavior to signal if the diff is empty or not (Empty: 0, Error: 1, Not empty: 2) |                                                                 |
+| `--help`                | No       | Displays the help message.                                                                             |                                                                 |
 
 #### Examples
 


### PR DESCRIPTION
⚠️ To be merged for 3.11 release

Add `--exit-code` flag to migrate diff reference documentation

See Slack thread [here](https://prisma-company.slack.com/archives/C02FNFLDUS3/p1646844222542039).

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
