### PR TITLE
Update 800-production-troubleshooting.mdx

### DIFF
--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -72,7 +72,7 @@ The following example demonstrates how to manually complete the steps of a migra
 
 ## Fixing failed migrations with <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
 
-In versions 3.9.0 and later, we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations. For more information about these commands, and others, refer to our [CLI Reference documentation](/reference/api-reference/command-reference).
+In versions 3.9.0 and later, we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations. For more information about these commands, and others, refer to our [CLI Reference documentation](/reference/api-reference/command-reference) <span class="api"></span>.
 
 <Admonition type="warning">
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -84,8 +84,8 @@ The `migrate diff` and `db execute` commands are currently a [Preview feature](/
 
 The two new commands that we provide are:
 
-- [`prisma migrate diff`](/reference/api-reference/command-reference#prisma-migrate) which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
-- [`prisma db execute`](/reference/api-reference/command-reference#db-execute) which applies a SQL script to the database without interacting with the Prisma migrations table.
+- [`prisma migrate diff`](/reference/api-reference/command-reference#prisma-migrate) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
+- [`prisma db execute`](/reference/api-reference/command-reference#db-execute) <span class="api"></span> which applies a SQL script to the database without interacting with the Prisma migrations table.
 
 ### Example of a failed migration
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -72,7 +72,7 @@ The following example demonstrates how to manually complete the steps of a migra
 
 ## Fixing failed migrations with <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
 
-In versions 3.9.0 and later, we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations.
+In versions 3.9.0 and later, we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations. For more information about these commands, and others, refer to our [CLI Reference documentation](/reference/api-reference/command-reference).
 
 <Admonition type="warning">
 
@@ -84,8 +84,8 @@ The `migrate diff` and `db execute` commands are currently a [Preview feature](/
 
 The two new commands that we provide are:
 
-- `prisma migrate diff` which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
-- `prisma db execute` which applies a SQL script to the database without interacting with the Prisma migrations table.
+- [`prisma migrate diff`](/reference/api-reference/command-reference#prisma-migrate) which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
+- [`prisma db execute`](/reference/api-reference/command-reference#db-execute) which applies a SQL script to the database without interacting with the Prisma migrations table.
 
 ### Example of a failed migration
 


### PR DESCRIPTION
On the failed migrations troubleshooting page, where we explain how to use `migrate diff` and `db execute` I added links to the CLI Reference page. Thanks @janpio  for this recommendation.

