### PR TITLE
Add no notice support of Composite types

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/300-next-steps.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/300-next-steps.mdx
@@ -79,6 +79,12 @@ You can run it with two ways:
 1. Run `$ npx prisma studio` in your terminal.
 2. Install [the desktop app](https://github.com/prisma/studio/releases) from the installers. Windows, macOS and Linux are supported.
 
+<Admonition type="warning">
+
+[Composite types](https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#defining-composite-types) or [embedded documents](https://docs.mongodb.com/manual/core/data-model-design/#std-label-data-modeling-embedding) are not supported in Prisma Studio, the Data Browser or the Query Console.
+
+</Admonition>
+
 ### Try a Prisma example
 
 The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository contains a number of ready-to-run examples:

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/300-next-steps.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/300-next-steps.mdx
@@ -79,6 +79,12 @@ You can run it with two ways:
 1. Run `$ npx prisma studio` in your terminal.
 2. Install [the desktop app](https://github.com/prisma/studio/releases) from the installers. Windows, macOS and Linux are supported.
 
+<Admonition type="warning">
+
+[Composite types](https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#defining-composite-types) or [embedded documents](https://docs.mongodb.com/manual/core/data-model-design/#std-label-data-modeling-embedding) are not supported in Prisma Studio, the Data Browser or the Query Console.
+
+</Admonition>
+
 ### Try a Prisma example
 
 The [`prisma-examples`](https://github.com/prisma/prisma-examples/) repository contains a number of ready-to-run examples:

--- a/content/200-concepts/200-database-connectors/07-mongodb.mdx
+++ b/content/200-concepts/200-database-connectors/07-mongodb.mdx
@@ -155,6 +155,7 @@ As MongoDB support is currently in preview there are some known limitations that
   - Management of `@unique` indexes is realized through `db push`
 - [`@@id`](/reference/api-reference/prisma-schema-reference#id-1) and [auto-increment](/reference/api-reference/prisma-schema-reference#generate-auto-incrementing-integers-as-ids) are **not** supported.
 - Error handling is incomplete.
+- [Composite types](https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#defining-composite-types) or [embedded documents](https://docs.mongodb.com/manual/core/data-model-design/#std-label-data-modeling-embedding) are not supported in Prisma Studio, the Data Browser or the Query Console.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Describe this PR

We're adding a notice that Composite types are not supported in Studio, Data Browser and Query Console. If a user tries to open a model with composite types, Studio and Data Browser will [crash with an error](https://prisma-company.slack.com/archives/C013RMLGE72/p1648554920518609).
As such, a first disclaimer is to let people know of this behavior, before we proceed to fix or suppress the actual issues.

## Changes
Added the notification:
> [Composite types](https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#defining-composite-types) or [embedded documents](https://docs.mongodb.com/manual/core/data-model-design/#std-label-data-modeling-embedding) are not supported in Prisma Studio, the Data Browser or the Query Console.
in the following places:
- Getting Started > Set up Prisma > Add to existing project > MongoDB > Next Steps
- Getting Started > Set up Prisma > Start from scratch > MongoDB > Next Steps
- Concepts > Database connectors > MongoDB#Known Limitations

Here's what it looks like:
![image](https://user-images.githubusercontent.com/329419/160835197-62d5ebbc-b54f-484f-ac59-6cae0a70f2a6.png)
