### PR TITLE
Remove Preview flag from `migrate diff` and `db execute`

### DIFF
--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -72,20 +72,14 @@ The following example demonstrates how to manually complete the steps of a migra
 
 ## Fixing failed migrations with <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
 
-In versions 3.9.0 and later, we are offering two new commands in [Preview](/about/prisma/releases#preview) that can be used to fix failed migrations. For more information about these commands, and others, refer to our [CLI Reference documentation](/reference/api-reference/command-reference) <span class="api"></span>.
+To help with fixing a failed migration, Prisma Migrate provides the following commands for creating and executing a migration file:
 
-<Admonition type="warning">
-
-The `migrate diff` and `db execute` commands are currently a [Preview feature](/concepts/components/preview-features/cli-preview-features). To use these commands, you will need to add the `--preview-feature` flag.
-
-</Admonition>
-
-### New commands <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
-
-The two new commands that we provide are:
-
-- [`prisma migrate diff`](/reference/api-reference/command-reference#migrate-diff) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the new execute command.
+- [`prisma migrate diff`](/reference/api-reference/command-reference#migrate-diff) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the `db execute` command.
 - [`prisma db execute`](/reference/api-reference/command-reference#db-execute) <span class="api"></span> which applies a SQL script to the database without interacting with the Prisma migrations table.
+
+These commands are available in Preview in versions `3.9.0` and later, and generally available in versions `3.13.0` and later.
+
+This section gives an example scenario of a failed migration, and explains how to use `migrate diff` and `db execute` to fix it.
 
 ### Example of a failed migration
 
@@ -142,7 +136,7 @@ In this case, you need to create a migration that takes your production database
   - Run the following `prisma migrate diff` command:
 
     ```bash
-     npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql**
+     npx prisma migrate diff --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql**
     ```
 
     This will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
@@ -150,7 +144,7 @@ In this case, you need to create a migration that takes your production database
   - Run the following `prisma db execute` command:
 
     ```bash
-     npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file backward.sql
+     npx prisma db execute --url "$DATABASE_URL_PROD" --file backward.sql
     ```
 
     This applies the changes in the SQL script against the target database without interacting with the migrations table.
@@ -176,7 +170,7 @@ In this case, you need to fix the non-unique data and then go ahead with the res
 
     ```bash
 
-    npx prisma migrate diff --preview-feature --from-url "$DATABASE_URL_PROD" --to-schema-datamodel schema.prisma --script > forward.sql
+    npx prisma migrate diff --from-url "$DATABASE_URL_PROD" --to-schema-datamodel schema.prisma --script > forward.sql
 
     ```
 
@@ -185,7 +179,7 @@ In this case, you need to fix the non-unique data and then go ahead with the res
   - Run the following `prisma db execute` command:
 
     ```bash
-    npx prisma db execute --preview-feature --url "$DATABASE_URL_PROD" --file forward.sql
+    npx prisma db execute --url "$DATABASE_URL_PROD" --file forward.sql
     ```
 
     This applies the changes in the SQL script against the target database without interacting with the migrations table.

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -72,7 +72,7 @@ The following example demonstrates how to manually complete the steps of a migra
 
 ## Fixing failed migrations with <inlinecode>migrate diff</inlinecode> and <inlinecode>db execute</inlinecode>
 
-To help with fixing a failed migration, Prisma Migrate provides the following commands for creating and executing a migration file:
+To help with fixing a failed migration, Prisma provides the following commands for creating and executing a migration file:
 
 - [`prisma migrate diff`](/reference/api-reference/command-reference#migrate-diff) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped to the `db execute --stdin` command.
 - [`prisma db execute`](/reference/api-reference/command-reference#db-execute) <span class="api"></span> which applies a SQL script to the database without interacting with the Prisma migrations table.

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -77,7 +77,7 @@ To help with fixing a failed migration, Prisma Migrate provides the following co
 - [`prisma migrate diff`](/reference/api-reference/command-reference#migrate-diff) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the `db execute` command.
 - [`prisma db execute`](/reference/api-reference/command-reference#db-execute) <span class="api"></span> which applies a SQL script to the database without interacting with the Prisma migrations table.
 
-These commands are available in Preview in versions `3.9.0` and later, and generally available in versions `3.13.0` and later.
+These commands are available in Preview in versions `3.9.0` and later (with the `--preview-feature` CLI flag), and generally available in versions `3.13.0` and later.
 
 This section gives an example scenario of a failed migration, and explains how to use `migrate diff` and `db execute` to fix it.
 

--- a/content/300-guides/050-database/800-production-troubleshooting.mdx
+++ b/content/300-guides/050-database/800-production-troubleshooting.mdx
@@ -74,7 +74,7 @@ The following example demonstrates how to manually complete the steps of a migra
 
 To help with fixing a failed migration, Prisma Migrate provides the following commands for creating and executing a migration file:
 
-- [`prisma migrate diff`](/reference/api-reference/command-reference#migrate-diff) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped directly to the `db execute` command.
+- [`prisma migrate diff`](/reference/api-reference/command-reference#migrate-diff) <span class="api"></span> which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped to the `db execute --stdin` command.
 - [`prisma db execute`](/reference/api-reference/command-reference#db-execute) <span class="api"></span> which applies a SQL script to the database without interacting with the Prisma migrations table.
 
 These commands are available in Preview in versions `3.9.0` and later (with the `--preview-feature` CLI flag), and generally available in versions `3.13.0` and later.

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -193,10 +193,10 @@ The `init` command does not interpret any existing files. Instead, it creates a 
 
 #### Arguments
 
-| Argument                | Required | Description                                                                                                                                                                       | Default      |
-| ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| Argument                | Required | Description                                                                                                                                                                                      | Default      |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
 | `--datasource-provider` | No       | Specifies the default value for the `provider` field in the `datasource` block - can be `sqlite`, `postgresql`, `mysql`, `sqlserver`, `mongodb`, `cockroachdb` (Preview, requires preview flag). | `postgresql` |
-| `--url`                 | No       | Define a custom datasource url.                                                                                                                                                   |              |
+| `--url`                 | No       | Define a custom datasource url.                                                                                                                                                                  |              |
 
 #### Examples
 
@@ -778,13 +778,13 @@ Other options:
 - Take the content of a SQL file located at `./script.sql` and execute it on the database specified by the URL in the `datasource` block of your `schema.prisma` file:
 
   ```terminal
-  prisma db execute --preview-feature --file ./script.sql --schema schema.prisma
+  prisma db execute --file ./script.sql --schema schema.prisma
   ```
 
 - Take the SQL script from standard input and execute it on the database specified by the data source URL given in the `DATABASE_URL` environment variable:
 
   ```terminal
-  $ echo 'TRUNCATE TABLE dev;' | prisma db execute --preview-feature --stdin --url="$DATABASE_URL"
+  $ echo 'TRUNCATE TABLE dev;' | prisma db execute --stdin --url="$DATABASE_URL"
   ```
 
 ## Prisma Migrate
@@ -1018,7 +1018,7 @@ The `migrate diff` command can only compare database features that are [supporte
 The format of the command is:
 
 ```terminal
-npx prisma migrate diff --preview-feature --from-... <source1> --to-... <source2>
+npx prisma migrate diff --from-... <source1> --to-... <source2>
 ```
 
 where the `--from-...` and `--to-...` options are selected based on the type of database schema source. The supported types of sources are:
@@ -1084,7 +1084,6 @@ Other options:
 
   ```terminal
    prisma migrate diff \
-    --preview-feature \
     --from-url "$DATABASE_URL" \
     --to-url "postgresql://login:password@localhost:5432/db2"
   ```
@@ -1093,7 +1092,6 @@ Other options:
 
   ```terminal
   prisma migrate diff \
-   --preview-feature \
    --from-url "$DATABASE_URL" \
    --to-migrations ./migrations \
    --script > script.sql


### PR DESCRIPTION
Remove preview feature flags from migrate diff and db execute

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #3045 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
