### PR TITLE
Update link to shadow database page in prisma migrate concepts doc

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/02-data-sources.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/02-data-sources.mdx
@@ -18,7 +18,7 @@ datasource db {
 A Prisma schema can only have _one_ data source. However, you can:
 
 - [Programmatically override a data source `url` when creating your `PrismaClient`](/reference/api-reference/prisma-client-reference#programmatically-override-a-datasource-url)
-- [Specify a different URL for Prisma Migrate's shadow database if you are working with cloud-hosted development databases](/concepts/components/prisma-migrate#cloud-hosted-shadow-databases-must-be-created-manually)
+- [Specify a different URL for Prisma Migrate's shadow database if you are working with cloud-hosted development databases](/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually)
 
 > **Note**: Multiple provider support was removed in 2.22.0. Please see [Deprecation of provider array notation](https://github.com/prisma/prisma/issues/3834) for more information.
 


### PR DESCRIPTION
## Describe this PR

The current link when you click on the text "Specify a different URL for Prisma Migrate's shadow database if you are working with cloud-hosted development databases" does not lead to the correct page.

## Changes

**Before**
* Linked to `/concepts/components/prisma-migrate#cloud-hosted-shadow-databases-must-be-created-manually`

<img width="1786" alt="Screen Shot 2022-06-13 at 1 04 27 PM" src="https://user-images.githubusercontent.com/9094098/173407024-6796cc0b-bbb0-49c9-a54f-7697ebfcfe0d.png">


**After**
* Links to `/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually`

<img width="1789" alt="Screen Shot 2022-06-13 at 1 05 44 PM" src="https://user-images.githubusercontent.com/9094098/173407245-4502ec6e-9306-474b-98ed-f4764aa28250.png">


## What issue does this fix?

N/A - I just noticed this while reading through the docs.

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
