### PR TITLE
Update 03-frontmatter.mdx

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/03-frontmatter.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-frontmatter.mdx
@@ -41,7 +41,7 @@ toc: true
 
 ## <inlinecode>tocDepth</inlinecode>
 
-Controls the depth of headings to show in the ToC:
+Controls the depth of headings to show in the in-page ToC:
 
 ```
 tocDepth: 2


### PR DESCRIPTION
## Clarify the tocdepth tag in docs page front matter

I've specified that this refers to the in-page TOC, to make it clear this doesn't affect the site TOC (the side nav). In my view, this makes the description a bit clearer.