### PR TITLE
docs: Rename global prisma variable for next.js

### DIFF
--- a/content/500-support/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/500-support/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -26,16 +26,16 @@ import { PrismaClient } from '@prisma/client'
 declare global {
   // allow global `var` declarations
   // eslint-disable-next-line no-var
-  var prisma: PrismaClient | undefined
+  var prismaInstance: PrismaClient | undefined
 }
 
 export const prisma =
-  global.prisma ||
+  global.prismaInstance ||
   new PrismaClient({
     log: ['query'],
   })
 
-if (process.env.NODE_ENV !== 'production') global.prisma = prisma
+if (process.env.NODE_ENV !== 'production') global.prismaInstance = prisma
 ```
 
 After creating this file, you can now import this `PrismaClient` instance anywhere in your Next.js `pages` as follows:


### PR DESCRIPTION
## Describe this PR

Global `prisma` variable was preventing lint from validating the missing import from `./db`, meaning lint would not complain about undefined/unimported `prisma` variable.

Renaming the global variable to `prismaInstance` works better since it's not overriding `prisma` export name.

## Changes

Rename global `prisma` to `prismaInstance`.
