### PR TITLE
Fix wrong variable name for MySQL example

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -963,13 +963,13 @@ const transactions: PrismaPromise<any>[] = []
 transactions.push(prisma.$executeRaw`SET FOREIGN_KEY_CHECKS = 0;`)
 
 const tablenames = await prisma.$queryRaw<
-  Array<{ tablename: string }>
+  Array<{ TABLE_NAME: string }>
 >`SELECT TABLE_NAME from information_schema.TABLES WHERE TABLE_SCHEMA = 'tests';`
 
 for (const { TABLE_NAME } of tablenames) {
-  if (tablename !== '_prisma_migrations') {
+  if (TABLE_NAME !== '_prisma_migrations') {
     try {
-      transactions.push(prisma.$executeRawUnsafe(`TRUNCATE ${tablename};`))
+      transactions.push(prisma.$executeRawUnsafe(`TRUNCATE ${TABLE_NAME};`))
     } catch (error) {
       console.log({ error })
     }


### PR DESCRIPTION
## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

The MySQL example is using the wrong type and variable usage in the `Deleting all data with raw SQL` section. (`tablename` instead of `TABLE_NAME`)

## Changes

<!-- What changes have you made? Keep it brief!
- Refactored example to include new database field
- ... -->

It fixes the example in the `Deleting all data with raw SQL` section

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
