### PR TITLE
Add warning about OCC

### DIFF
--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -681,6 +681,12 @@ You can now retry the same logic multiple times with the same input without adve
 
 ### Optimistic concurrency control
 
+<Admonition type="warning">
+
+**The technique described below doesn't work as expected**. We're working on fixing it. Follow along with [this issue](https://github.com/prisma/prisma/issues/8612) for updates.
+
+</Admonition>
+
 Optimistic concurrency control (OCC) is a model for handling concurrent operations on a single entity that does not rely on 🔒 locking. Instead, we **optimistically** assume that a record will remain unchanged in between reading and writing, and use a concurrency token (a timestamp or version field) to detect changes to a record.
 
 If a ❌ conflict occurs (someone else has changed the record since you read it), you cancel the transaction. Depending on your scenario, you can then:


### PR DESCRIPTION
Right now the OCC section of the transaction guide doesn't work as expected. [This issue has more details](https://github.com/prisma/prisma/issues/8612#issuecomment-1072832337).

Preview: https://deploy-preview-2993--prisma2-docs.netlify.app/docs/guides/performance-and-optimization/prisma-client-transactions-guide#optimistic-concurrency-control