### PR TITLE
edits to state that Decimal field not supported in MongoDB

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/index.mdx
@@ -27,7 +27,7 @@ const newTypes = await prisma.sample.create({
 
 <Admonition type="info">
 
-The use of the `Decimal` field is not currently supported in MongoDB.
+The use of the `Decimal` field [is not currently supported in MongoDB](https://github.com/prisma/prisma/issues/12637).
 
 </Admonition>
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/index.mdx
@@ -25,6 +25,12 @@ const newTypes = await prisma.sample.create({
 })
 ```
 
+<Admonition type="info">
+
+The use of the `Decimal` field is not currently supported in MongoDB.
+
+</Admonition>
+
 ## Working with <inlinecode>BigInt</inlinecode>
 
 `BigInt` fields are represented by the [`BigInt` type](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) (Node.js 10.4.0+ required). The following example demonstrates how to use the `BigInt` type:

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -652,7 +652,7 @@ Floating point number.
 | PostgreSQL    | `decimal(65,30)` |
 | Microsoft SQL | `decimal(32,16)` |
 | MySQL         | `DECIMAL(65,30)` |
-| MongoDB       | `Decimal`        |
+| MongoDB       | Not supported    |
 | SQLite        | `DECIMAL`        |
 
 #### PostgreSQL
@@ -672,9 +672,9 @@ Floating point number.
 
 - † `p` (precision), the maximum total number of decimal digits to be stored. `s` (scale), the number of decimal digits that are stored to the right of the decimal point.
 
-#### MongoDB (Preview)
+#### MongoDB
 
-`Decimal`
+Not supported.
 
 #### Microsoft SQL Server
 
@@ -1636,12 +1636,7 @@ model User {
 </tab>
 <tab>
 
-```prisma
-model User {
-  id     String  @default(auto()) @map("_id") @db.ObjectId
-  number Decimal @default(22.99)
-}
-```
+Not supported.
 
 </tab>
 </TabbedContent>

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -652,7 +652,7 @@ Floating point number.
 | PostgreSQL    | `decimal(65,30)` |
 | Microsoft SQL | `decimal(32,16)` |
 | MySQL         | `DECIMAL(65,30)` |
-| MongoDB       | Not supported    |
+| MongoDB       | [Not supported](https://github.com/prisma/prisma/issues/12637)    |
 | SQLite        | `DECIMAL`        |
 
 #### PostgreSQL

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -674,7 +674,7 @@ Floating point number.
 
 #### MongoDB
 
-Not supported.
+[Not supported](https://github.com/prisma/prisma/issues/12637).
 
 #### Microsoft SQL Server
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1636,7 +1636,7 @@ model User {
 </tab>
 <tab>
 
-Not supported.
+[Not supported](https://github.com/prisma/prisma/issues/12637).
 
 </tab>
 </TabbedContent>


### PR DESCRIPTION
Per Docs Issue #3034 this PR edits the docs to show that Prisma doesn't support the field `Decimal` with MongoDB.

TO DOs: 
--we might want to add further explanation, about `Decimal128`... ?
-- this PR doesn't make any changes to the new Guide for MOngoDB; will address that in the Guide's PR.