### PR TITLE
Changed variable names in json update example as "i" could have been …

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -812,16 +812,12 @@ getUsers.forEach((user) => {
   ) {
     const petsObject = user.extendedPetsData as Prisma.JsonObject
 
-    const insuranceList = petsObject['insurances']
+    const insuranceList = petsObject['insurances'] // is a Prisma.JsonArray
 
-    if (insuranceList && typeof insuranceList === 'object' && Array.isArray(insuranceList)) {
-      const insurancesArray = insuranceList as Prisma.JsonArray
-
-      insurancesArray.forEach((insuranceItem) => {
+    if (Array.isArray(insuranceList)) {
+      insuranceList.forEach((insuranceItem) => {
         if (insuranceItem && typeof insuranceItem === 'object' && !Array.isArray(insuranceItem)) {
-          const insuranceObject = insuranceItem as Prisma.JsonObject
-
-          insuranceObject['status'] = 'expired'
+          insuranceItem['status'] = 'expired' // is a  Prisma.JsonObject
         }
       })
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -812,14 +812,14 @@ getUsers.forEach((user) => {
   ) {
     const petsObject = user.extendedPetsData as Prisma.JsonObject
 
-    const i = petsObject['insurances']
+    const insuranceList = petsObject['insurances']
 
-    if (i && typeof i === 'object' && Array.isArray(i)) {
-      const insurancesArray = i as Prisma.JsonArray
+    if (insuranceList && typeof insuranceList === 'object' && Array.isArray(insuranceList)) {
+      const insurancesArray = insuranceList as Prisma.JsonArray
 
-      insurancesArray.forEach((i) => {
-        if (i && typeof i === 'object' && !Array.isArray(i)) {
-          const insuranceObject = i as Prisma.JsonObject
+      insurancesArray.forEach((insuranceItem) => {
+        if (insuranceItem && typeof insuranceItem === 'object' && !Array.isArray(insuranceItem)) {
+          const insuranceObject = insuranceItem as Prisma.JsonObject
 
           insuranceObject['status'] = 'expired'
         }


### PR DESCRIPTION
…misunderstood

## Describe this PR

The variable name ```i``` could have been misunderstood even if later on the object (or array) is renamed properly. I feel this solution can be a little bit more understandable.

