### PR TITLE
Update index.mdx

### DIFF
--- a/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
@@ -87,7 +87,8 @@ Frameworks like [Next.js](https://nextjs.org/) support hot reloading of changed 
 As a workaround, you can store `PrismaClient` as a global variable in development environments only, as global variables are not reloaded:
 
 ```ts file=client.ts
-import { PrismaClient } from '@prisma/client'
+import type { PrismaClient } from '@prisma/client'
+import Prisma from '@prisma/client'
 
 // add prisma to the NodeJS global type
 interface CustomNodeJsGlobal extends NodeJS.Global {
@@ -97,7 +98,7 @@ interface CustomNodeJsGlobal extends NodeJS.Global {
 // Prevent multiple instances of Prisma Client in development
 declare const global: CustomNodeJsGlobal
 
-const prisma = global.prisma || new PrismaClient()
+const prisma = global.prisma || new Prisma.PrismaClient()
 
 if (process.env.NODE_ENV === 'development') global.prisma = prisma
 


### PR DESCRIPTION
## Describe this PR

The way the docs recommend to import prisma causes the following error when running build with Vite on a Svelte Kit procject:

import { PrismaClient } from '@prisma/client';
         ^^^^^^^^^^^^
SyntaxError: Named export 'PrismaClient' not found. The requested module '@prisma/client' is a CommonJS module, which may not support all module.exports as named exports.

## Changes

Import prisma like this instead:

```
import type { PrismaClient } from '@prisma/client'
import Prisma from '@prisma/client'
```

And the rest of the example: 
```
// add prisma to the NodeJS global type
interface CustomNodeJsGlobal extends NodeJS.Global {
    prisma: PrismaClient
}

// Prevent multiple instances of Prisma Client in development
declare const global: CustomNodeJsGlobal

const prisma = global.prisma || new Prisma.PrismaClient()

if (process.env.NODE_ENV === 'development') {
    global.prisma = prisma
}
```