### PR TITLE
Fix typo in 175-squashing-migrations.mdx

### DIFF
--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
@@ -29,7 +29,7 @@ For detailed steps on how to achieve this using `migrate dev`, see the section o
 
 ### Creating a clean history in a production environment
 
-Squashing migrations can also be used in a production environment to squash all migration files into one. This can be useful when the production enviroment has accumulated a longer migration history, and replaying it in new environments has become a burden due to intermediate steps requiring extra time. Since the team is not deriving value from the migration steps (and could get them back from version control history in a pinch) the decision is made to squash the whole history into a single migration.
+Squashing migrations can also be used in a production environment to squash all migration files into one. This can be useful when the production environment has accumulated a longer migration history, and replaying it in new environments has become a burden due to intermediate steps requiring extra time. Since the team is not deriving value from the migration steps (and could get them back from version control history in a pinch) the decision is made to squash the whole history into a single migration.
 
 For detailed steps on how to achieve this using `migrate diff` and `migrate resolve` see the section on [how to create a clean history in a production environment](#how-to-create-a-clean-history-in-a-production-environment).
 


### PR DESCRIPTION


## Describe this PR

Fixed typo.
```
enviroment -> environment
```