### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Read through the [contributing guide](CONTRIBUTING.md) to learn how you can cont
    brew install libvips
    ```
 
-## Run locally
+## Run the docs site locally
 
-Clone this repository and get started by running the following commands:
+1. Clone this repository.
+2. On your computer, open a terminal window in the repository's directory.
+3. Run the following commands:
 
 ```
 npm install


### PR DESCRIPTION
Some wording clarifications to the docs installation instructions.

## Describe this PR

I got a bit lost following the docs installation in the README file. "Clone this repository and get started by running the following commands" implies that you run the commands to clone the depository and get started, when actually they just do the "get started" part (which means "run the docs site locally").

I've separated the sentence into separate steps, to clarify this.  I've also changed the heading of this section to make it clearer exactly what result the user should expect from the section.

## Changes

I've spelled out the fact that you need to clone the repo, _then_ enter the commands to run the docs site locally. It wasn't clear that these were separate steps. Ideally, we might want to add some steps on how to clone the repo, but I think this is good enough for now.