### PR TITLE
Small typo in full text search docs

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -146,7 +146,7 @@ Here's how the following queries would match that text:
 | `+dog +fox`    | Yes    | The text contains 'dog' and 'fox'                      |
 | `+dog -cat`    | Yes    | The text contains 'dog' but not 'cat'                  |
 | `-cat`         | Yes    | 'cat' is not in the text                               |
-| `fox dog`      | Yes    | The text contains 'fox' or 'cat'                       |
+| `fox dog`      | Yes    | The text contains 'fox' or 'dog'                       |
 | `-cat -pig`    | No     | The text does not contain 'cat' or 'pig'               |
 | `quic*`        | Yes    | The text contains a word starting with 'quic'          |
 | `quick fox @2` | Yes    | 'fox' starts within a 2 word distance of 'quick'       |


### PR DESCRIPTION
## Describe this PR

Quick typo fix

## Changes

Replaced 'cat' with 'dog' in the full text search table to align with its respective example

## What issue does this fix?

Nothing too important - a minor typo

## Any other relevant information

None