### PR TITLE
Removed references to `filterjson` being a preview feature

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -114,25 +114,6 @@ Advanced `Json` filtering is supported by [PostgreSQL](/concepts/database-connec
 
 </Admonition>
 
-### Enable advanced filtering
-
-You can enable advanced filtering by editing the `previewFeatures` field in the `generator` block in your schema, then re-generating the Prisma Client:
-
-1. Update the `previewFeatures` block in your schema:
-
-   ```prisma
-   generator client {
-     provider        = "prisma-client-js"
-     previewFeatures = ["filterJson"]
-   }
-   ```
-
-2. Generate the Prisma Client:
-
-   ```terminal copy
-   npx prisma generate
-   ```
-
 ### Database connector implementation differences
 
 The implementation of `Json` filtering differs between connectors:
@@ -816,7 +797,11 @@ getUsers.forEach((user) => {
 
     if (Array.isArray(insuranceList)) {
       insuranceList.forEach((insuranceItem) => {
-        if (insuranceItem && typeof insuranceItem === 'object' && !Array.isArray(insuranceItem)) {
+        if (
+          insuranceItem &&
+          typeof insuranceItem === 'object' &&
+          !Array.isArray(insuranceItem)
+        ) {
           insuranceItem['status'] = 'expired' // is a  Prisma.JsonObject
         }
       })

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -110,7 +110,7 @@ From v2.23.0, you can filter rows by the data inside a `Json` type. We call this
 
 The availability of advanced `Json` filtering depends on your Prisma version:
 
-- V4.0.0 or later: advanced `Json` filtering is [generally available](/concepts/data-platform/about-platform/platform-releases#general-availability).
+- V4.0.0 or later: advanced `Json` filtering is [generally available](/about/prisma/releases#generally-available-ga).
 - From v2.23.0, but before v4.0.0: advanced `Json` filtering is a [preview feature](/concepts/components/preview-features/client-preview-features). Add `previewFeatures = ["filterJson"]` to your schema. [Learn more](/concepts/components/preview-features/client-preview-features#enabling-a-prisma-client-preview-feature).
 - Before v2.23.0: you can [filter on the exact `Json` field value](#filter-on-exact-field-value), but you cannot use the other features described in this section.
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -106,7 +106,7 @@ See also: [Advanced example: Update a nested JSON key value](#advanced-example-u
 
 ## Filter on a <inlinecode>Json</inlinecode> field
 
-From v2.23.0, you can filter rows by the data inside a `Json` type. We call this **advanced `Json`filtering**.
+From v2.23.0, you can filter rows by the data inside a `Json` type. We call this **advanced `Json` filtering**.
 
 The availability of advanced `Json` filtering depends on your Prisma version:
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -104,9 +104,15 @@ const createUser = await prisma.user.create({
 
 See also: [Advanced example: Update a nested JSON key value](#advanced-example-update-a-nested-json-key-value)
 
-## Filtering on a <inlinecode>Json</inlinecode> field
+## Filter on a <inlinecode>Json</inlinecode> field
 
-Advanced `Json` filtering is available from [2.23.0 and later](https://github.com/prisma/prisma/releases/tag/2.23.0). In earlier versions, you can [filter on the exact `Json` field value](#filter-on-exact-field-value).
+From v2.23.0, you can filter rows by the data inside a `Json` type. We call this **advanced `Json`filtering**.
+
+The availability of advanced `Json` filtering depends on your Prisma version:
+
+- V4.0.0 or later: advanced `Json` filtering is [generally available](/concepts/data-platform/about-platform/platform-releases#general-availability).
+- From v2.23.0, but before v4.0.0: advanced `Json` filtering is a [preview feature](/concepts/components/preview-features/client-preview-features). Add `previewFeatures = ["filterJson"]` to your schema. [Learn more](/concepts/components/preview-features/client-preview-features#enabling-a-prisma-client-preview-feature).
+- Before v2.23.0: you can [filter on the exact `Json` field value](#filter-on-exact-field-value), but you cannot use the other features described in this section.
 
 <Admonition type="warning">
 

--- a/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
@@ -7,7 +7,6 @@ metaDescription: Prisma Client features that are currently in preview.
 
 The following [Preview](/about/prisma/releases#preview) feature flags are available for Prisma Client and the Prisma schema:
 
-- [`filterJson`](/concepts/components/prisma-client/working-with-fields/working-with-json-fields) since release [2.23.0](https://github.com/prisma/prisma/releases/tag/2.23.0) - [Submit feedback](https://github.com/prisma/prisma/issues/7135)
 - [`interactiveTransactions`](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview) since release [2.29.0](https://github.com/prisma/prisma/releases/tag/2.29.0) - [Submit feedback](https://github.com/prisma/prisma/issues/8664)
 - [`fullTextSearch`](/concepts/components/prisma-client/full-text-search) since release [2.30.0](https://github.com/prisma/prisma/releases/tag/2.30.0) - [Submit feedback](https://github.com/prisma/prisma/issues/8877)
 - [`referentialIntegrity`](/concepts/components/prisma-schema/relations/referential-integrity) since release [3.1.1](https://github.com/prisma/prisma/releases/tag/3.1.1) - [Submit feedback](https://github.com/prisma/prisma/issues/9380)

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4762,8 +4762,6 @@ const updatePosts = await prisma.post.updateMany({
 
 ## <inlinecode>JSON</inlinecode> filters
 
-JSON filters are currently in **[Preview](/about/prisma/platform-releases)**. To use JSON filters in your queries, you need to [enable](/guides/upgrade-guides/upgrading-to-use-preview-features#enabling-preview-features) the `filterJson` preview feature.
-
 For use cases and advanced examples, see: [Working with `Json` fields](/concepts/components/prisma-client/working-with-fields/working-with-json-fields) <span class="concepts"></span>
 
 <Admonition type="warning">


### PR DESCRIPTION
Removed references in
* /concepts/components/prisma-client/working-with-fields/working-with-json-fields#enable-advanced-filtering
* /concepts/components/preview-features/client-preview-features
* /reference/api-reference/prisma-client-reference#json-filters
