### PR TITLE
Add info about Apple M1-specific prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Read through the [contributing guide](CONTRIBUTING.md) to learn how you can cont
 ## Prerequisites for macOS Monterey (Apple M1 chip)
 
 1. Install [homebrew](https://brew.sh/).
-2. Install libvips via homebrew.
+2. Install [`libvips`](https://github.com/libvips/libvips) via homebrew.
 
-```
-brew install libvips
-```
+    ```
+    brew install libvips
+    ```
 
 
 ## Run locally

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ This repository contains the [source code](./src) and the [content](./content) f
 
 Read through the [contributing guide](CONTRIBUTING.md) to learn how you can contribute to the Prisma documentation.
 
+## Prerequisites for macOS Monterey (Apple M1 chip)
+
+1. Install [homebrew](https://brew.sh/).
+2. Install libvips via homebrew.
+
+```
+brew install libvips
+```
+
+
 ## Run locally
 
 Clone this repository and get started by running the following commands:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This repository contains the [source code](./src) and the [content](./content) f
 
 Read through the [contributing guide](CONTRIBUTING.md) to learn how you can contribute to the Prisma documentation.
 
-## Prerequisites for macOS Monterey (Apple M1 chip)
+## Prerequisites for Apple M1 chip (macOS BigSur and later)
 
-1. Install [homebrew](https://brew.sh/).
+1. Install [`homebrew`](https://brew.sh/).
 2. Install [`libvips`](https://github.com/libvips/libvips) via homebrew.
 
     ```


### PR DESCRIPTION
## Describe this PR

On a Macbook with an M1 chip running macOS Monterey, cloning the docs/ repo and running `npm install` results in the following error during the installation of core-js@2.6.12:

...
npm ERR! ../src/common.cc:24:10: fatal error: 'vips/vips8' file not found
npm ERR! #include <vips/vips8>
...

`npm install` is successful after libvips is installed with homebrew.

## Changes

Added a **Prerequisites** section to the README listing the installation of libvips on macOS Monterey.

## What issue does this fix?

No issue.

## Any other relevant information

N/A
