### PR TITLE
fix: prev button for CDB/PScale getting started

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client.mdx
@@ -109,7 +109,7 @@ Whenever you make changes to your Prisma schema in the future, you manually need
   href="./using-prisma-migrate-node-planetscale"
   arrowLeft
 >
-  Creating the database schema
+  Using Prisma Migrate
 </ButtonLink>
 
 <ButtonLink
@@ -136,7 +136,7 @@ Whenever you make changes to your Prisma schema in the future, you manually need
   href="./using-prisma-migrate-node-cockroachdb"
   arrowLeft
 >
-  Creating the database schema
+  Using Prisma Migrate
 </ButtonLink>
 
 <ButtonLink


### PR DESCRIPTION
Fix https://github.com/prisma/docs/pull/2972#issuecomment-1069576836

The name of the link was incorrect for PlanetScale and CockroachDB, probably a copy paste.