### PR TITLE
Fixed grammatical error in the section description

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/index.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/index.mdx
@@ -7,7 +7,7 @@ toc: false
 
 <TopBlock>
 
-Start a fresh project from scratch with following tutorials as they introduce you to the [Prisma CLI](/concepts/components/prisma-cli), [Prisma Client](/concepts/components/prisma-client), and [Prisma Migrate](/concepts/components/prisma-migrate).
+Start a fresh project from scratch with the following tutorials as they introduce you to the [Prisma CLI](/concepts/components/prisma-cli), [Prisma Client](/concepts/components/prisma-client), and [Prisma Migrate](/concepts/components/prisma-migrate).
 
 </TopBlock>
 


### PR DESCRIPTION
## Describe this PR
- Hey there, this is super quick PR that fixes a grammatical error I found in the description of the **Getting Started** tutorial.

## Changes
- Fixed a grammatical error in the Getting Started tutorial.

## What issue does this fix?
- N/A

## Any other relevant information

@all-contributors please add @IM-Deane for doc
