### PR TITLE
Update 400-self-relations.mdx

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/400-self-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/400-self-relations.mdx
@@ -342,8 +342,8 @@ model Follows {
 model User {
   id         Int       @id @default(autoincrement())
   name       String?
-  followedBy Follows[] @relation("follower")
-  following  Follows[] @relation("following")
+  followedBy Follows[] @relation("following")
+  following  Follows[] @relation("follower")
 }
 
 model Follows {


### PR DESCRIPTION
relations of `Follows` in `User` should be swapped because they represent "the other end" of the relation.

Otherwise this will return nothing:
```
const id = getMyUserId();

const usersFollowingMe = await prisma.user.findMany({
    where: {
      following: {
        some: {
          followingId: id,
        },
      },
    },
  });
```

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
