### PR TITLE
Fixed Redirection Links in Error reference page

### DIFF
--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -383,15 +383,15 @@ Possible errors:
 
 #### <inlinecode>P3020</inlinecode>
 
-"The automatic creation of shadow databases is disabled on Azure SQL. Please set up a shadow database using the `shadowDatabaseUrl` datasource attribute.<br />Read the docs page for more details: https://pris.ly/d/migrate-shadow"
+"The automatic creation of shadow databases is disabled on Azure SQL. Please set up a shadow database using the `shadowDatabaseUrl` datasource attribute.<br />Read the docs page for more details: [https://pris.ly/d/migrate-shadow](https://pris.ly/d/migrate-shadow)"
 
 #### <inlinecode>P3021</inlinecode>
 
-"Foreign keys cannot be created on this database. Learn more how to handle this: https://pris.ly/d/migrate-no-foreign-keys"
+"Foreign keys cannot be created on this database. Learn more how to handle this: [https://pris.ly/d/migrate-no-foreign-keys](https://pris.ly/d/migrate-no-foreign-keys)"
 
 #### <inlinecode>P3022</inlinecode>
 
-"Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here how to handle this: https://pris.ly/d/migrate-no-direct-ddl"
+"Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here how to handle this: [https://pris.ly/d/migrate-no-direct-ddl]([https://pris.ly/d/migrate-no-direct-ddl)"
 
 ### <inlinecode>prisma db pull</inlinecode> (Introspection Engine)
 

--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -391,7 +391,7 @@ Possible errors:
 
 #### <inlinecode>P3022</inlinecode>
 
-"Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here how to handle this: [https://pris.ly/d/migrate-no-direct-ddl](https://pris.ly/d/migrate-no-direct-ddl)"
+"Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here about how to handle this: [https://pris.ly/d/migrate-no-direct-ddl](https://pris.ly/d/migrate-no-direct-ddl)"
 
 ### <inlinecode>prisma db pull</inlinecode> (Introspection Engine)
 

--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -391,7 +391,7 @@ Possible errors:
 
 #### <inlinecode>P3022</inlinecode>
 
-"Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here how to handle this: [https://pris.ly/d/migrate-no-direct-ddl]([https://pris.ly/d/migrate-no-direct-ddl)"
+"Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here how to handle this: [https://pris.ly/d/migrate-no-direct-ddl](https://pris.ly/d/migrate-no-direct-ddl)"
 
 ### <inlinecode>prisma db pull</inlinecode> (Introspection Engine)
 


### PR DESCRIPTION
## Describe this PR

Quote (") was appended to the links due to which the redirected page was resulting in a 404.
Issue can be checked here: https://www.prisma.io/docs/reference/api-reference/error-reference#p3020

## Changes

Updated markdown file to fix link.

## What issue does this fix?

Clicking on Links of Issue P3020, P3021, and P3022 was resulting in a 404 as " was appended to the URL.

<img width="1329" alt="Screenshot 2022-05-04 at 4 01 03 PM" src="https://user-images.githubusercontent.com/13049676/166665194-0ba33cf7-60a6-4622-8f12-316cc51ed2d5.png">


## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
