### PR TITLE
Note CockroachDB "char" intended for internal use

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -454,15 +454,15 @@ model Model {
 
 #### CockroachDB (Preview)
 
-| Native database type              | Native database type attribute | Notes |
-| :-------------------------------- | :----------------------------- | ----- |
-| `STRING` \| `TEXT` \| `VARCHAR`   | `@db.String`                   |       |
-| `CHAR`                            | `@db.Char(x)`                  |       |
-| `"char"`                          | `@db.SingleChar`               |       |
-| `BIT`                             | `@db.Bit(x)`                   |       |
-| `VARBIT`                          | `@db.VarBit`                   |       |
-| `UUID`                            | `@db.Uuid`                     |       |
-| `INET`                            | `@db.Inet`                     |       |
+| Native database type              | Native database type attribute | Notes                                        |
+| :-------------------------------- | :----------------------------- | -------------------------------------------- |
+| `STRING` \| `TEXT` \| `VARCHAR`   | `@db.String`                   |                                              |
+| `CHAR`                            | `@db.Char(x)`                  |                                              |
+| `"char"`                          | `@db.SingleChar`               | Intended for internal use in system catalogs |
+| `BIT`                             | `@db.Bit(x)`                   |                                              |
+| `VARBIT`                          | `@db.VarBit`                   |                                              |
+| `UUID`                            | `@db.Uuid`                     |                                              |
+| `INET`                            | `@db.Inet`                     |                                              |
 
 Note that the `xml` and `citext` types supported in PostgreSQL are not currently supported in CockroachDB.
 


### PR DESCRIPTION
Note that CockroachDB "char" is intended for internal use in system catalogs. CockroachDB docs: https://www.cockroachlabs.com/docs/stable/string.html#related-types

@all-contributors please add @kernfeld-cockroach for doc