### PR TITLE
note about filtering for undefined fields

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
@@ -14,7 +14,7 @@ Prisma Client differentiates between `null` and `undefined`:
 
 > **Notes**:
 
-- In patch release [3.11.1](https://github.com/prisma/prisma/releases/tag/3.11.1) we changed what data is returned when filtering MongoDB documents on undefined fields. Previsouly, undefined fields were by default treated the same as null fields. With the release of version 3.11.1, now **undefined fields are excluded by default** unless explicitly filtered for, using the `iSet` operator. This allows you to query for undefined and null values separately. For more information about filtering for undefined fields, see [Composite types](/concepts/components/prisma-client/composite-types).
+- In patch release [3.11.1](https://github.com/prisma/prisma/releases/tag/3.11.1) we changed what data is returned when filtering MongoDB documents on undefined fields. Previsouly, undefined fields were by default treated the same as null fields. With the release of version 3.11.1, now **undefined fields are excluded by default** unless explicitly filtered for, using the `isSet` operator. This allows you to query for undefined and null values separately. For more information about filtering for undefined fields, see [Composite types](/concepts/components/prisma-client/composite-types).
 - Understanding `null` and `undefined` is particularly important to account for in [a **Prisma with GraphQL context**, where the two are interchangeable](#use-case-null-and-undefined-in-a-graphql-resolver).
 
 In the following example, if `emailInput` is `null`, the query sets `email` (a **mandatory** field) to `undefined` - which means ✔ **do not include this in the update**:

--- a/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
@@ -14,7 +14,7 @@ Prisma Client differentiates between `null` and `undefined`:
 
 > **Notes**:
 
-- In patch release [3.11.1](https://github.com/prisma/prisma/releases/tag/3.11.1) we have changed what data is returned when filtering MongoDB documents on undefined fields. Previsouly, undefined fields were by default treated the same as null fileds. With the release of version 3.11.1, now **undefined fields are excluded by default** unless explicitly filtered for, using the `iSet` operator. This allows you to query for undefined and null values separately. For more information about filtering for undefined fields, see [Composite types](/concepts/components/prisma-client/composite-types).
+- In patch release [3.11.1](https://github.com/prisma/prisma/releases/tag/3.11.1) we changed what data is returned when filtering MongoDB documents on undefined fields. Previsouly, undefined fields were by default treated the same as null fields. With the release of version 3.11.1, now **undefined fields are excluded by default** unless explicitly filtered for, using the `iSet` operator. This allows you to query for undefined and null values separately. For more information about filtering for undefined fields, see [Composite types](/concepts/components/prisma-client/composite-types).
 - Understanding `null` and `undefined` is particularly important to account for in [a **Prisma with GraphQL context**, where the two are interchangeable](#use-case-null-and-undefined-in-a-graphql-resolver).
 
 In the following example, if `emailInput` is `null`, the query sets `email` (a **mandatory** field) to `undefined` - which means ✔ **do not include this in the update**:

--- a/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
@@ -10,9 +10,12 @@ preview: false
 Prisma Client differentiates between `null` and `undefined`:
 
 - `null` is a **value**
-- `undefined` means **do nothing**
+- `undefined` means **no value has been assigned**
 
-> **Note**: This is particularly important to account for in [a **Prisma with GraphQL context**, where `null` and `undefined` are interchangeable](#use-case-null-and-undefined-in-a-graphql-resolver).
+> **Notes**:
+
+- In patch release [3.11.1](https://github.com/prisma/prisma/releases/tag/3.11.1), we've changed what data is returned when filtering MongoDB documents on undefined fields. Previsouly undefined fields were, by default, treated the same as null fileds, With the release of version 3.11.1, now **undefined fields are excluded by default** unless explicitly filtered for, using the `iSet` operator. This allows you to query for undefined and null values separately. For more information about filtering for undefined fields, see [Composite types](/concepts/components/prisma-client/composite-types).
+- Understanding `null` and `undefined` is particularly important to account for in [a **Prisma with GraphQL context**, where the two are interchangeable](#use-case-null-and-undefined-in-a-graphql-resolver).
 
 In the following example, if `emailInput` is `null`, the query sets `email` (a **mandatory** field) to `undefined` - which means ✔ **do not include this in the update**:
 

--- a/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
@@ -14,7 +14,7 @@ Prisma Client differentiates between `null` and `undefined`:
 
 > **Notes**:
 
-- In patch release [3.11.1](https://github.com/prisma/prisma/releases/tag/3.11.1), we've changed what data is returned when filtering MongoDB documents on undefined fields. Previsouly undefined fields were, by default, treated the same as null fileds, With the release of version 3.11.1, now **undefined fields are excluded by default** unless explicitly filtered for, using the `iSet` operator. This allows you to query for undefined and null values separately. For more information about filtering for undefined fields, see [Composite types](/concepts/components/prisma-client/composite-types).
+- In patch release [3.11.1](https://github.com/prisma/prisma/releases/tag/3.11.1) we have changed what data is returned when filtering MongoDB documents on undefined fields. Previsouly, undefined fields were by default treated the same as null fileds. With the release of version 3.11.1, now **undefined fields are excluded by default** unless explicitly filtered for, using the `iSet` operator. This allows you to query for undefined and null values separately. For more information about filtering for undefined fields, see [Composite types](/concepts/components/prisma-client/composite-types).
 - Understanding `null` and `undefined` is particularly important to account for in [a **Prisma with GraphQL context**, where the two are interchangeable](#use-case-null-and-undefined-in-a-graphql-resolver).
 
 In the following example, if `emailInput` is `null`, the query sets `email` (a **mandatory** field) to `undefined` - which means ✔ **do not include this in the update**:


### PR DESCRIPTION
Added a Note about the 3.11.1 patch and the new default behaviour for filtering undefined fields. Linked to the "Composite types" topic for more info.
