### PR TITLE
BigInt is mapped to BIGINT for Postgres

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -550,7 +550,7 @@ True or false value.
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
-| PostgreSQL    | `integer`       |
+| PostgreSQL    | `BIGINT`        |
 | Microsoft SQL | `int`           |
 | MySQL         | `INT`           |
 | MongoDB       | `Long`          |

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -550,7 +550,7 @@ True or false value.
 
 | Connector     | Default mapping |
 | ------------- | --------------- |
-| PostgreSQL    | `BIGINT`        |
+| PostgreSQL    | `bigint`        |
 | Microsoft SQL | `int`           |
 | MySQL         | `INT`           |
 | MongoDB       | `Long`          |


### PR DESCRIPTION
Change default mapping of Prisma's `BigInt` for Postgres from `integer` to `BIGINT`. #2849 is closed, so here is another PR to fix this. The library itself already maps it like this.

Fixes #2690.
