### PR TITLE
 Update native type docs for cockroachdb 

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -458,6 +458,7 @@ model Model {
 | :-------------------------------- | :----------------------------- | ----- |
 | `STRING` \| `TEXT` \| `VARCHAR`   | `@db.String`                   |       |
 | `CHAR`                            | `@db.Char(x)`                  |       |
+| `"char"`                          | `@db.SingleChar`               |       |
 | `BIT`                             | `@db.Bit(x)`                   |       |
 | `VARBIT`                          | `@db.VarBit`                   |       |
 | `UUID`                            | `@db.Uuid`                     |       |

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -454,15 +454,14 @@ model Model {
 
 #### CockroachDB (Preview)
 
-| Native database type | Native database type attribute | Notes |
-| :------------------- | :----------------------------- | ----- |
-| `STRING` \| `TEXT`   | `@db.Text`                     |       |
-| `CHAR`               | `@db.Char(x)`                  |       |
-| `VARCHAR`            | `@db.VarChar(n)`               |       |
-| `BIT`                | `@db.Bit(x)`                   |       |
-| `VARBIT`             | `@db.VarBit`                   |       |
-| `UUID`               | `@db.Uuid`                     |       |
-| `INET`               | `@db.Inet`                     |       |
+| Native database type              | Native database type attribute | Notes |
+| :-------------------------------- | :----------------------------- | ----- |
+| `STRING` \| `TEXT` \| `VARCHAR`   | `@db.String`                   |       |
+| `CHAR`                            | `@db.Char(x)`                  |       |
+| `BIT`                             | `@db.Bit(x)`                   |       |
+| `VARBIT`                          | `@db.VarBit`                   |       |
+| `UUID`                            | `@db.Uuid`                     |       |
+| `INET`                            | `@db.Inet`                     |       |
 
 Note that the `xml` and `citext` types supported in PostgreSQL are not currently supported in CockroachDB.
 
@@ -518,7 +517,7 @@ True or false value.
 
 | Native database types | Native database type attribute | Notes |
 | :-------------------- | :----------------------------- | ----- |
-| `BOOL`                | `@db.Boolean`                  |       |
+| `BOOL`                | `@db.Bool`                  |       |
 
 #### Clients
 
@@ -589,12 +588,12 @@ True or false value.
 
 | Native database types        | Native database type attribute           | Notes                                                                                                             |
 | ---------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `INTEGER` \| `INT` \| `INT8` | `@db.BigInt`                             | Note that this differs from PostgreSQL, where `integer` and `int` are aliases for `int4` and map to `@db.Integer` |
-| `INT4`                       | `@db.Integer`                            |                                                                                                                   |
-| `INT2` \| `SMALLINT`         | `@db.SmallInt`                           |                                                                                                                   |
-| `SMALLSERIAL` \| `SERIAL2`   | `@db.SmallInt @default(autoincrement())` |                                                                                                                   |
-| `SERIAL` \| `SERIAL4`        | `@db.Int @default(autoincrement())`      |                                                                                                                   |
-| `SERIAL8` \| `BIGSERIAL`     | `@db.BigInt @default(autoincrement())`   |                                                                                                                   |
+| `INTEGER` \| `INT` \| `INT8` | `@db.Int8`                               | Note that this differs from PostgreSQL, where `integer` and `int` are aliases for `int4` and map to `@db.Integer` |
+| `INT4`                       | `@db.Int4`                               |                                                                                                                   |
+| `INT2` \| `SMALLINT`         | `@db.Int2`                               |                                                                                                                   |
+| `SMALLSERIAL` \| `SERIAL2`   | `@db.Int2 @default(autoincrement())`     |                                                                                                                   |
+| `SERIAL` \| `SERIAL4`        | `@db.Int4 @default(autoincrement())`     |                                                                                                                   |
+| `SERIAL8` \| `BIGSERIAL`     | `@db.Int8 @default(autoincrement())`     |                                                                                                                   |
 
 #### Clients
 
@@ -649,8 +648,8 @@ True or false value.
 
 | Native database types       | Native database type attribute         | Notes                                                                      |
 | --------------------------- | -------------------------------------- | -------------------------------------------------------------------------- |
-| `BIGINT` \| `INT` \| `INT8` | `@db.BigInt`                           | Note that this differs from PostgreSQL, where `int` is an alias for `int4` |
-| `bigserial` \| `serial8`    | `@db.BigInt @default(autoincrement())` |                                                                            |
+| `BIGINT` \| `INT` \| `INT8` | `@db.Int8`                             | Note that this differs from PostgreSQL, where `int` is an alias for `int4` |
+| `bigserial` \| `serial8`    | `@db.Int8 @default(autoincrement())`   |                                                                            |
 
 #### Clients
 
@@ -710,9 +709,8 @@ Floating point number.
 
 | Native database types          | Native database type attribute | Notes |
 | ------------------------------ | ------------------------------ | ----- |
-| `FLOAT`                        | `@db.Float`                    |       |
-| `DOUBLE PRECISION` \| `FLOAT8` | `@db.DoublePrecision`          |       |
-| `REAL` \| `FLOAT4`             | `@db.Real`                     |       |
+| `DOUBLE PRECISION` \| `FLOAT8` | `@db.Float8`                   |       |
+| `REAL` \| `FLOAT4` \| `FLOAT`  | `@db.Float4`                   |       |
 
 #### Clients
 
@@ -975,7 +973,7 @@ Not supported
 
 | Native database types        | Native database type attribute |
 | ---------------------------- | ------------------------------ |
-| `BYTES` \| `BYTEA` \| `BLOB` | `@db.ByteA`                    |
+| `BYTES` \| `BYTEA` \| `BLOB` | `@db.Bytes`                    |
 
 #### Clients
 


### PR DESCRIPTION
    
We changed the native types for cockroachdb to stick closer to the names
  given in the cockroachdb documentation, rather than the postgresql   names.
    
Implemented in https://github.com/prisma/prisma-engines/pull/2866

Original design document: https://www.notion.so/prismaio/Proposal-CockroachDB-Native-Types-35731cea487d4b7b834c993e5eb1e069