### PR TITLE
Remove cockroachdb migrations admonition

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -9,8 +9,8 @@ tocDepth: 3
 
 <Admonition type="warning">
 
-**MongoDB and CockroachDB not supported** <br />
-Prisma Migrate does not currently support the [MongoDB](/concepts/database-connectors/mongodb) or [CockroachDB](/concepts/database-connectors/cockroachdb) connectors.
+**MongoDB not supported** <br />
+Prisma Migrate does not currently support the [MongoDB](/concepts/database-connectors/mongodb) connector.
 
 </Admonition>
 

--- a/content/200-concepts/200-database-connectors/08-cockroachdb.mdx
+++ b/content/200-concepts/200-database-connectors/08-cockroachdb.mdx
@@ -11,7 +11,7 @@ The CockroachDB data source connector connects Prisma to a [CockroachDB](https:/
 
 <Admonition type="warning">
 
-CockroachDB support is currently a [Preview feature](https://www.prisma.io/docs/concepts/components/preview-features).
+CockroachDB support is currently a [Preview feature](https://www.prisma.io/docs/concepts/components/preview-features). Introspection support was added with the first Preview version, [3.9.0](https://github.com/prisma/prisma/releases/tag/3.9.0) and Prisma Migrate support since [3.11.0](https://github.com/prisma/prisma/releases/tag/3.11.0).
 
 </Admonition>
 

--- a/content/200-concepts/200-database-connectors/08-cockroachdb.mdx
+++ b/content/200-concepts/200-database-connectors/08-cockroachdb.mdx
@@ -11,7 +11,7 @@ The CockroachDB data source connector connects Prisma to a [CockroachDB](https:/
 
 <Admonition type="warning">
 
-CockroachDB support is currently a [Preview feature](https://www.prisma.io/docs/concepts/components/preview-features). Introspection of an existing database is supported, but Prisma Migrate is [not yet supported](https://github.com/prisma/prisma/issues/4702), so if you are starting a new database you will first need to define the schema with SQL.
+CockroachDB support is currently a [Preview feature](https://www.prisma.io/docs/concepts/components/preview-features).
 
 </Admonition>
 


### PR DESCRIPTION
`3.11.0` adds support for migrations in cockroachdb. This PR removes the admonitions around that.