### PR TITLE
(fix) Remove copy button on cmdResult code block

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -98,7 +98,7 @@ npm run dev
 
 <cmdResult>
 
-```json5 no-lines
+```json5 no-lines no-copy
 [
   { id: 1, email: 'sarah@prisma.io', name: 'Sarah', posts: [] },
   {

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/500-troubleshooting-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/500-troubleshooting-relations.mdx
@@ -51,7 +51,7 @@ const getAnimals = await prisma.animal.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
       "id": 7,
       "name": "Salmon",
@@ -104,7 +104,7 @@ const getAnimals = await prisma.animal.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   "id": 1,
   "name": "Salmon",

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/130-logging.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/130-logging.mdx
@@ -104,7 +104,7 @@ prisma.$on('query', (e) => {
 </cmd>
 <cmdResult>
 
-```sql
+```sql no-copy
 Query: SELECT "public"."User"."id", "public"."User"."email", "public"."User"."name" FROM "public"."User" WHERE 1=1 OFFSET $1
 Params: [0]
 Duration: 3ms
@@ -153,7 +153,7 @@ prisma.$on('query', (e) => {
 </cmd>
 <cmdResult>
 
-```terminal
+```terminal no-copy
 Query: db.User.aggregate([ { $project: { _id: 1, email: 1, name: 1, }, }, ])
 Query: db.Post.aggregate([ { $match: { userId: { $in: [ "622f0bbbdf635a42016ee325", ], }, }, }, { $project: { _id: 1, slug: 1, title: 1, body: 1, userId: 1, }, }, ])
 ```

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -168,7 +168,7 @@ const user = await prisma.user.create({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 22,
   name: 'Elsa Prisma',
@@ -254,7 +254,7 @@ const createMany = await prisma.user.createMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   count: 3
 }
@@ -542,7 +542,7 @@ const user = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 { email: 'emma@prisma.io', name: "Emma" }
 ```
 
@@ -583,7 +583,7 @@ const user = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 { email: 'emma@prisma.io', posts: [ { likes: 0 }, { likes: 0 } ] }
 ```
 
@@ -617,7 +617,7 @@ const users = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
     "id": 38,
     "name": "Maria",
@@ -688,7 +688,7 @@ const updateUser = await prisma.user.update({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
    "id": 43,
    "name": "Viola the Magnificent",
@@ -725,7 +725,7 @@ const updateUsers = await prisma.user.updateMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
    "count": 19
 }
@@ -759,7 +759,7 @@ const upsertUser = await prisma.user.upsert({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
    "id": 43,
    "name": "Viola the Magnificent",

--- a/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
@@ -227,7 +227,7 @@ To return **specific relation fields**, you can:
 
 The following query uses a nested `select` to select each user's `name` and the `title` of each related post:
 
-<CodeWithResult>
+<CodeWithResult expanded="{true}">
 <cmd>
 
 ```ts highlight=normal;2,5
@@ -265,7 +265,7 @@ const users = await prisma.user.findMany({
 
 The following query uses `select` within an `include`, and returns _all_ user fields and each post's `title` field:
 
-<CodeWithResult>
+<CodeWithResult expanded="{true}">
 <cmd>
 
 ```ts highlight=normal;2,5

--- a/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
@@ -169,7 +169,7 @@ const getUser: User | null = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 22,
   name: "Alice",
@@ -206,7 +206,7 @@ const getUser: object | null = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   name: "Alice",
   email: "alice@prisma.io",
@@ -246,7 +246,7 @@ const users = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
    "name":"Sabelle",
    "posts":[
@@ -284,7 +284,7 @@ const users = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   "id": 9
   "name": "Sabelle",

--- a/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
@@ -317,7 +317,7 @@ const getUser = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```no-copy
+```code no-copy
 Invalid `prisma.user.findUnique()` invocation:
 
 {

--- a/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
@@ -43,7 +43,7 @@ const getUser = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 19,
   name: null,
@@ -100,7 +100,7 @@ const getPosts = await prisma.post.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   {
     id: 17,
@@ -164,7 +164,7 @@ const user = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
     "id": 40,
     "name": "Yvette",
@@ -234,7 +234,7 @@ const getUser = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   name: "Elsa",
   posts: [ { title: 'My first post' }, { title: 'How to make cookies' } ]
@@ -268,7 +268,7 @@ const getUser = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   "id": 1,
   "name": null,
@@ -317,7 +317,7 @@ const getUser = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```
+```no-copy
 Invalid `prisma.user.findUnique()` invocation:
 
 {
@@ -468,7 +468,7 @@ const user = await prisma.user.create({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 29,
   name: 'Elsa',
@@ -564,7 +564,7 @@ const user = await prisma.user.create({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
     "id": 40,
     "name": "Yvette",
@@ -637,7 +637,7 @@ const user = await prisma.user.create({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
     "id": 43,
     "name": null,
@@ -723,7 +723,7 @@ const user = await prisma.user.create({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 27,
   name: null,
@@ -808,7 +808,7 @@ const createPost = await prisma.post.create({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 26,
   title: 'How to make croissants',
@@ -856,7 +856,7 @@ const updatePost = await prisma.user.update({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 16,
   name: null,
@@ -895,7 +895,7 @@ const updatePost = await prisma.post.update({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 23,
   title: 'How to eat an omelette',
@@ -937,7 +937,7 @@ const updateUser = await prisma.user.update({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   id: 16,
   name: null,

--- a/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
@@ -51,7 +51,7 @@ const result = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```json5
+```json5 no-copy
 [
   {
     id: 1,
@@ -116,7 +116,7 @@ const result = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```json5
+```json5 no-copy
 [{ email: 'yewande@prisma.io' }, { email: `raheem@gmail.com` }]
 ```
 
@@ -245,7 +245,7 @@ const usersWithPosts = await prisma.user.findMany({
 
 <cmdResult>
 
-```json
+```json no-copy
 [
   {
     "email": "kwame@prisma.io",

--- a/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
@@ -637,7 +637,7 @@ const distinctScores = await prisma.play.findMany({
 </cmd>
 <cmdResult>
 
-```no-copy
+```code no-copy
 [
   {
     score: 900,

--- a/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
@@ -73,7 +73,7 @@ const aggregations = await prisma.user.aggregate({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   _avg: {
     age: null
@@ -130,7 +130,7 @@ const groupUsers = await prisma.user.groupBy({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   { country: 'Germany', _sum: { profileViews: 126 } },
   { country: 'Sweden', _sum: { profileViews: 0 } },
@@ -276,7 +276,7 @@ const groupBy = await prisma.user.groupBy({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   { city: 'Berlin', count: { city: 3 } },
   { city: 'Paris', count: { city: 2 } },
@@ -356,7 +356,7 @@ const usersWithCount = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 { id: 1, _count: { posts: 3 } },
 { id: 2, _count: { posts: 2 } },
 { id: 3, _count: { posts: 2 } },
@@ -393,7 +393,7 @@ const usersWithCount = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 { id: 1, _count: { posts: 3 } },
 { id: 2, _count: { posts: 2 } },
 { id: 3, _count: { posts: 2 } },
@@ -424,7 +424,7 @@ const usersWithCount = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   _count: {
     posts: 3
@@ -458,7 +458,7 @@ const usersWithCount = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   _count: {
     posts: 3,
@@ -492,7 +492,7 @@ const userCount = await prisma.user.count({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 { _all: 30, name: 10 }
 ```
 
@@ -553,7 +553,7 @@ const distinctRoles = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   {
     role: 'USER',
@@ -637,7 +637,7 @@ const distinctScores = await prisma.play.findMany({
 </cmd>
 <cmdResult>
 
-```
+```no-copy
 [
   {
     score: 900,

--- a/content/200-concepts/100-components/02-prisma-client/070-case-sensitivity.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/070-case-sensitivity.mdx
@@ -46,7 +46,7 @@ SELECT @@character_set_database, @@collation_database;
 
 <cmdResult>
 
-```no-lines
+```no-lines no-copy
   +--------------------------+----------------------+
   | @@character_set_database | @@collation_database |
   +--------------------------+----------------------+
@@ -77,7 +77,7 @@ SELECT id, email FROM User WHERE email LIKE "%prisMa%"
 
 <cmdResult>
 
-```no-lines
+```no-lines no-copy
  +----+-----------------------------------+
  | id | email                             |
  +----+-----------------------------------+

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -382,7 +382,7 @@ console.log(result)
 
 <cmdResult>
 
-```terminal
+```terminal no-copy
 { bigint: BigInt("123"), bytes: Buffer.from([1, 2]), decimal: Decimal("12.34"), date: Date("<some_date>") }
 ```
 

--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -67,17 +67,17 @@ To get started with Prisma Migrate in a development environment:
 
 1. Create the first migration:
 
-   <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
+      <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
 <cmd>
 
    ```terminal
    prisma migrate dev --name init
    ```
 
-   </cmd>
+      </cmd>
 <cmdResult>
 
-   ```sql
+   ```sql no-copy
      -- CreateTable
    CREATE TABLE "User" (
        "id" SERIAL,
@@ -99,7 +99,7 @@ To get started with Prisma Migrate in a development environment:
    ALTER TABLE "Post" ADD FOREIGN KEY("authorId")REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
    ```
 
-   </cmdResult>
+      </cmdResult>
 </CodeWithResult>
 
    Your Prisma schema is now in sync with your database schema and you have initialized a migration history:
@@ -123,22 +123,22 @@ To get started with Prisma Migrate in a development environment:
 
 1. Create the second migration:
 
-   <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
+      <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
 <cmd>
 
    ```terminal
    prisma migrate dev --name added_job_title
    ```
 
-   </cmd>
+      </cmd>
 <cmdResult>
 
-   ```sql
+   ```sql no-copy
      -- AlterTable
    ALTER TABLE "User" ADD COLUMN     "jobTitle" TEXT NOT NULL;
    ```
 
-   </cmdResult>
+      </cmdResult>
 </CodeWithResult>
 
    Your Prisma schema is once again in sync with your database schema, and your migration history contains two migrations:

--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -67,14 +67,14 @@ To get started with Prisma Migrate in a development environment:
 
 1. Create the first migration:
 
-      <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
+   <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
 <cmd>
 
    ```terminal
    prisma migrate dev --name init
    ```
 
-      </cmd>
+   </cmd>
 <cmdResult>
 
    ```sql no-copy
@@ -99,7 +99,7 @@ To get started with Prisma Migrate in a development environment:
    ALTER TABLE "Post" ADD FOREIGN KEY("authorId")REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
    ```
 
-      </cmdResult>
+   </cmdResult>
 </CodeWithResult>
 
    Your Prisma schema is now in sync with your database schema and you have initialized a migration history:
@@ -123,14 +123,14 @@ To get started with Prisma Migrate in a development environment:
 
 1. Create the second migration:
 
-      <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
+   <CodeWithResult showText="Show migration SQL" hideText="Hide migration SQL">
 <cmd>
 
    ```terminal
    prisma migrate dev --name added_job_title
    ```
 
-      </cmd>
+   </cmd>
 <cmdResult>
 
    ```sql no-copy
@@ -138,7 +138,7 @@ To get started with Prisma Migrate in a development environment:
    ALTER TABLE "User" ADD COLUMN     "jobTitle" TEXT NOT NULL;
    ```
 
-      </cmdResult>
+   </cmdResult>
 </CodeWithResult>
 
    Your Prisma schema is once again in sync with your database schema, and your migration history contains two migrations:

--- a/content/200-concepts/100-components/04-introspection.mdx
+++ b/content/200-concepts/100-components/04-introspection.mdx
@@ -160,7 +160,7 @@ npx prisma generate
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 $ npx prisma generate
 Error: Schema parsing
 error: The model "User" cannot be defined because a model with that name already exists.

--- a/content/200-concepts/100-components/04-introspection.mdx
+++ b/content/200-concepts/100-components/04-introspection.mdx
@@ -160,7 +160,7 @@ npx prisma generate
 
 <cmdResult>
 
-```
+```no-copy
 $ npx prisma generate
 Error: Schema parsing
 error: The model "User" cannot be defined because a model with that name already exists.

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
@@ -196,7 +196,7 @@ To change the direction of a 1-1 relation:
 
    <cmdResult>
 
-   ```no-copy
+   ```code no-copy
    ⚠️  There will be data loss when applying the migration:
 
    • The migration will add a unique constraint covering the columns `[profileId]` on the table `User`. If there are existing duplicate values, the migration will fail.

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
@@ -196,7 +196,7 @@ To change the direction of a 1-1 relation:
 
    <cmdResult>
 
-   ```
+   ```no-copy
    ⚠️  There will be data loss when applying the migration:
 
    • The migration will add a unique constraint covering the columns `[profileId]` on the table `User`. If there are existing duplicate values, the migration will fail.

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
@@ -132,7 +132,7 @@ npx prisma migrate dev --name first-migration
 </cmd>
 <cmdResult>
 
-```
+```no-copy
 √ Name of migration ... first-migration
 The following migration(s) have been created and applied from new schema changes:
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/index.mdx
@@ -132,7 +132,7 @@ npx prisma migrate dev --name first-migration
 </cmd>
 <cmdResult>
 
-```no-copy
+```code no-copy
 √ Name of migration ... first-migration
 The following migration(s) have been created and applied from new schema changes:
 

--- a/content/300-guides/050-database/700-patching-production.mdx
+++ b/content/300-guides/050-database/700-patching-production.mdx
@@ -40,7 +40,7 @@ To reconcile your migration history and database schema in production:
    </cmd>
    <cmdResult>
 
-    ```bash
+    ```bash no-copy
     migrations/
     └─ 20210316150542_retroactively_add_index/
     └─ migration.sql

--- a/content/300-guides/050-database/870-using-prisma-with-mongodb.mdx
+++ b/content/300-guides/050-database/870-using-prisma-with-mongodb.mdx
@@ -184,7 +184,7 @@ console.log(createNull)
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 {
   id: '6242c4ae032bc76da250b207',
   email: 'user1@prisma.io',
@@ -225,7 +225,7 @@ console.log(createMissing)
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 {
   id: '6242c4ae032bc76da250b208',
   email: 'user2@prisma.io',

--- a/content/300-guides/050-database/870-using-prisma-with-mongodb.mdx
+++ b/content/300-guides/050-database/870-using-prisma-with-mongodb.mdx
@@ -184,7 +184,7 @@ console.log(createNull)
 
 <cmdResult>
 
-```
+```no-copy
 {
   id: '6242c4ae032bc76da250b207',
   email: 'user1@prisma.io',
@@ -225,7 +225,7 @@ console.log(createMissing)
 
 <cmdResult>
 
-```
+```no-copy
 {
   id: '6242c4ae032bc76da250b208',
   email: 'user2@prisma.io',
@@ -267,7 +267,7 @@ console.log(findNulls)
 
 <cmdResult>
 
-```terminal
+```terminal no-copy
 [
   {
     id: '6242c4ae032bc76da250b207',
@@ -311,7 +311,7 @@ console.log(findNullOrMissing)
 
 <cmdResult>
 
-```terminal
+```terminal no-copy
 [
   {
     id: '6242c4ae032bc76da250b207',

--- a/content/300-guides/100-performance-and-optimization/085-query-optimization-performance.mdx
+++ b/content/300-guides/100-performance-and-optimization/085-query-optimization-performance.mdx
@@ -108,7 +108,7 @@ const User = objectType({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   timestamp: 2021-02-19T09:43:06.343Z,
   query: 'SELECT `dev`.`Post`.`id`, `dev`.`Post`.`createdAt`, `dev`.`Post`.`updatedAt`, `dev`.`Post`.`title`, `dev`.`Post`.`content`, `dev`.`Post`.`published`, `dev`.`Post`.`viewCount`, `dev`.`Post`.`authorId` FROM `dev`.`Post` WHERE `dev`.`Post`.`authorId` = ? LIMIT ? OFFSET ?',
@@ -182,7 +182,7 @@ const User = objectType({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   timestamp: 2021-02-19T09:59:46.340Z,
   query: 'SELECT `dev`.`User`.`id`, `dev`.`User`.`email`, `dev`.`User`.`name` FROM `dev`.`User` WHERE 1=1 LIMIT ? OFFSET ?',
@@ -247,7 +247,7 @@ users.forEach(async (usr) => {
 </cmd>
 <cmdResult>
 
-```sql
+```sql no-copy
 SELECT "public"."User"."id", "public"."User"."email", "public"."User"."name" FROM "public"."User" WHERE 1=1 OFFSET $1
 SELECT "public"."Post"."id", "public"."Post"."title" FROM "public"."Post" WHERE "public"."Post"."authorId" = $1 OFFSET $2
 SELECT "public"."Post"."id", "public"."Post"."title" FROM "public"."Post" WHERE "public"."Post"."authorId" = $1 OFFSET $2
@@ -282,7 +282,7 @@ const usersWithPosts = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```sql
+```sql no-copy
 SELECT "public"."User"."id", "public"."User"."email", "public"."User"."name" FROM "public"."User" WHERE 1=1 OFFSET $1
 SELECT "public"."Post"."id", "public"."Post"."title", "public"."Post"."authorId" FROM "public"."Post" WHERE "public"."Post"."authorId" IN ($1,$2,$3,$4) OFFSET $5
 ```
@@ -314,7 +314,7 @@ const posts = await prisma.post.findMany({
 </cmd>
 <cmdResult>
 
-```sql
+```sql no-copy
 SELECT "public"."User"."id", "public"."User"."email", "public"."User"."name" FROM "public"."User" WHERE 1=1 OFFSET $1
 SELECT "public"."Post"."id", "public"."Post"."createdAt", "public"."Post"."updatedAt", "public"."Post"."title", "public"."Post"."content", "public"."Post"."published", "public"."Post"."authorId" FROM "public"."Post" WHERE "public"."Post"."authorId" IN ($1,$2,$3,$4) OFFSET $5
 ```

--- a/content/300-guides/125-development-environment/050-environment-variables/100-managing-env-files-and-setting-variables.mdx
+++ b/content/300-guides/125-development-environment/050-environment-variables/100-managing-env-files-and-setting-variables.mdx
@@ -47,7 +47,7 @@ printenv DATABASE_URL
 
 <cmdResult>
 
-```
+```no-copy
 postgresql://test:test@localhost:5432/test?schema=public
 ```
 

--- a/content/300-guides/125-development-environment/050-environment-variables/100-managing-env-files-and-setting-variables.mdx
+++ b/content/300-guides/125-development-environment/050-environment-variables/100-managing-env-files-and-setting-variables.mdx
@@ -47,7 +47,7 @@ printenv DATABASE_URL
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 postgresql://test:test@localhost:5432/test?schema=public
 ```
 

--- a/content/300-guides/150-testing/150-integration-testing.mdx
+++ b/content/300-guides/150-testing/150-integration-testing.mdx
@@ -150,7 +150,7 @@ docker-compose up -d
 
    <cmdResult>
 
-   ```
+   ```no-copy
    CONTAINER ID   IMAGE             COMMAND                  CREATED         STATUS        PORTS                    NAMES
    1322e42d833f   postgres:13       "docker-entrypoint.s…"   2 seconds ago   Up 1 second   0.0.0.0:5433->5432/tcp   integration-tests-prisma
    ```
@@ -175,7 +175,7 @@ docker-compose up -d
 
    <cmdResult>
 
-   ```
+   ```no-copy
    tests=# \l
                                  List of databases
       Name    | Owner  | Encoding |  Collate   |   Ctype    | Access privileges

--- a/content/300-guides/150-testing/150-integration-testing.mdx
+++ b/content/300-guides/150-testing/150-integration-testing.mdx
@@ -150,7 +150,7 @@ docker-compose up -d
 
    <cmdResult>
 
-   ```no-copy
+   ```code no-copy
    CONTAINER ID   IMAGE             COMMAND                  CREATED         STATUS        PORTS                    NAMES
    1322e42d833f   postgres:13       "docker-entrypoint.s…"   2 seconds ago   Up 1 second   0.0.0.0:5433->5432/tcp   integration-tests-prisma
    ```
@@ -175,7 +175,7 @@ docker-compose up -d
 
    <cmdResult>
 
-   ```no-copy
+   ```code no-copy
    tests=# \l
                                  List of databases
       Name    | Owner  | Encoding |  Collate   |   Ctype    | Access privileges

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -198,7 +198,7 @@ main()
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 prisma:info  Starting a postgresql pool with 13 connections.
 prisma:info  Started http server
 prisma:query SELECT COUNT(*) FROM (SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 ORDER BY "public"."User"."coinflips" ASC OFFSET $1) AS "sub"

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -198,7 +198,7 @@ main()
 
 <cmdResult>
 
-```
+```no-copy
 prisma:info  Starting a postgresql pool with 13 connections.
 prisma:info  Started http server
 prisma:query SELECT COUNT(*) FROM (SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 ORDER BY "public"."User"."coinflips" ASC OFFSET $1) AS "sub"
@@ -241,7 +241,7 @@ main()
 
 <cmdResult>
 
-```js
+```js no-copy
 {
   timestamp: 2020-11-17T10:32:10.898Z,
   query: 'SELECT COUNT(*) FROM (SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1 OFFSET $1) AS "sub"',
@@ -299,7 +299,7 @@ main()
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   timestamp: 2020-11-17T10:33:24.592Z,
   message: 'Starting a postgresql pool with 13 connections.',
@@ -458,11 +458,11 @@ Use model queries to perform CRUD operations on your models. See also: [CRUD](/c
 
 #### Return type
 
-| Return type               | Example                    | Description                                                                                                                                                      |
-| ------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| JavaScript object (typed) | `User`                     |                                                                                                                                                                  |
-| JavaScript object (plain) | `{ title: "Hello world" }` | Use `select` and `include` to determine which fields to return.                                                                                                  |
-| `null`                    | `null`                     | Record not found                                                                                                                                                 |
+| Return type               | Example                    | Description                                                                                                                                                       |
+| ------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JavaScript object (typed) | `User`                     |                                                                                                                                                                   |
+| JavaScript object (plain) | `{ title: "Hello world" }` | Use `select` and `include` to determine which fields to return.                                                                                                   |
+| `null`                    | `null`                     | Record not found                                                                                                                                                  |
 | Error                     |                            | If `rejectOnNotFound` is true, `findUnique` throws an error (`NotFoundError` by default, [customizable globally](#rejectonnotfound)) instead of returning `null`. |
 
 #### Reference
@@ -572,11 +572,11 @@ const result = await prisma.user.findUnique({
 
 #### Return type
 
-| Return type               | Example                    | Description                                                                                                                                                      |
-| ------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| JavaScript object (typed) | `User`                     | Specifies which properties to include on the returned object.                                                                                                    |
-| JavaScript object (plain) | `{ title: "Hello world" }` | Use `select` and `include` to determine which fields to return.                                                                                                  |
-| `null`                    | `null`                     | Record not found                                                                                                                                                 |
+| Return type               | Example                    | Description                                                                                                                                                       |
+| ------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JavaScript object (typed) | `User`                     | Specifies which properties to include on the returned object.                                                                                                     |
+| JavaScript object (plain) | `{ title: "Hello world" }` | Use `select` and `include` to determine which fields to return.                                                                                                   |
+| `null`                    | `null`                     | Record not found                                                                                                                                                  |
 | Error                     |                            | If `rejectOnNotFound` is true, `findUnique` throws an error (`NotFoundError` by default, [customizable globally](#rejectonnotfound)) instead of returning `null`. |
 
 #### Remarks
@@ -806,7 +806,7 @@ main()
 
 <cmdResult>
 
-```sql
+```sql no-copy
 prisma:query BEGIN
 prisma:query INSERT INTO "public"."User" ("name","email","profileViews","role","coinflips") VALUES ($1,$2,$3,$4,$5) RETURNING "public"."User"."id"
 prisma:query SELECT "public"."User"."id", "public"."User"."name", "public"."User"."email", "public"."User"."profileViews", "public"."User"."role", "public"."User"."coinflips" FROM "public"."User" WHERE "public"."User"."id" = $1 LIMIT $2 OFFSET $3
@@ -994,7 +994,7 @@ const deleteUser = await prisma.user.delete({
 
 <cmdResult>
 
-```json
+```json no-copy
 { "email": "elsa@prisma.io", "name": "Elsa" }
 ```
 
@@ -1318,7 +1318,7 @@ const minMaxAge = await prisma.user.aggregate({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   _count: { _all: 29 },
   _max: { profileViews: 90 },
@@ -1345,7 +1345,7 @@ const setValue = await prisma.user.aggregate({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   "_sum": {
     "profileViews": 9493
@@ -1431,7 +1431,7 @@ const groupUsers = await prisma.user.groupBy({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   {
     country: 'Denmark',
@@ -1503,7 +1503,7 @@ const result = await prisma.user.findUnique({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   name: "Alice",
   profileViews: 0
@@ -1530,7 +1530,7 @@ const result = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   {
     email: 'alice@prisma.io',
@@ -1564,7 +1564,7 @@ const usersWithCount = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 {
   _count: {
     posts: 3
@@ -1598,7 +1598,7 @@ const result = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```ts
+```ts no-copy
 ;[
   {
     id: 1,
@@ -1641,7 +1641,7 @@ const result = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   {
     id: 1,
@@ -1796,7 +1796,7 @@ const usersWithCount = await prisma.user.findMany({
 </cmd>
 <cmdResult>
 
-```js
+```js no-copy
 { id: 1, name: "Bob", email: "bob@prisma.io", _count: { posts: 3 } },
 { id: 2,  name: "Enya", email: "enya@prisma.io", _count: { posts: 2 } }
 ```
@@ -2111,7 +2111,7 @@ const users = await prisma.user.findMany({
 
 <cmdResult>
 
-```json
+```json no-copy
 [
   {
     "email": "yuki@prisma.io",
@@ -2179,7 +2179,7 @@ const users = await prisma.user.findMany({
 
 <cmdResult>
 
-```json
+```json no-copy
 [
   {
     "email": "mary@prisma.io",
@@ -2244,7 +2244,7 @@ const users3 = await prisma.user.findMany({
 
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   {
     name: 'Alice',
@@ -2298,7 +2298,7 @@ const usersWithPosts = await prisma.user.findMany({
 
 <cmdResult>
 
-```json
+```json no-copy
 [
   {
     "id": 2,
@@ -2374,7 +2374,7 @@ const userWithPosts = await prisma.user.findUnique({
 
 <cmdResult>
 
-```json
+```json no-copy
 {
   "email": "sarah@prisma.io",
   "id": 1,
@@ -2426,7 +2426,7 @@ const sort = await prisma.user.findMany({
 
 <cmdResult>
 
-```json
+```json no-copy
 [
   {
     "email": "emma@prisma.io",
@@ -2508,7 +2508,7 @@ const distinctCities = await prisma.user.findMany({
 
 <cmdResult>
 
-```js no-lines
+```js no-lines no-copy
 ;[
   { city: 'Paris', country: 'France' },
   { city: 'Lyon', country: 'France' },
@@ -2541,7 +2541,7 @@ const distinctCitiesAndCountries = await prisma.user.findMany({
 
 <cmdResult>
 
-```js no-lines
+```js no-lines no-copy
 ;[
   { city: 'Paris', country: 'France' },
   { city: 'Paris', country: 'Denmark' },
@@ -2582,7 +2582,7 @@ const distinctCitiesAndCountries = await prisma.user.findMany({
 
 <cmdResult>
 
-```js
+```js no-copy
 ;[
   { city: 'Paris', country: 'Denmark' },
   { city: 'Lyon', country: 'France' },

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -27,7 +27,7 @@ prisma
 
 <cmdResult>
 
-```
+```no-copy
 Prisma is a modern DB toolkit to query, migrate and model your database (https://prisma.io)
 
 Usage
@@ -104,7 +104,7 @@ prisma version
 
 <cmdResult>
 
-```
+```no-copy
 Environment variables loaded from ./prisma/.env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
@@ -135,7 +135,7 @@ prisma -v
 
 <cmdResult>
 
-```
+```no-copy
 Environment variables loaded from ./prisma/.env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
@@ -166,7 +166,7 @@ prisma version --json
 
 <cmdResult>
 
-```
+```no-copy
 Environment variables loaded from prisma\.env
 {
   "prisma": "2.21.0-dev.4",
@@ -214,7 +214,7 @@ prisma init
 
 <cmdResult>
 
-```
+```no-copy
 ✔ Your Prisma schema was created at prisma/schema.prisma.
   You can now open it in your favorite editor.
 
@@ -364,7 +364,7 @@ prisma generate
 
 <cmdResult>
 
-```
+```no-copy
 ✔ Generated Prisma Client to ./node_modules/.prisma/client in 61ms
 
 You can now start using Prisma Client in your code:
@@ -401,7 +401,7 @@ prisma generate --watch
 
 <cmdResult>
 
-```
+```no-copy
 Watching... /home/prismauser/prisma/prisma-play/prisma/schema.prisma
 
 ✔ Generated Prisma Client to ./node_modules/.prisma/client in 45ms
@@ -448,7 +448,7 @@ npx prisma format
 </cmd>
 <cmdResult>
 
-```
+```no-copy
 Environment variables loaded from prisma/.env
 Prisma schema loaded from prisma/schema.prisma
 Formatted prisma/schema.prisma in 116ms �
@@ -469,7 +469,7 @@ npx prisma format
 </cmd>
 <cmdResult>
 
-```
+```no-copy
 Environment variables loaded from prisma/.env
 Prisma schema loaded from prisma/schema.prisma
 Error: Schema parsing
@@ -546,7 +546,7 @@ prisma db pull
 
 <cmdResult>
 
-```
+```no-copy
 Introspecting based on datasource defined in schema.prisma …
 
 ✔ Wrote Prisma data model into schema.prisma in 38ms
@@ -572,7 +572,7 @@ prisma db pull --schema=./alternative/schema.prisma
 
 <cmdResult>
 
-```
+```no-copy
 Introspecting based on datasource defined in alternative/schema.prisma …
 
 ✔ Wrote Prisma data model into alternative/schema.prisma in 60ms
@@ -598,7 +598,7 @@ prisma db pull --print
 
 <cmdResult>
 
-```prisma
+```prisma no-copy
 generator client {
   provider = "prisma-client-js"
 }

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -27,7 +27,7 @@ prisma
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 Prisma is a modern DB toolkit to query, migrate and model your database (https://prisma.io)
 
 Usage
@@ -104,7 +104,7 @@ prisma version
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 Environment variables loaded from ./prisma/.env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
@@ -135,7 +135,7 @@ prisma -v
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 Environment variables loaded from ./prisma/.env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
@@ -166,7 +166,7 @@ prisma version --json
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 Environment variables loaded from prisma\.env
 {
   "prisma": "2.21.0-dev.4",
@@ -214,7 +214,7 @@ prisma init
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 ✔ Your Prisma schema was created at prisma/schema.prisma.
   You can now open it in your favorite editor.
 
@@ -364,7 +364,7 @@ prisma generate
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 ✔ Generated Prisma Client to ./node_modules/.prisma/client in 61ms
 
 You can now start using Prisma Client in your code:
@@ -401,7 +401,7 @@ prisma generate --watch
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 Watching... /home/prismauser/prisma/prisma-play/prisma/schema.prisma
 
 ✔ Generated Prisma Client to ./node_modules/.prisma/client in 45ms
@@ -448,7 +448,7 @@ npx prisma format
 </cmd>
 <cmdResult>
 
-```no-copy
+```code no-copy
 Environment variables loaded from prisma/.env
 Prisma schema loaded from prisma/schema.prisma
 Formatted prisma/schema.prisma in 116ms �
@@ -469,7 +469,7 @@ npx prisma format
 </cmd>
 <cmdResult>
 
-```no-copy
+```code no-copy
 Environment variables loaded from prisma/.env
 Prisma schema loaded from prisma/schema.prisma
 Error: Schema parsing
@@ -546,7 +546,7 @@ prisma db pull
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 Introspecting based on datasource defined in schema.prisma …
 
 ✔ Wrote Prisma data model into schema.prisma in 38ms
@@ -572,7 +572,7 @@ prisma db pull --schema=./alternative/schema.prisma
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 Introspecting based on datasource defined in alternative/schema.prisma …
 
 ✔ Wrote Prisma data model into alternative/schema.prisma in 60ms

--- a/content/600-about/200-prisma-docs/20-style-guide/01-mdx-examples.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-mdx-examples.mdx
@@ -379,7 +379,7 @@ yarn prisma init
 
 <cmdResult>
 
-```
+```no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field
@@ -417,7 +417,7 @@ yarn prisma init
 
 <cmdResult>
 
-```
+``` no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field
@@ -455,7 +455,7 @@ yarn prisma init
 
 <cmdResult>
 
-```
+```no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field
@@ -493,7 +493,7 @@ yarn prisma init
 
 <cmdResult>
 
-```
+``` no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field

--- a/content/600-about/200-prisma-docs/20-style-guide/01-mdx-examples.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-mdx-examples.mdx
@@ -379,7 +379,7 @@ yarn prisma init
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field
@@ -417,7 +417,7 @@ yarn prisma init
 
 <cmdResult>
 
-``` no-copy
+```code no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field
@@ -455,7 +455,7 @@ yarn prisma init
 
 <cmdResult>
 
-```no-copy
+```code no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field
@@ -493,7 +493,7 @@ yarn prisma init
 
 <cmdResult>
 
-``` no-copy
+```code no-copy
 $ yarn prisma init
 yarn run v1.22.0
 warning package.json: No license field

--- a/src/components/customMdx/code.tsx
+++ b/src/components/customMdx/code.tsx
@@ -72,6 +72,8 @@ const Code = ({ children, className, ...props }: PreCodeProps) => {
   const code = stringify(children)
 
   const hasCopy = props['copy'] || language === 'copy'
+  const noCopy = props['no-copy']
+
   let hasNoLine = true
   const isTerminal = props['terminal'] || language === 'terminal'
   const hasTerminalSymbol = props['bash-symbol'] || language === 'bash-symbol' || isTerminal
@@ -96,13 +98,13 @@ const Code = ({ children, className, ...props }: PreCodeProps) => {
         <Highlight {...defaultProps} code={code} language={language} theme={theme}>
           {({ className: blockClassName, style, tokens, getLineProps, getTokenProps }) => (
             <Pre className={`${blockClassName} ${isTerminal ? 'is-terminal' : ''}`} style={style}>
-              {/* {(props['copy'] || language === 'copy') && ( */}
-              <AbsoluteCopyButton className="copy-button">
-                <CopyButton text={code}>
-                  <Copy />
-                </CopyButton>
-              </AbsoluteCopyButton>
-              {/* )} */}
+              {!noCopy && (
+                <AbsoluteCopyButton className="copy-button">
+                  <CopyButton text={code}>
+                    <Copy />
+                  </CopyButton>
+                </AbsoluteCopyButton>
+              )}
               <code>
                 {cleanTokens(tokens).map((line: any, i: number) => {
                   let lineClass = {


### PR DESCRIPTION
## Describe this PR

Copy button on the `<cmdResult>` code blocks need to be removed, as the UI looks odd with it.

## Changes

Added a `no-copy` prop to mdx files with `<cmdResult>` tags. Conditionally rendering the copy button according to the `no-copy` prop.

## What issue does this fix?

[Fixes #2945](https://github.com/prisma/docs/issues/2945)
