### PR TITLE
fix: highlighting of bucket name path

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -297,7 +297,10 @@ const HeaderSec = ({ headerProps }: HeaderViewProps) => {
       <SecondLevelNav>
         <div>
           {bucketItems.map((item) => {
-            const isCurrent = location && item.to && location.pathname.includes(item.to)
+            const bucketStringPosition = process.env.NODE_ENV === 'production' ? 2 : 1
+            const bucketPath = `/${location.pathname.split('/')[bucketStringPosition]}`
+            const isCurrent = location && item.to && bucketPath !== '' && item.to === bucketPath
+
             return (
               <DarkNavLink
                 to={item.to}


### PR DESCRIPTION
## Describe this PR

Our navigation highlighting can also be triggered by the names of subpages. #3232 

## Changes

Made the path matching strict

## What issue does this fix?

Fixes #3232 

