### PR TITLE
CDB: Rename SingleChar native type to CatalogSingleChar

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -454,15 +454,15 @@ model Model {
 
 #### CockroachDB (Preview)
 
-| Native database type              | Native database type attribute | Notes                                        |
-| :-------------------------------- | :----------------------------- | -------------------------------------------- |
-| `STRING` \| `TEXT` \| `VARCHAR`   | `@db.String`                   |                                              |
-| `CHAR`                            | `@db.Char(x)`                  |                                              |
-| `"char"`                          | `@db.SingleChar`               | Intended for internal use in system catalogs |
-| `BIT`                             | `@db.Bit(x)`                   |                                              |
-| `VARBIT`                          | `@db.VarBit`                   |                                              |
-| `UUID`                            | `@db.Uuid`                     |                                              |
-| `INET`                            | `@db.Inet`                     |                                              |
+| Native database type            | Native database type attribute | Notes                                        |
+|:--------------------------------|:-------------------------------|----------------------------------------------|
+| `STRING` \| `TEXT` \| `VARCHAR` | `@db.String`                   |                                              |
+| `CHAR`                          | `@db.Char(x)`                  |                                              |
+| `"char"`                        | `@db.CatalogSingleChar`        | Intended for internal use in system catalogs |
+| `BIT`                           | `@db.Bit(x)`                   |                                              |
+| `VARBIT`                        | `@db.VarBit`                   |                                              |
+| `UUID`                          | `@db.Uuid`                     |                                              |
+| `INET`                          | `@db.Inet`                     |                                              |
 
 Note that the `xml` and `citext` types supported in PostgreSQL are not currently supported in CockroachDB.
 


### PR DESCRIPTION
-------

## Describe this PR

We renamed one CockroachDB native type.

## Changes

`@db.SingleChar` was renamed to `@db.CatalogSingleChar`.

## What issue does this fix?

Internal Slack discussion: https://prisma-company.slack.com/archives/C02FNFLDUS3/p1651589077529669