### PR TITLE
chore: add undocumented `BYTES` type to SQLite

### DIFF
--- a/content/200-concepts/200-database-connectors/05-sqlite.mdx
+++ b/content/200-concepts/200-database-connectors/05-sqlite.mdx
@@ -42,7 +42,7 @@ The SQLite connector maps the [scalar types](/concepts/components/prisma-schema/
 | `Float`    | `REAL`        |
 | `Decimal`  | `DECIMAL`     |
 | `Json`     | Not supported |
-| `Bytes`    | Not supported |
+| `Bytes`    | `BYTES`       |
 
 ## Connection details
 

--- a/content/200-concepts/200-database-connectors/05-sqlite.mdx
+++ b/content/200-concepts/200-database-connectors/05-sqlite.mdx
@@ -42,7 +42,7 @@ The SQLite connector maps the [scalar types](/concepts/components/prisma-schema/
 | `Float`    | `REAL`        |
 | `Decimal`  | `DECIMAL`     |
 | `Json`     | Not supported |
-| `Bytes`    | `BYTES`       |
+| `Bytes`    | `BLOB`       |
 
 ## Connection details
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -928,7 +928,7 @@ Not supported
 | Microsoft SQL | `varbinary`     |
 | MySQL         | `LONGBLOB`      |
 | MongoDB       | `BinData`       |
-| SQLite        | `BYTES`         |
+| SQLite        | `BLOB`         |
 | CockroachDB   | `BYTES`         |
 
 #### PostgreSQL

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -928,7 +928,7 @@ Not supported
 | Microsoft SQL | `varbinary`     |
 | MySQL         | `LONGBLOB`      |
 | MongoDB       | `BinData`       |
-| SQLite        | Not supported   |
+| SQLite        | `BYTES`         |
 | CockroachDB   | `BYTES`         |
 
 #### PostgreSQL

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -968,7 +968,7 @@ Not supported
 
 #### SQLite
 
-Not supported
+`BLOB`
 
 #### CockroachDB (Preview)
 


### PR DESCRIPTION
## Describe this PR

This PR updates the documentation to show that the SQLite adapter actually supports the `BYTES` type as stated in  [#10537](https://github.com/prisma/prisma/issues/10537)

## Changes
- Updated the database-connector docs for SQLite by updating the compatibility table
- Update prisma-schema-reference docs

## What issue does this fix?

- [#1747](https://github.com/prisma/prisma/issues/1747)
- closes [#10537 ](https://github.com/prisma/prisma/issues/10537)