### PR TITLE
Document use of `@@index` and `@@unique` with composite type fields

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -1008,7 +1008,7 @@ Composite types only support a limited set of [attributes](/reference/api-refere
 - `@map`
 - [Native types](/reference/api-reference/prisma-schema-reference#model-field-scalar-types), such as `@db.ObjectId`
 
-The following attributes are not supported:
+The following attributes are not supported inside composite types:
 
 - `@unique`
 - `@id`

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -818,7 +818,7 @@ You can optionally define a [custom unique constraint name](/concepts/components
 
 #### Composite type unique constraints
 
-When using the MongoDB provider in version `3.12.0` and later, you can define a unique constraint on a field `field` of a [composite type](#defining-composite-types) `compositeType` using the syntax `@@unique([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column unique constraint.
+When using the MongoDB provider in version `3.12.0` and later, you can define a unique constraint on a field of a [composite type](#defining-composite-types) using the syntax `@@unique([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column unique constraint.
 
 The following example defines a multi-column unique constraint based on the `email` field of the `User` model and the `number` field of the `Address` composite type:
 

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -820,7 +820,7 @@ You can optionally define a [custom unique constraint name](/concepts/components
 
 When using the MongoDB provider in version `3.12.0` and later, you can define a unique constraint on a field of a [composite type](#defining-composite-types) using the syntax `@@unique([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column unique constraint.
 
-The following example defines a multi-column unique constraint based on the `email` field of the `User` model and the `number` field of the `Address` composite type:
+The following example defines a multi-column unique constraint based on the `email` field of the `User` model and the `number` field of the `Address` composite type which is used in `User.address`:
 
 ```prisma file=schema.prisma
 type Address {

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -881,7 +881,7 @@ You can optionally define a [custom index name](/concepts/components/prisma-sche
 
 #### Defining composite type indexes
 
-In MongoDB in version `3.12.0` and later, you can define an index on a field `field` of a [composite type](#defining-composite-types) `compositeType` using the syntax `@@index([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column index.
+In MongoDB in version `3.12.0` and later, you can define an index on a field of a [composite type](#defining-composite-types) using the syntax `@@index([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column index.
 
 The following example defines a multi-column index based on the `email` field of the `User` model and the `number` field of the `Address` composite type:
 

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -818,7 +818,7 @@ You can optionally define a [custom unique constraint name](/concepts/components
 
 #### Composite type unique constraints
 
-In MongoDB in version `3.12.0` and later, you can define a unique constraint on a field `field` of a [composite type](#defining-composite-types) `compositeType` using the syntax `@@unique([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column unique constraint.
+When using the MongoDB provider in version `3.12.0` and later, you can define a unique constraint on a field `field` of a [composite type](#defining-composite-types) `compositeType` using the syntax `@@unique([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column unique constraint.
 
 The following example defines a multi-column unique constraint based on the `email` field of the `User` model and the `number` field of the `Address` composite type:
 
@@ -881,7 +881,7 @@ You can optionally define a [custom index name](/concepts/components/prisma-sche
 
 #### Defining composite type indexes
 
-In MongoDB in version `3.12.0` and later, you can define an index on a field of a [composite type](#defining-composite-types) using the syntax `@@index([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column index.
+When using the MongoDB provider in version `3.12.0` and later, you can define an index on a field of a [composite type](#defining-composite-types) using the syntax `@@index([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column index.
 
 The following example defines a multi-column index based on the `email` field of the `User` model and the `number` field of the `Address` composite type:
 

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -816,6 +816,48 @@ You can optionally define a [custom unique constraint name](/concepts/components
 
 </Admonition>
 
+#### Composite type unique constraints
+
+In MongoDB in version `3.12.0` and later, you can define a unique constraint on a field `field` of a [composite type](#defining-composite-types) `compositeType` using the syntax `@@unique([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column unique constraint.
+
+The following example defines a multi-column unique constraint based on the `email` field of the `User` model and the `number` field of the `Address` composite type:
+
+```prisma file=schema.prisma
+type Address {
+  street String
+  number Int
+}
+
+model User {
+  id      Int     @id
+  email   String
+  address Address
+
+  @@unique([email, address.number])
+}
+```
+
+This notation can be chained if there is more than one nested composite type:
+
+```prisma file=schema.prisma
+
+type City {
+  name String
+}
+
+type Address {
+  number Int
+  city   City
+}
+
+model User {
+  id      Int       @id
+  address Address[]
+
+  @@unique([address.city.name])
+}
+```
+
 ### Defining an index
 
 You can define indexes on one or multiple fields of your models via the [`@@index`](/reference/api-reference/prisma-schema-reference#index) <span class="api"></span> on a model. The following example defines a multi-column index based on the `title` and `content` field:
@@ -836,6 +878,48 @@ model Post {
 You can optionally define a [custom index name](/concepts/components/prisma-schema/names-in-underlying-database#constraint-and-index-names-preview) in the underlying database.
 
 </Admonition>
+
+#### Composite type indexes
+
+In MongoDB in version `3.12.0` and later, you can define an index on a field `field` of a [composite type](#defining-composite-types) `compositeType` using the syntax `@@index([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column index.
+
+The following example defines a multi-column index based on the `email` field of the `User` model and the `number` field of the `Address` composite type:
+
+```prisma file=schema.prisma
+type Address {
+  street String
+  number Int
+}
+
+model User {
+  id      Int     @id
+  email   String
+  address Address
+
+  @@index([email, address.number])
+}
+```
+
+This notation can be chained if there is more than one nested composite type:
+
+```prisma file=schema.prisma
+
+type City {
+  name String
+}
+
+type Address {
+  number Int
+  city   City
+}
+
+model User {
+  id      Int       @id
+  address Address[]
+
+  @@index([address.city.name])
+}
+```
 
 ## Defining enums
 

--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -879,7 +879,7 @@ You can optionally define a [custom index name](/concepts/components/prisma-sche
 
 </Admonition>
 
-#### Composite type indexes
+#### Defining composite type indexes
 
 In MongoDB in version `3.12.0` and later, you can define an index on a field `field` of a [composite type](#defining-composite-types) `compositeType` using the syntax `@@index([compositeType.field])`. As with other fields, composite type fields can be used as part of a multi-column index.
 
@@ -1016,6 +1016,10 @@ The following attributes are not supported:
 - `@ignore`
 - `@updatedAt`
 - `@createdAt`
+
+However, unique constraints can still be defined by using the `@@unique` attribute on the level of the model that uses the composite type. For more details, see [Composite type unique constraints](#composite-type-unique-constraints).
+
+Indexes can be defined by using the `@@index` attribute on the level of the model that uses the composite type. For more details, see [Composite type indexes](#defining-composite-type-indexes).
 
 ## Using functions
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -647,13 +647,13 @@ Floating point number.
 
 #### Default type mappings
 
-| Connector     | Default mapping  |
-| ------------- | ---------------- |
-| PostgreSQL    | `decimal(65,30)` |
-| Microsoft SQL | `decimal(32,16)` |
-| MySQL         | `DECIMAL(65,30)` |
-| MongoDB       | [Not supported](https://github.com/prisma/prisma/issues/12637)    |
-| SQLite        | `DECIMAL`        |
+| Connector     | Default mapping                                                |
+| ------------- | -------------------------------------------------------------- |
+| PostgreSQL    | `decimal(65,30)`                                               |
+| Microsoft SQL | `decimal(32,16)`                                               |
+| MySQL         | `DECIMAL(65,30)`                                               |
+| MongoDB       | [Not supported](https://github.com/prisma/prisma/issues/12637) |
+| SQLite        | `DECIMAL`                                                      |
 
 #### PostgreSQL
 
@@ -2285,6 +2285,8 @@ While you cannot configure these option in your Prisma schema, you can still con
 
 ##### MongoDB
 
+- In version `3.12.0` and later, you can define an index on a field `field` of a [composite type](/concepts/components/prisma-schema/data-model#defining-composite-types) `compositeType` using the syntax `@@index([compositeType.field])`. See [Defining composite type indexes](/concepts/components/prisma-schema/data-model#defining-composite-type-indexes) for more details.
+
 #### Arguments
 
 | Name     | Required | Type               | Description                                                                                                                                                                                                                                 |
@@ -2384,6 +2386,31 @@ model Post {
   content String?
 
   @@index(fields: [title, content], name: "main_index")
+}
+```
+
+</tab>
+<tab>
+</tab>
+</TabbedContent>
+
+##### Define an index on a composite type field
+
+<TabbedContent tabs={[<FileWithIcon text="MongoDB" icon="database"/>]}>
+<tab>
+
+```prisma
+type Address {
+  street String
+  number Int
+}
+
+model User {
+  id      Int     @id
+  email   String
+  address Address
+
+  @@index([address.number])
 }
 ```
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2285,7 +2285,7 @@ While you cannot configure these option in your Prisma schema, you can still con
 
 ##### MongoDB
 
-- In version `3.12.0` and later, you can define an index on a field `field` of a [composite type](/concepts/components/prisma-schema/data-model#defining-composite-types) `compositeType` using the syntax `@@index([compositeType.field])`. See [Defining composite type indexes](/concepts/components/prisma-schema/data-model#defining-composite-type-indexes) for more details.
+- In version `3.12.0` and later, you can define an index on a field of a [composite type](/concepts/components/prisma-schema/data-model#defining-composite-types) using the syntax `@@index([compositeType.field])`. See [Defining composite type indexes](/concepts/components/prisma-schema/data-model#defining-composite-type-indexes) for more details.
 
 #### Arguments
 


### PR DESCRIPTION
Add composite type indexes and unique constraints to data model

## Describe this PR

Note that this doesn't include any documentation of using `@@fulltext` attribute with composite types yet, because this is still missing from the reference docs (see issue #2628). Will add a separate PR for that

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #3007 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
