### PR TITLE
Update 050-prisma-client-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4762,7 +4762,7 @@ const updatePosts = await prisma.post.updateMany({
 
 ## <inlinecode>JSON</inlinecode> filters
 
-JSON filters are currently in **[Preview](/about/prisma/platform-releases)**. To use JSON filters in your queries, you need to [enable](/guides/upgrade-guides/upgrading-to-use-preview-features#enabling-preview-features) the `filterJson` preview feature.
+JSON filters are currently in **[Preview](/about/prisma/releases)**. To use JSON filters in your queries, you need to [enable](/guides/upgrade-guides/upgrading-to-use-preview-features#enabling-preview-features) the `filterJson` preview feature.
 
 For use cases and advanced examples, see: [Working with `Json` fields](/concepts/components/prisma-client/working-with-fields/working-with-json-fields) <span class="concepts"></span>
 


### PR DESCRIPTION
## Describe this PR

Update the Preview link which should point to ORM releases and maturity (it currently incorrectly points to the Data Platform maturity page).

## Changes

Update the link to the correct page.

## What issue does this fix?

Fixes #3268
