### PR TITLE
fix(production-troubleshooting): Fix anchor link for migrate diff

### DIFF
--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -84,7 +84,7 @@ The `migrate diff` and `db execute` commands are currently a [Preview feature](/
 
 The two new commands that we provide are:
 
-- [`prisma migrate diff`](/reference/api-reference/command-reference#prisma-migrate) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
+- [`prisma migrate diff`](/reference/api-reference/command-reference#migrate-diff) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
 - [`prisma db execute`](/reference/api-reference/command-reference#db-execute) <span class="api"></span> which applies a SQL script to the database without interacting with the Prisma migrations table.
 
 ### Example of a failed migration


### PR DESCRIPTION
Currently uses wrong anchor to link to.