### PR TITLE
Update Style Guide re version numbers

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/index.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/index.mdx
@@ -142,6 +142,15 @@ Read more in the [Prisma docs](https://www.prisma.io/docs/)
 Read more in the Prisma docs [here](https://www.prisma.io/docs/)
 ```
 
+### Be specific when using version numbers
+When you are writing about a specific version, be sure to specifiy * to what product* you are referring. For example, in the following sentence it might be unclear to users whether version 3.11.1 refers to Prisma or to MongoDB:
+
+*This filter is available on MongoDB only in versions 3.11.1 and later.*
+
+So instead, insert the product name in front of the version number whenever possible.
+
+*This filter is available on MongoDB only in Prisma version 3.11.1 and later.*
+
 ### Indicate when something is optional
 
 When a paragraph or sentence offers an optional path, the beginning of the first sentence should indicate that it’s optional. For example, "if you’d like to learn more about xyz, see our reference guide" is clearer than "Go to the reference guide if you’d like to learn more about xyz."


### PR DESCRIPTION
Added a section to state that we should specify the product name in front of the version number wherever possible, so that it is clear to what the version number refers.