### PR TITLE
docs: Minor update to CRUD docs

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -28,13 +28,13 @@ All examples are based on the following schema:
 <tab>
 
 ```prisma
-generator client {
-  provider = "prisma-client-js"
-}
-
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
 }
 
 model ExtendedProfile {


### PR DESCRIPTION
## Describe this PR

Right now, in the CRUD docs, the comparison between Relational databases and MongoDB example schema seems like the order of datasource definition is different between the two. This PR changes that to make it easier to see the difference between the two.

## Changes

Move the datasource definition for Postgres example schema to make it the same as with the Mongo example schema