### PR TITLE
Fix typo where 'expand and contact' should be 'expand and contract'

### DIFF
--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
@@ -158,7 +158,7 @@ By using this approach, you avoid potential downtime that altering existing fiel
 
 Note that this pattern is applicable in any situation involving a change to a column that has data and is in use by the application code. Examples include combining two fields into one, or transforming a `1:n` relation to a `m:n` relation.
 
-To learn more, check out the Data Guide article on [the expand and contact pattern](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern)
+To learn more, check out the Data Guide article on [the expand and contract pattern](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern)
 
 ## Changing the direction of a 1-1 relation
 


### PR DESCRIPTION
## Describe this PR

Fix minor typo in [customizing-migrations](https://www.prisma.io/docs/guides/database/developing-with-prisma-migrate/customizing-migrations#using-the-expand-and-contract-pattern-to-evolve-the-schema-without-downtime)

## Changes

> To learn more, check out the Data Guide article on the expand and contact pattern

> To learn more, check out the Data Guide article on the expand and cont**r**act pattern
