### PR TITLE
fix(docs) typo in prisma generator client example

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
@@ -30,7 +30,7 @@ The generator for Prisma's Javascript Client accepts multiple additional propert
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["sample-preview-feature"]
-  binaryTargets   = ["linux-msl"]
+  binaryTargets   = ["linux-musl"]
 }
 ```
 


### PR DESCRIPTION
## Describe this PR

Simple typo fix

## Changes

linux-msl -> linux-musl

## What issue does this fix?

Prevents people from copy-pasting this erroneously
