### PR TITLE
Deploying to Netlify: Admonition alert

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/500-deploying-to-netlify.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/500-deploying-to-netlify.mdx
@@ -6,7 +6,9 @@ metaDescription: 'Learn how to deploy Node.js and TypeScript applications that a
 
 <TopBlock>
 
-> **Note: This deployment guide is outdated and will be updated soon.**
+<Admonition type="alert">
+  This deployment guide is outdated and will be updated soon.
+</Admonition>
 
 In this guide, you will set up and deploy a serverless Node.js application to [Netlify](https://www.netlify.com/). The application will expose a REST API and use Prisma Client to handle fetching, creating, and deleting records from a database.
 

--- a/content/300-guides/200-deployment/110-deployment-guides/500-deploying-to-netlify.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/500-deploying-to-netlify.mdx
@@ -7,7 +7,8 @@ metaDescription: 'Learn how to deploy Node.js and TypeScript applications that a
 <TopBlock>
 
 <Admonition type="alert">
-  This deployment guide is outdated and will be updated soon.
+  This deployment guide is currently outdated. We are in the process of updating
+  the contents. Stay tuned.
 </Admonition>
 
 In this guide, you will set up and deploy a serverless Node.js application to [Netlify](https://www.netlify.com/). The application will expose a REST API and use Prisma Client to handle fetching, creating, and deleting records from a database.


### PR DESCRIPTION
## Describe this PR

The current note in the Deploying to Netlify guide is not visible enough.

## Changes

* The note was changed to an admonition type="alert"
* The contents of the admonition are updated to a multiline text to avoid the alert visualization issue when single-line text is added.
* The content is now "This deployment guide is currently outdated. We are in the process of updating
  the contents. Stay tuned."

## What issue does this fix?

Fixes #3139

## Any other relevant information

Not really a fix, just a more visible presentation of an important note to avoid people reading outdated information.
