### PR TITLE
3266 remove reference to dmmf

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -217,8 +217,6 @@ There are two types of comments that are supported in the schema file:
 - `// comment`: This comment is for the reader's clarity and is not present in the abstract syntax tree (AST) of the schema file.
 - `/// comment`: These comments will show up in the abstract syntax tree (AST) of the schema file as descriptions to AST nodes. Tools can then use these comments to provide additional information. All comments are attached to the next available node - [free-floating comments](https://github.com/prisma/prisma/issues/3544) are not supported and are not included in the AST.
 
-> **Note**: `///` comments are not present in the generated Prisma Client.
-
 Here are some different examples:
 
 ```prisma

--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -217,7 +217,7 @@ There are two types of comments that are supported in the schema file:
 - `// comment`: This comment is for the reader's clarity and is not present in the abstract syntax tree (AST) of the schema file.
 - `/// comment`: These comments will show up in the abstract syntax tree (AST) of the schema file as descriptions to AST nodes. Tools can then use these comments to provide additional information. All comments are attached to the next available node - [free-floating comments](https://github.com/prisma/prisma/issues/3544) are not supported and are not included in the AST.
 
-> **Note**: `///` comments are **not** present of the generated Prisma Client, but are present in the internal Data Model Meta Format (DMMF).
+> **Note**: `///` comments are not present in the generated Prisma Client.
 
 Here are some different examples:
 


### PR DESCRIPTION
I removed the only reference to DMMF in our docs. On its own, it was confusing/potentially annoying to users. DMMF is a complex and non-mainstream feature; this single mention was not helpful on its own.
