### PR TITLE
Add redirects from website-v8 here directly instead

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -144,7 +144,11 @@ let plugins = [
 ]
 
 if (process.env.INDEX_ALGOLIA === 'true') {
-  plugins = [...plugins, algoliaPlugin]
+  if (process.env.GATSBY_ALGOLIA_APP_ID) {
+    plugins = [...plugins, algoliaPlugin]
+  } else {
+    console.warn('INDEX_ALGOLIA === true, but GATSBY_ALGOLIA_APP_ID is undefined.')
+  }
 }
 
 module.exports = {

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,341 @@
+#######################################
+### Redirects: Page renamed in Docs ###
+#######################################
+
+/docs/getting-started/quickstart-typescript /docs/getting-started/quickstart/ 301!
+/docs/getting-started/quickstart-javascript /docs/getting-started/quickstart/ 301!
+/docs/getting-started/quickstart-node /docs/getting-started/quickstart/ 301!
+
+/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-file	/docs/reference/tools-and-interfaces/prisma-schema 301!	
+/docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
+/docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
+/docs/guides/upgrade-from-prisma-1/should-you-upgrade       /docs/guides/upgrade-from-prisma-1/how-to-upgrade 301!
+/docs/reference/tools-and-interfaces/prisma-schema/models       /docs/reference/tools-and-interfaces/prisma-schema/data-model 301!
+
+/docs/concepts/overview/api-comparisons/prisma-and-typeorm /docs/concepts/more/comparisons/prisma-and-typeorm 301!
+/docs/concepts/overview/api-comparisons/prisma-and-sequelize /docs/concepts/more/comparisons/prisma-and-sequelize 301!
+/docs/concepts/overview/api-comparisons/prisma-and-mongoose /docs/concepts/more/comparisons/prisma-and-mongoose 301!
+/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-typeorm /docs/concepts/more/comparisons/prisma-and-typeorm 301!
+/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-sequelize /docs/concepts/more/comparisons/prisma-and-sequelize 301!
+/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-mongoose /docs/concepts/more/comparisons/prisma-and-mongoose 301!
+
+/docs/getting-started/setup-prisma/start-from-scratch-sql-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-sql-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-sql-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch-sql-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
+
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
+
+/docs/getting-started/setup-prisma/start-from-scratch-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
+
+##############################################
+### Redirects: Tech switcher page defaults ###
+##############################################
+
+/docs/getting-started/setup-prisma/add-to-existing-project	/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch  /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/guides/general-guides/database-workflows/sql-views /docs/guides/general-guides/database-workflows/sql-views-postgres 301!
+/docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres 301!
+/docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch /docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch-typescript 301!
+/docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities /docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres 301!
+
+### Docs
+
+/docs/faq/*     https://v1.prisma.io/docs/1.34/faq/:splat 301!
+
+/docs/-a002     https://v1.prisma.io/docs/1.34/get-started/ 301!
+/docs/-t002     https://v1.prisma.io/docs/1.34/get-started/ 301!
+/docs/-t002/    https://v1.prisma.io/docs/1.34/get-started/ 301!
+
+/docs/prisma-admin/                  https://v1.prisma.io/docs/1.34/prisma-admin/ 301!
+/docs/prisma-cli-and-configuration/  https://v1.prisma.io/docs/1.34/prisma-cli-and-configuration/ 301!
+/docs/prisma-client/                 https://v1.prisma.io/docs/1.34/prisma-client/ 301!
+/docs/prisma-server/                 https://v1.prisma.io/docs/1.34/prisma-server/ 301!
+/docs/quickstart/                    https://v1.prisma.io/docs/1.34/get-started/ 301!
+/docs/releases-and-maintenance/      https://v1.prisma.io/docs/1.34/releases-and-maintenance/ 301!
+/docs/datamodel-and-migrations/      https://v1.prisma.io/docs/1.34/datamodel-and-migrations 301!
+
+/docs/get-started/01-setting-up-prisma-new-database-GO-g002/                  https://v1.prisma.io/docs/1.34/get-started 301!
+/docs/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002/          https://v1.prisma.io/docs/1.34/get-started 301!
+/docs/get-started/01-setting-up-prisma-demo-server-a001/                      https://v1.prisma.io/docs/1.34/get-started/01-setting-up-prisma-demo-server-JAVASCRIPT-a001/ 301!
+/docs/get-started/01-setting-up-prisma-existing-database-a003/                https://v1.prisma.io/docs/1.34/get-started/01-setting-up-prisma-demo-server-JAVASCRIPT-a001/ 301!
+/docs/get-started/01-setting-up-prisma-new-database-a002/                     https://v1.prisma.io/docs/1.34/get-started/01-setting-up-prisma-new-database-JAVASCRIPT-a002/ 301!
+/docs/datamodel-and-migrations/datamodel-MYSQL-knul/                          https://v1.prisma.io/docs/1.34/datamodel-and-migrations 301!
+/docs/data-model-and-migrations/introspection-mapping-to-existing-db-soi1/    https://v1.prisma.io/docs/1.34/data-model-and-migrations/introspection-mapping-to-existing-db-soi1/ 301!
+/docs/understand-prisma/how-prisma-works-under-the-hood-j8ff/                 https://v1.prisma.io/docs/1.34/understand-prisma/how-prisma-works-under-the-hood-j8ff/ 301!
+/docs/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4/       https://v1.prisma.io/docs/1.34/understand-prisma/prisma-basics-datamodel-client-and-server-fgz4/ 301!
+/docs/understand-prisma/prisma-introduction-what-why-how-j9ff/                https://v1.prisma.io/docs/1.34/understand-prisma/prisma-introduction-what-why-how-j9ff/ 301!
+/docs/understand-prisma/prisma-vs-traditional-orms/prisma-vs-mongoose-ys8c/   https://v1.prisma.io/docs/1.34/understand-prisma/prisma-vs-traditional-orms/prisma-vs-mongoose-ys8c/ 301!
+/docs/understand-prisma/prisma-vs-traditional-orms/prisma-vs-sequelize-c4fk/  https://v1.prisma.io/docs/1.34/understand-prisma/prisma-vs-traditional-orms/prisma-vs-sequelize-c4fk/ 301!
+/docs/understand-prisma/prisma-vs-traditional-orms/prisma-vs-typeorm-k9fh/    https://v1.prisma.io/docs/1.34/understand-prisma/prisma-vs-traditional-orms/prisma-vs-typeorm-k9fh/ 301!
+
+/docs/prisma-client/basic-data-access/reading-data-GO-go05/           https://v1.prisma.io/docs/1.34/prisma-client/basic-data-access/reading-data-GO-go05/ 301!
+/docs/prisma-client/basic-data-access/reading-data-JAVASCRIPT-rsc2/   https://v1.prisma.io/docs/1.34/prisma-client/basic-data-access/reading-data-JAVASCRIPT-rsc2/ 301!
+/docs/prisma-client/basic-data-access/reading-data-TYPESCRIPT-rsc3/   https://v1.prisma.io/docs/1.34/prisma-client/basic-data-access/reading-data-TYPESCRIPT-rsc3/ 301!
+/docs/prisma-client/basic-data-access/writing-data-GO-go08/           https://v1.prisma.io/docs/1.34/prisma-client/basic-data-access/writing-data-GO-go08/ 301!
+/docs/prisma-client/basic-data-access/writing-data-JAVASCRIPT-rsc6/   https://v1.prisma.io/docs/1.34/prisma-client/basic-data-access/writing-data-JAVASCRIPT-rsc6/ 301!
+/docs/prisma-client/basic-data-access/writing-data-TYPESCRIPT-rsc7/   https://v1.prisma.io/docs/1.34/prisma-client/basic-data-access/writing-data-TYPESCRIPT-rsc7/ 301!
+/docs/prisma-client/features/check-existence-GO-go01/                 https://v1.prisma.io/docs/1.34/prisma-client/features/check-existence-GO-go01/ 301!
+/docs/prisma-client/features/check-existence-JAVASCRIPT-pyl1/         https://v1.prisma.io/docs/1.34/prisma-client/features/check-existence-JAVASCRIPT-pyl1/ 301!
+/docs/prisma-client/features/check-existence-TYPESCRIPT-pyl2/         https://v1.prisma.io/docs/1.34/prisma-client/features/check-existence-TYPESCRIPT-pyl2/ 301!
+/docs/prisma-client/features/realtime-GO-go06/                        https://v1.prisma.io/docs/1.34/prisma-client/features/realtime-GO-go06/ 301!
+/docs/prisma-client/features/realtime-JAVASCRIPT-rsc8/                https://v1.prisma.io/docs/1.34/prisma-client/features/realtime-JAVASCRIPT-rsc8/ 301!
+/docs/prisma-client/features/realtime-TYPESCRIPT-rsc9/                https://v1.prisma.io/docs/1.34/prisma-client/features/realtime-TYPESCRIPT-rsc9/ 301!
+/docs/prisma-client/setup/constructor-GO-go02/                        https://v1.prisma.io/docs/1.34/prisma-client/setup/constructor-GO-go02/ 301!
+/docs/prisma-client/setup/constructor-JAVASCRIPT-rsc4/                https://v1.prisma.io/docs/1.34/prisma-client/setup/constructor-JAVASCRIPT-rsc4/ 301!
+/docs/prisma-client/setup/constructor-TYPESCRIPT-rsc5/                https://v1.prisma.io/docs/1.34/prisma-client/setup/constructor-TYPESCRIPT-rsc5/ 301!
+/docs/prisma-client/setup/generating-the-client-GO-r3c3/              https://v1.prisma.io/docs/1.34/prisma-client/setup/generating-the-client-GO-r3c3/ 301!
+/docs/prisma-client/setup/generating-the-client-JAVASCRIPT-rsc1/      https://v1.prisma.io/docs/1.34/prisma-client/setup/generating-the-client-JAVASCRIPT-rsc1/ 301!
+/docs/prisma-client/setup/generating-the-client-TYPESCRIPT-r3c2/      https://v1.prisma.io/docs/1.34/prisma-client/setup/generating-the-client-TYPESCRIPT-r3c2/ 301!
+/docs/run-prisma-server/database-connector-MYSQL-jgfs/                https://v1.prisma.io/docs/1.34/prisma-server/database-connector-MYSQL-jgfs/ 301!
+
+# Upgrade guides
+/docs/guides/upgrade-from-prisma-1/how-to-upgrade /docs/guides/upgrade-guides/upgrade-from-prisma-1/how-to-upgrade/ 301!
+/docs/guides/upgrade-from-prisma-1/schema-incompatibilities  /docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres /docs/guides/upgrade-guides/upgrade-from-prisma-1/ 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-nexus-prisma-to-nexus /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-nexus-prisma-to-nexus  301!
+/docs/guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-nexus /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-nexus 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-sdl-first /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-sdl-first 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-a-rest-api /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-a-rest-api 301!
+
+#######################################
+### DOC: Pages renamed in Docs ###
+#######################################
+
+/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-file	/docs/reference/tools-and-interfaces/prisma-schema 301!	
+/docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
+/docs/guides/upgrade-from-prisma-1/should-you-upgrade       /docs/guides/upgrade-from-prisma-1/how-to-upgrade 301!
+/docs/reference/tools-and-interfaces/prisma-schema/models       /docs/reference/tools-and-interfaces/prisma-schema/data-model 301!
+
+#######################################
+### DOC: Redesign redirects 2020
+#######################################
+
+/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-reference       /docs/reference/api-reference/prisma-schema-reference 301!
+/docs/reference/tools-and-interfaces/prisma-cli/command-reference        /docs/reference/api-reference/command-reference 301!
+/docs/reference/database-connectors/database-features        /docs/reference/database-reference/database-features 301!
+/docs/reference/database-connectors/connection-urls      /docs/reference/database-reference/connection-urls 301!
+/docs/more/supported-databases       /docs/reference/database-reference/supported-databases 301!
+
+/docs/reference/tools-and-interfaces/*       /docs/concepts/components/:splat 301!
+/docs/reference/database-connectors/*         /docs/concepts/database-connectors/:splat 301!
+/docs/reference/more/*                        /docs/concepts/more/:splat 301!
+/docs/understand-prisma/introduction         /docs/concepts/overview/what-is-prisma 301!
+/docs/understand-prisma/data-modeling       /docs/concepts/overview/what-is-prisma/data-modeling 301!
+
+/docs/understand-prisma/*       /docs/concepts/overview/:splat 301!
+
+/docs/understand-prisma/api-comparisons/*        /docs/concepts/overview/why-prisma/api-comparisons 301!
+
+/docs/more/*     /docs/about/:splat 301!
+
+### Getting started redirects
+
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate      /docs/getting-started/setup-prisma/start-from-scratch-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-sql      /docs/getting-started/setup-prisma 301!      
+
+### Guides redirects
+
+/docs/guides/prisma-guides/prisma-migrate-guides      /docs/guides/prisma-guides/add-prisma-migrate-to-a-project 301!
+/docs/guides/prisma-guides/prisma-migrate-guides/add-prisma-migrate-to-a-project      /docs/guides/prisma-guides/add-prisma-migrate-to-a-project 301!
+
+### Reference redirects
+
+/docs/concepts/components/prisma-client/distinct	/docs/concepts/components/prisma-client/aggregation-grouping-summarizing#select-distinct 301!
+/docs/concepts/components/prisma-client/configuring-the-prisma-client-api	/docs/concepts/components/prisma-client/generating-prisma-client/customizing-the-prisma-client-api 301!
+/docs/concepts/components/prisma-client/constructor	/docs/reference/api-reference/prisma-client-reference#prismaclient 301!
+/docs/concepts/components/prisma-client/field-selection	/docs/concepts/components/prisma-client/select-fields 301!
+/docs/concepts/components/prisma-client/error-reference	/docs/reference/api-reference/error-reference 301!
+/docs/concepts/components/prisma-client/sorting	/docs/concepts/components/prisma-client/filtering-and-sorting 301!
+/docs/concepts/components/prisma-client/filtering	/docs/concepts/components/prisma-client/filtering-and-sorting 301!
+/docs/concepts/components/prisma-client/aggregations	/docs/concepts/components/prisma-client/aggregation-grouping-summarizing 301!
+/docs/concepts/components/prisma-client/working-with-json	/docs/concepts/components/prisma-client/working-with-advanced-types 301!
+/docs/concepts/components/prisma-client/group-by	/docs/concepts/components/prisma-client/aggregation-grouping-summarizing#group-by-preview 301!
+/docs/concepts/components/prisma-client/advanced-usage-of-generated-types	/docs/concepts/components/prisma-client/working-with-generated-types 301!
+
+/docs/concepts/components/preview-features/native-types/native-types-mappings /docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types 301!
+/docs/concepts/components/preview-features/native-types /docs/concepts/components/prisma-schema/data-model#native-types-mapping 301!
+
+### PrismaClient section redirects
+
+/docs/concepts/components/prisma-client/generating-prisma-client  /docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client 301!
+/docs/concepts/components/prisma-client/generating-prisma-client/customizing-the-prisma-client-api  /docs/concepts/components/prisma-client/working-with-prismaclient/use-custom-model-and-field-names 301!
+/docs/concepts/components/prisma-client/connection-management /docs/concepts/components/prisma-client/working-with-prismaclient/connection-management 301!
+/docs/concepts/components/prisma-client/logging /docs/concepts/components/prisma-client/working-with-prismaclient/logging 301!
+/docs/concepts/components/prisma-client/error-formatting  /docs/concepts/components/prisma-client/working-with-prismaclient/error-formatting 301!
+
+### Prisma Migrate release redirects
+
+/docs/concepts/components/prisma-client/deployment /docs/guides/deployment/deployment 301!
+/docs/concepts/components/prisma-migrate/prisma-migrate-flows  /docs/concepts/components/prisma-migrate 301!
+/docs/guides/prisma-guides/seed-database  /docs/guides/application-lifecycle/seed-database 301!
+/docs/guides/prisma-guides/add-prisma-migrate-to-a-project  /docs/guides/database/developing-with-prisma-migrate/add-prisma-migrate-to-a-project 301!
+
+### Support redirects
+
+/docs/about/creating-bug-reports  /docs/support/creating-bug-reports 301!
+
+### Other
+
+/docs/concepts/components/prisma-client/working-with-generated-types  /docs/concepts/components/prisma-client/advanced-type-safety/operating-against-partial-structures-of-model-types 301!
+/docs/reference/utility-types-reference /docs/reference/api-reference/prisma-client-reference#prismavalidator 301!
+
+### Connection / deployment refactor (April 2021)
+
+/docs/concepts/components/prisma-client/query-engine  /docs/concepts/components/prisma-engines/query-engine 301!
+/docs/concepts/overview/under-the-hood  /docs/concepts/components/prisma-engines 301!
+/docs/guides/application-lifecycle/add-prisma-migrate-to-a-project  /docs/guides/database/developing-with-prisma-migrate/add-prisma-migrate-to-a-project 301!
+/docs/guides/deployment/patching-production  /docs/guides/database/patching-production 301!
+/docs/guides/deployment/production-troubleshooting  /docs/guides/database/production-troubleshooting 301!
+/docs/guides/application-lifecycle/*  /docs/guides/database/:splat 301!
+/docs/guides/deployment/deploying-to-azure-functions  /docs/guides/deployment/deployment-guides/deploying-to-azure-functions 301!
+/docs/guides/deployment/deploying-to-heroku  /docs/guides/deployment/deployment-guides/deploying-to-heroku 301!
+/docs/guides/deployment/deploying-to-vercel  /docs/guides/deployment/deployment-guides/deploying-to-vercel 301!
+/docs/guides/deployment/deploying-to-aws-lambda  /docs/guides/deployment/deployment-guides/deploying-to-aws-lambda 301!
+/docs/guides/deployment/deploying-to-netlify  /docs/guides/deployment/deployment-guides/deploying-to-netlify 301!
+/docs/guides/general-guides/database-workflows/cascading-deletes/*  /docs/guides/database/advanced-database-tasks/cascading-deletes/:splat 301!
+/docs/guides/general-guides/database-workflows/data-validation/*  /docs/guides/database/advanced-database-tasks/data-validation/:splat 301!
+/docs/guides/general-guides/database-workflows/sql-views-postgres  /docs/guides/database/advanced-database-tasks/sql-views-postgres 301!
+/docs/guides/general-guides/database-workflows/sql-views-mysql  /docs/guides/database/advanced-database-tasks/sql-views-mysql 301!
+/docs/guides/prisma-guides/*  /docs/guides/performance-and-optimization/:splat 301!
+
+/docs/mongodb  /docs/concepts/database-connectors/mongodb 301!
+
+/docs/guides/database/developing-with-prisma-migrate/advanced-migrate-scenarios  /docs/guides/database/developing-with-prisma-migrate/customizing-migrations 301!
+
+/docs/concepts/components/prisma-migrate/type-mapping /docs/concepts/components/prisma-migrate/supported-types-and-db-features 301!
+
+/docs/concepts/components/prisma-client/working-with-advanced-types /docs/concepts/components/prisma-client/working-with-fields 301!
+/docs/concepts/more/codemod  /docs/guides/upgrade-guides/upgrading-versions/codemods 301!
+
+### Relational databases getting started redirects
+
+/docs/getting-started/setup-prisma/start-from-scratch-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project-typescript-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres 301!
+
+#### Postgres - TypeScript
+
+/docs/getting-started/setup-prisma/start-from-scratch/connect-your-database-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/using-prisma-migrate-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/install-prisma-client-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/querying-the-database-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/next-steps-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps-typescript-postgres 301!
+
+/docs/getting-started/setup-prisma/add-to-existing-project/connect-your-database-typescript-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/introspection-typescript-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/install-prisma-client-typescript-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/querying-the-database-typescript-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/next-steps-typescript-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps-typescript-postgres 301!
+
+#### Postgres - Node
+
+/docs/getting-started/setup-prisma/start-from-scratch/connect-your-database-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/using-prisma-migrate-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/install-prisma-client-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/querying-the-database-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch/next-steps-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps-node-postgres 301!
+
+/docs/getting-started/setup-prisma/add-to-existing-project/connect-your-database-node-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-node-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/introspection-node-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/install-prisma-client-node-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/querying-the-database-node-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-postgres 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/next-steps-node-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps-node-postgres 301!
+
+#### MySQL - TypeScript
+
+/docs/getting-started/setup-prisma/start-from-scratch/connect-your-database-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/using-prisma-migrate-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/install-prisma-client-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/querying-the-database-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/next-steps-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps-typescript-mysql 301!
+
+/docs/getting-started/setup-prisma/add-to-existing-project/connect-your-database-typescript-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/introspection-typescript-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/install-prisma-client-typescript-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/querying-the-database-typescript-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/next-steps-typescript-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps-typescript-mysql 301!
+
+#### MySQL - Node
+
+/docs/getting-started/setup-prisma/start-from-scratch/connect-your-database-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/using-prisma-migrate-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/install-prisma-client-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/querying-the-database-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-node-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch/next-steps-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps-node-mysql 301!
+
+/docs/getting-started/setup-prisma/add-to-existing-project/connect-your-database-node-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-node-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/introspection-node-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/install-prisma-client-node-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/querying-the-database-node-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-mysql 301!
+/docs/getting-started/setup-prisma/add-to-existing-project/next-steps-node-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps-node-mysql 301!
+
+## Development environment section
+
+/docs/concepts/more/environment-variables /docs/guides/development-environment/environment-variables 301!
+/docs/concepts/more/environment-variables/managing-env-files-and-setting-variables /docs/guides/development-environment/environment-variables/managing-env-files-and-setting-variables 301!
+/docs/concepts/more/environment-variables/using-multiple-env-files /docs/guides/development-environment/environment-variables/using-multiple-env-files 301!
+/docs/concepts/more/editor-setup /docs/guides/development-environment/editor-setup 301!
+
+## About section
+
+/docs/about/about-the-docs /docs/about/prisma-docs/about-the-docs 301!
+/docs/about/whats-new-in-prisma-docs /docs/about/prisma-docs/whats-new-in-prisma-docs 301!
+/docs/about/limitations /docs/about/prisma/limitations 301!
+/docs/about/roadmap /docs/about/prisma/roadmap 301!
+/docs/about/faq /docs/about/prisma/faq 301!
+/docs/about/releases /docs/about/prisma/releases 301!
+/docs/about/example-projects /docs/about/prisma/example-projects 301!
+/docs/about/style-guide /docs/about/prisma-docs/style-guide 301!
+/docs/about/style-guide/mdx-examples /docs/about/prisma-docs/style-guide/mdx-examples 301!
+/docs/about/style-guide/frontmatter /docs/about/prisma-docs/style-guide/frontmatter 301!
+/docs/about/style-guide/template /docs/about/prisma-docs/style-guide/template 301!
+
+## SQL Server 
+
+/docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch-typescript /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-sql-server 301!
+/docs/concepts/database-connectors/microsoft-sql-server /docs/concepts/database-connectors/sql-server 301!
+/docs/concepts/components/preview-features/sql-server/sql-server-connection-string /docs/concepts/database-connectors/sql-server 301!
+/docs/concepts/components/preview-features/sql-server/sql-server-local /docs/concepts/database-connectors/sql-server/sql-server-local 301!
+/docs/concepts/components/preview-features/sql-server/sql-server-docker /docs/concepts/database-connectors/sql-server/sql-server-docker 301!
+/docs/concepts/components/preview-features/sql-server /docs/concepts/database-connectors/sql-server 301!
+
+## Upgrade guides
+
+/docs/guides/upgrade-guides/upgrading-to-latest /docs/guides/upgrade-guides/upgrading-versions 301!
+/docs/guides/upgrade-guides/upgrading-to-use-preview-features/enabling-named-constraints /docs/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/named-constraints 301!
+
+
+## Referential actions section
+/docs/concepts/components/prisma-schema/relations/referential-actions/cyclic-referential-actions /docs/concepts/components/prisma-schema/relations/referential-actions/special-rules-for-referential-actions 301!
+
+## Indexes section
+/docs/concepts/components/prisma-schema/index-configuration /docs/concepts/components/prisma-schema/indexes 301!
+
+## Prisma Data Platform section
+/docs/concepts/components/prisma-data-platform   /docs/concepts/data-platform  301!
+
+
+## ADD NEW DOCS REDIRECTS ABOVE THIS LINE ##
+
+#######################################
+### DOC: Redirects to Data Guide
+#######################################
+
+/docs/guides/database-workflows/setting-up-a-database/postgresql       /dataguide/postgresql/setting-up-a-local-postgresql-database 301!
+/docs/guides/database-workflows/setting-up-a-database/mysql       /dataguide/mysql/setting-up-a-local-mysql-database 301!
+/docs/guides/database-workflows/setting-up-a-database/sqlite       /dataguide/sqlite/setting-up-a-local-sqlite-database 301!  
+
+/docs/guides/database-workflows/import-and-export-data/postgresql       /dataguide/postgresql/inserting-and-modifying-data/importing-and-exporting-data-in-postgresql 301!
+/docs/guides/database-workflows/import-and-export-data/mysql       /dataguide/mysql/importing-and-exporting-data-in-mysql 301!
+/docs/guides/database-workflows/import-and-export-data/sqlite       /dataguide/sqlite/importing-and-exporting-data-in-sqlite 301!
+
+/docs/guides/database-workflows/*       /docs/guides/general-guides/database-workflows/:splat 301!
+/docs/guides/troubleshooting       /docs/support/help-articles 301!
+/docs/guides/troubleshooting/autocompletion-in-graphql-resolvers-with-js       /docs/support/help-articles/autocompletion-in-graphql-resolvers-with-js 301!
+

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,51 +1,7 @@
-#######################################
-### Redirects: Page renamed in Docs ###
-#######################################
 
-/docs/getting-started/quickstart-typescript /docs/getting-started/quickstart/ 301!
-/docs/getting-started/quickstart-javascript /docs/getting-started/quickstart/ 301!
-/docs/getting-started/quickstart-node /docs/getting-started/quickstart/ 301!
-
-/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-file	/docs/reference/tools-and-interfaces/prisma-schema 301!	
-/docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
-/docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
-/docs/guides/upgrade-from-prisma-1/should-you-upgrade       /docs/guides/upgrade-from-prisma-1/how-to-upgrade 301!
-/docs/reference/tools-and-interfaces/prisma-schema/models       /docs/reference/tools-and-interfaces/prisma-schema/data-model 301!
-
-/docs/concepts/overview/api-comparisons/prisma-and-typeorm /docs/concepts/more/comparisons/prisma-and-typeorm 301!
-/docs/concepts/overview/api-comparisons/prisma-and-sequelize /docs/concepts/more/comparisons/prisma-and-sequelize 301!
-/docs/concepts/overview/api-comparisons/prisma-and-mongoose /docs/concepts/more/comparisons/prisma-and-mongoose 301!
-/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-typeorm /docs/concepts/more/comparisons/prisma-and-typeorm 301!
-/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-sequelize /docs/concepts/more/comparisons/prisma-and-sequelize 301!
-/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-mongoose /docs/concepts/more/comparisons/prisma-and-mongoose 301!
-
-/docs/getting-started/setup-prisma/start-from-scratch-sql-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch-sql-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch-sql-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
-/docs/getting-started/setup-prisma/start-from-scratch-sql-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
-
-/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
-/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
-
-/docs/getting-started/setup-prisma/start-from-scratch-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
-/docs/getting-started/setup-prisma/start-from-scratch-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
-
-##############################################
-### Redirects: Tech switcher page defaults ###
-##############################################
-
-/docs/getting-started/setup-prisma/add-to-existing-project	/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch  /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
-/docs/guides/general-guides/database-workflows/sql-views /docs/guides/general-guides/database-workflows/sql-views-postgres 301!
-/docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres 301!
-/docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch /docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch-typescript 301!
-/docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities /docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres 301!
-
-### Docs
+################################
+### Redirects: Prisma 1 docs ###
+################################
 
 /docs/faq/*     https://v1.prisma.io/docs/1.34/faq/:splat 301!
 
@@ -95,57 +51,121 @@
 /docs/prisma-client/setup/generating-the-client-TYPESCRIPT-r3c2/      https://v1.prisma.io/docs/1.34/prisma-client/setup/generating-the-client-TYPESCRIPT-r3c2/ 301!
 /docs/run-prisma-server/database-connector-MYSQL-jgfs/                https://v1.prisma.io/docs/1.34/prisma-server/database-connector-MYSQL-jgfs/ 301!
 
-# Upgrade guides
-/docs/guides/upgrade-from-prisma-1/how-to-upgrade /docs/guides/upgrade-guides/upgrade-from-prisma-1/how-to-upgrade/ 301!
-/docs/guides/upgrade-from-prisma-1/schema-incompatibilities  /docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres 301!
-/docs/guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres /docs/guides/upgrade-guides/upgrade-from-prisma-1/ 301!
-/docs/guides/upgrade-from-prisma-1/upgrading-nexus-prisma-to-nexus /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-nexus-prisma-to-nexus  301!
-/docs/guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-nexus /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-nexus 301!
-/docs/guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-sdl-first /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-sdl-first 301!
-/docs/guides/upgrade-from-prisma-1/upgrading-a-rest-api /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-a-rest-api 301!
+
+##############################################
+### Redirects: Content moved to Data Guide ###
+##############################################
+
+/docs/guides/database-workflows/setting-up-a-database/postgresql  /dataguide/postgresql/setting-up-a-local-postgresql-database 301!
+/docs/guides/database-workflows/setting-up-a-database/mysql       /dataguide/mysql/setting-up-a-local-mysql-database 301!
+/docs/guides/database-workflows/setting-up-a-database/sqlite      /dataguide/sqlite/setting-up-a-local-sqlite-database 301!  
+
+/docs/guides/database-workflows/import-and-export-data/postgresql  /dataguide/postgresql/inserting-and-modifying-data/importing-and-exporting-data-in-postgresql 301!
+/docs/guides/database-workflows/import-and-export-data/mysql       /dataguide/mysql/importing-and-exporting-data-in-mysql 301!
+/docs/guides/database-workflows/import-and-export-data/sqlite      /dataguide/sqlite/importing-and-exporting-data-in-sqlite 301!
+
+/docs/guides/database-workflows/*    /docs/guides/general-guides/database-workflows/:splat 301!
+
+/docs/guides/troubleshooting                                                   /docs/support/help-articles 301!
+/docs/guides/troubleshooting/autocompletion-in-graphql-resolvers-with-js       /docs/support/help-articles/autocompletion-in-graphql-resolvers-with-js 301!
+
 
 #######################################
-### DOC: Pages renamed in Docs ###
+### Redirects: Page renamed in Docs ###
 #######################################
+
+/docs/getting-started/quickstart-typescript /docs/getting-started/quickstart 301!
+/docs/getting-started/quickstart-javascript /docs/getting-started/quickstart 301!
+/docs/getting-started/quickstart-node /docs/getting-started/quickstart 301!
+
+/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-file	/docs/reference/tools-and-interfaces/prisma-schema 301!	
+/docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
+/docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
+/docs/guides/upgrade-from-prisma-1/should-you-upgrade       /docs/guides/upgrade-from-prisma-1/how-to-upgrade 301!
+/docs/reference/tools-and-interfaces/prisma-schema/models       /docs/reference/tools-and-interfaces/prisma-schema/data-model 301!
+
+/docs/concepts/overview/api-comparisons/prisma-and-typeorm /docs/concepts/more/comparisons/prisma-and-typeorm 301!
+/docs/concepts/overview/api-comparisons/prisma-and-sequelize /docs/concepts/more/comparisons/prisma-and-sequelize 301!
+/docs/concepts/overview/api-comparisons/prisma-and-mongoose /docs/concepts/more/comparisons/prisma-and-mongoose 301!
+/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-typeorm /docs/concepts/more/comparisons/prisma-and-typeorm 301!
+/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-sequelize /docs/concepts/more/comparisons/prisma-and-sequelize 301!
+/docs/concepts/overview/why-prisma/api-comparisons/prisma-and-mongoose /docs/concepts/more/comparisons/prisma-and-mongoose 301!
+
+/docs/getting-started/setup-prisma/start-from-scratch-sql-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-sql-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-sql-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch-sql-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
+
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
+
+/docs/getting-started/setup-prisma/start-from-scratch-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-node-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch-typescript-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql 301!
+/docs/getting-started/setup-prisma/start-from-scratch-node-mysql /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql 301!
 
 /docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-file	/docs/reference/tools-and-interfaces/prisma-schema 301!	
 /docs/reference/tools-and-interfaces/prisma-client/api			/docs/reference/tools-and-interfaces/prisma-client 301!
 /docs/guides/upgrade-from-prisma-1/should-you-upgrade       /docs/guides/upgrade-from-prisma-1/how-to-upgrade 301!
 /docs/reference/tools-and-interfaces/prisma-schema/models       /docs/reference/tools-and-interfaces/prisma-schema/data-model 301!
 
-#######################################
-### DOC: Redesign redirects 2020
-#######################################
 
-/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-reference       /docs/reference/api-reference/prisma-schema-reference 301!
-/docs/reference/tools-and-interfaces/prisma-cli/command-reference        /docs/reference/api-reference/command-reference 301!
-/docs/reference/database-connectors/database-features        /docs/reference/database-reference/database-features 301!
-/docs/reference/database-connectors/connection-urls      /docs/reference/database-reference/connection-urls 301!
-/docs/more/supported-databases       /docs/reference/database-reference/supported-databases 301!
+# Tech switcher page defaults
 
-/docs/reference/tools-and-interfaces/*       /docs/concepts/components/:splat 301!
-/docs/reference/database-connectors/*         /docs/concepts/database-connectors/:splat 301!
-/docs/reference/more/*                        /docs/concepts/more/:splat 301!
-/docs/understand-prisma/introduction         /docs/concepts/overview/what-is-prisma 301!
-/docs/understand-prisma/data-modeling       /docs/concepts/overview/what-is-prisma/data-modeling 301!
+/docs/getting-started/setup-prisma/add-to-existing-project	/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres 301!
+/docs/getting-started/setup-prisma/start-from-scratch  /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
+/docs/guides/general-guides/database-workflows/sql-views /docs/guides/general-guides/database-workflows/sql-views-postgres 301!
+/docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres 301!
+/docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch /docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch-typescript 301!
+/docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities /docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres 301!
 
-/docs/understand-prisma/*       /docs/concepts/overview/:splat 301!
 
-/docs/understand-prisma/api-comparisons/*        /docs/concepts/overview/why-prisma/api-comparisons 301!
+# Upgrade guides
+
+/docs/guides/upgrade-from-prisma-1/how-to-upgrade /docs/guides/upgrade-guides/upgrade-from-prisma-1/how-to-upgrade 301!
+/docs/guides/upgrade-from-prisma-1/schema-incompatibilities  /docs/guides/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-postgres 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgres /docs/guides/upgrade-guides/upgrade-from-prisma-1 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-nexus-prisma-to-nexus /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-nexus-prisma-to-nexus  301!
+/docs/guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-nexus /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-nexus 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-sdl-first /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-prisma-binding-to-sdl-first 301!
+/docs/guides/upgrade-from-prisma-1/upgrading-a-rest-api /docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-a-rest-api 301!
+
+
+# Redesign 2020
+
+/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-reference  /docs/reference/api-reference/prisma-schema-reference 301!
+/docs/reference/tools-and-interfaces/prisma-cli/command-reference           /docs/reference/api-reference/command-reference 301!
+/docs/reference/database-connectors/database-features                       /docs/reference/database-reference/database-features 301!
+/docs/reference/database-connectors/connection-urls                         /docs/reference/database-reference/connection-urls 301!
+/docs/more/supported-databases                                              /docs/reference/database-reference/supported-databases 301!
+
+/docs/reference/tools-and-interfaces/*     /docs/concepts/components/:splat 301!
+/docs/reference/database-connectors/*      /docs/concepts/database-connectors/:splat 301!
+/docs/reference/more/*                     /docs/concepts/more/:splat 301!
+/docs/understand-prisma/introduction       /docs/concepts/overview/what-is-prisma 301!
+/docs/understand-prisma/data-modeling      /docs/concepts/overview/what-is-prisma/data-modeling 301!
+
+/docs/understand-prisma/*                   /docs/concepts/overview/:splat 301!
+/docs/understand-prisma/api-comparisons/*   /docs/concepts/overview/why-prisma/api-comparisons 301!
 
 /docs/more/*     /docs/about/:splat 301!
 
-### Getting started redirects
+
+### Getting started
 
 /docs/getting-started/setup-prisma/start-from-scratch-prisma-migrate      /docs/getting-started/setup-prisma/start-from-scratch-typescript-postgres 301!
-/docs/getting-started/setup-prisma/start-from-scratch-sql      /docs/getting-started/setup-prisma 301!      
+/docs/getting-started/setup-prisma/start-from-scratch-sql                 /docs/getting-started/setup-prisma 301!      
 
-### Guides redirects
 
-/docs/guides/prisma-guides/prisma-migrate-guides      /docs/guides/prisma-guides/add-prisma-migrate-to-a-project 301!
+### Guides
+
+/docs/guides/prisma-guides/prisma-migrate-guides                                      /docs/guides/prisma-guides/add-prisma-migrate-to-a-project 301!
 /docs/guides/prisma-guides/prisma-migrate-guides/add-prisma-migrate-to-a-project      /docs/guides/prisma-guides/add-prisma-migrate-to-a-project 301!
 
-### Reference redirects
+
+### Reference
 
 /docs/concepts/components/prisma-client/distinct	/docs/concepts/components/prisma-client/aggregation-grouping-summarizing#select-distinct 301!
 /docs/concepts/components/prisma-client/configuring-the-prisma-client-api	/docs/concepts/components/prisma-client/generating-prisma-client/customizing-the-prisma-client-api 301!
@@ -158,11 +178,10 @@
 /docs/concepts/components/prisma-client/working-with-json	/docs/concepts/components/prisma-client/working-with-advanced-types 301!
 /docs/concepts/components/prisma-client/group-by	/docs/concepts/components/prisma-client/aggregation-grouping-summarizing#group-by-preview 301!
 /docs/concepts/components/prisma-client/advanced-usage-of-generated-types	/docs/concepts/components/prisma-client/working-with-generated-types 301!
-
 /docs/concepts/components/preview-features/native-types/native-types-mappings /docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types 301!
 /docs/concepts/components/preview-features/native-types /docs/concepts/components/prisma-schema/data-model#native-types-mapping 301!
 
-### PrismaClient section redirects
+### PrismaClient section
 
 /docs/concepts/components/prisma-client/generating-prisma-client  /docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client 301!
 /docs/concepts/components/prisma-client/generating-prisma-client/customizing-the-prisma-client-api  /docs/concepts/components/prisma-client/working-with-prismaclient/use-custom-model-and-field-names 301!
@@ -170,21 +189,21 @@
 /docs/concepts/components/prisma-client/logging /docs/concepts/components/prisma-client/working-with-prismaclient/logging 301!
 /docs/concepts/components/prisma-client/error-formatting  /docs/concepts/components/prisma-client/working-with-prismaclient/error-formatting 301!
 
-### Prisma Migrate release redirects
+
+### Prisma Migrate release
 
 /docs/concepts/components/prisma-client/deployment /docs/guides/deployment/deployment 301!
 /docs/concepts/components/prisma-migrate/prisma-migrate-flows  /docs/concepts/components/prisma-migrate 301!
 /docs/guides/prisma-guides/seed-database  /docs/guides/application-lifecycle/seed-database 301!
 /docs/guides/prisma-guides/add-prisma-migrate-to-a-project  /docs/guides/database/developing-with-prisma-migrate/add-prisma-migrate-to-a-project 301!
 
-### Support redirects
-
-/docs/about/creating-bug-reports  /docs/support/creating-bug-reports 301!
 
 ### Other
 
+/docs/about/creating-bug-reports  /docs/support/creating-bug-reports 301!
 /docs/concepts/components/prisma-client/working-with-generated-types  /docs/concepts/components/prisma-client/advanced-type-safety/operating-against-partial-structures-of-model-types 301!
 /docs/reference/utility-types-reference /docs/reference/api-reference/prisma-client-reference#prismavalidator 301!
+
 
 ### Connection / deployment refactor (April 2021)
 
@@ -205,6 +224,9 @@
 /docs/guides/general-guides/database-workflows/sql-views-mysql  /docs/guides/database/advanced-database-tasks/sql-views-mysql 301!
 /docs/guides/prisma-guides/*  /docs/guides/performance-and-optimization/:splat 301!
 
+
+### Other
+
 /docs/mongodb  /docs/concepts/database-connectors/mongodb 301!
 
 /docs/guides/database/developing-with-prisma-migrate/advanced-migrate-scenarios  /docs/guides/database/developing-with-prisma-migrate/customizing-migrations 301!
@@ -214,12 +236,14 @@
 /docs/concepts/components/prisma-client/working-with-advanced-types /docs/concepts/components/prisma-client/working-with-fields 301!
 /docs/concepts/more/codemod  /docs/guides/upgrade-guides/upgrading-versions/codemods 301!
 
+
 ### Relational databases getting started redirects
 
 /docs/getting-started/setup-prisma/start-from-scratch-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgres 301!
 /docs/getting-started/setup-prisma/add-to-existing-project-typescript-postgres /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgres 301!
 
-#### Postgres - TypeScript
+
+### Postgres - TypeScript
 
 /docs/getting-started/setup-prisma/start-from-scratch/connect-your-database-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-postgres 301!
 /docs/getting-started/setup-prisma/start-from-scratch/using-prisma-migrate-typescript-postgres /docs/getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-postgres 301!
@@ -275,12 +299,14 @@
 /docs/getting-started/setup-prisma/add-to-existing-project/querying-the-database-node-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-mysql 301!
 /docs/getting-started/setup-prisma/add-to-existing-project/next-steps-node-mysql /docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps-node-mysql 301!
 
+
 ## Development environment section
 
 /docs/concepts/more/environment-variables /docs/guides/development-environment/environment-variables 301!
 /docs/concepts/more/environment-variables/managing-env-files-and-setting-variables /docs/guides/development-environment/environment-variables/managing-env-files-and-setting-variables 301!
 /docs/concepts/more/environment-variables/using-multiple-env-files /docs/guides/development-environment/environment-variables/using-multiple-env-files 301!
 /docs/concepts/more/editor-setup /docs/guides/development-environment/editor-setup 301!
+
 
 ## About section
 
@@ -296,6 +322,7 @@
 /docs/about/style-guide/frontmatter /docs/about/prisma-docs/style-guide/frontmatter 301!
 /docs/about/style-guide/template /docs/about/prisma-docs/style-guide/template 301!
 
+
 ## SQL Server 
 
 /docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch-typescript /docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-sql-server 301!
@@ -304,6 +331,7 @@
 /docs/concepts/components/preview-features/sql-server/sql-server-local /docs/concepts/database-connectors/sql-server/sql-server-local 301!
 /docs/concepts/components/preview-features/sql-server/sql-server-docker /docs/concepts/database-connectors/sql-server/sql-server-docker 301!
 /docs/concepts/components/preview-features/sql-server /docs/concepts/database-connectors/sql-server 301!
+
 
 ## Upgrade guides
 
@@ -314,8 +342,10 @@
 ## Referential actions section
 /docs/concepts/components/prisma-schema/relations/referential-actions/cyclic-referential-actions /docs/concepts/components/prisma-schema/relations/referential-actions/special-rules-for-referential-actions 301!
 
+
 ## Indexes section
 /docs/concepts/components/prisma-schema/index-configuration /docs/concepts/components/prisma-schema/indexes 301!
+
 
 ## Prisma Data Platform section
 /docs/concepts/components/prisma-data-platform   /docs/concepts/data-platform  301!
@@ -323,19 +353,4 @@
 
 ## ADD NEW DOCS REDIRECTS ABOVE THIS LINE ##
 
-#######################################
-### DOC: Redirects to Data Guide
-#######################################
-
-/docs/guides/database-workflows/setting-up-a-database/postgresql       /dataguide/postgresql/setting-up-a-local-postgresql-database 301!
-/docs/guides/database-workflows/setting-up-a-database/mysql       /dataguide/mysql/setting-up-a-local-mysql-database 301!
-/docs/guides/database-workflows/setting-up-a-database/sqlite       /dataguide/sqlite/setting-up-a-local-sqlite-database 301!  
-
-/docs/guides/database-workflows/import-and-export-data/postgresql       /dataguide/postgresql/inserting-and-modifying-data/importing-and-exporting-data-in-postgresql 301!
-/docs/guides/database-workflows/import-and-export-data/mysql       /dataguide/mysql/importing-and-exporting-data-in-mysql 301!
-/docs/guides/database-workflows/import-and-export-data/sqlite       /dataguide/sqlite/importing-and-exporting-data-in-sqlite 301!
-
-/docs/guides/database-workflows/*       /docs/guides/general-guides/database-workflows/:splat 301!
-/docs/guides/troubleshooting       /docs/support/help-articles 301!
-/docs/guides/troubleshooting/autocompletion-in-graphql-resolvers-with-js       /docs/support/help-articles/autocompletion-in-graphql-resolvers-with-js 301!
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,17 @@
+# https://docs.netlify.com/routing/redirects/
+# 301! for redirects
+# 200! for rewrites/proxy
+# always ! behind numbers so local files are ignored even if present
+# Redirects first, then Rewrites, otherwise the rewrites will never be triggered
+# 
+# The redirects engine will process the first matching rule it finds, reading from top to bottom.
+# Rules in the _redirects file are always processed first, followed by rules in the Netlify configuration file.
+#
+
+#################
+### Redirects ### = send the user to a different URL in the address bar
+#################
+
 
 ################################
 ### Redirects: Prisma 1 docs ###


### PR DESCRIPTION
This PR adds the docs redirects that were all in https://github.com/prisma/website-v8/blob/main/public/_redirects.
It makes removing them there later possible: https://github.com/prisma/website-v8/pull/519

(The PR also makes it easier to run the docs locally without having to define Algolia env vars)