### PR TITLE
Remove the mention of free project limits

### DIFF
--- a/content/200-concepts/150-data-platform/02-about-platform.mdx
+++ b/content/200-concepts/150-data-platform/02-about-platform.mdx
@@ -22,12 +22,6 @@ In the current version of the platform, you can:
 - Invite users and assign roles
 - Connect your application to your database from serverless environments using [Prisma Data Proxy](/concepts/data-platform/data-proxy)
 
-<Admonition type="warning">
-
-There is a limit in the number of free projects you can create which is **2**. If you want to try out the Prisma Data Platform with more free projects or would like to learn more about our pricing plans, reach out to us through the Intercom bubble in the application.
-
-</Admonition>
-
 ## User Roles
 
 These roles are currently supported in the Platform:


### PR DESCRIPTION
This reverts the changes introduced in this PR: https://github.com/prisma/docs/pull/3048

We currently have no limits for the Early Access projects.