### PR TITLE
Add free limits notification for PDP

### DIFF
--- a/content/200-concepts/150-data-platform/02-about-platform.mdx
+++ b/content/200-concepts/150-data-platform/02-about-platform.mdx
@@ -22,6 +22,12 @@ In the current version of the platform, you can:
 - Invite users and assign roles
 - Connect your application to your database from serverless environments using [Prisma Data Proxy](/concepts/data-platform/data-proxy)
 
+<Admonition type="warning">
+
+There is a limit in the number of free projects you can create which is **2**. If you want to try out the Prisma Data Platform with more free projects or would like to learn more about our pricing plans, reach out to us through the Intercom bubble in the application.
+
+</Admonition>
+
 ## User Roles
 
 These roles are currently supported in the Platform:


### PR DESCRIPTION
We are planning to add a limit to the number of free projects a user can create in the Data Platform. While we don't have our pricing plans communicated yet in our marketing website, we would like to still communicate this limitation in places other than our application (where users will still get a notification from the system that they can't add more than 2 free projects).

![image](https://user-images.githubusercontent.com/329419/162227052-2216e793-832b-45d8-a484-cbec9a8a2218.png)
