### PR TITLE
Fix mistake in the description of `prisma migrate deploy`

### DIFF
--- a/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/300-guides/200-deployment/150-deploy-database-changes-with-prisma-migrate.mdx
@@ -6,7 +6,7 @@ metaDescription: 'Learn how to deploy database changes with Prisma Migrate.'
 
 <TopBlock>
 
-To apply pending migrations to development, staging, or testing environments, run the `migrate deploy` command as part of your CI/CD pipeline:
+To apply pending migrations to staging, testing, or production environments, run the `migrate deploy` command as part of your CI/CD pipeline:
 
 ```terminal
 npx prisma migrate deploy


### PR DESCRIPTION
The first paragraph mistakenly states that the `prisma migrate deploy` command is meant to be used in "development" environments, while it should in fact say "production". 
This command is meant to be used in non-development environments, such as production, as clearly stated [here](https://www.prisma.io/docs/concepts/components/prisma-migrate#production-and-testing-environments) and [here](https://www.prisma.io/blog/prisma-migrate-ga-b5eno5g08d0b#applying-migrations-in-production-and-other-environments).