### PR TITLE
3179 document mongodb composite default filling on required fields prisma 4

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -9,7 +9,7 @@ tocDepth: 2
 
 <Admonition type="info">
 
-Composite types are available in Preview in versions `3.10.0` and later.
+Composite types were available in Preview in versions `3.10.0` and later. They were made Generally Available in v3.12.0.
 
 </Admonition>
 
@@ -92,7 +92,54 @@ There are currently some limitations when using composite types in the Prisma Cl
 
 ## Default values in required composite types
 
-From v4.0.0, if a a [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields) composite type has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value) defined and the value read back from the database is `undefined`, then Prisma inserts the default value into the read result. This is the same behavior as with model fields.
+From v4.0.0, if you carry out a database read on a composite type when the following criteria are true, then Prisma Client inserts the default value into the result:
+
+- In your schema, the composite type is defined as [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields) and has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value).
+- The database read operation returns the value `undefined`.
+
+Note:
+
+- This is the same behavior as with [model fields](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types).
+- Prisma Client inserts the default value into the result, but it does not insert the default value into the database.
+
+### Example of default values in required composite types
+
+Add the following line to your schema:
+
+```prisma file=schema.prisma
+type Photo {
+  height Int    @default(200)
+  width  Int    @default(100)
+  url    String
++ description String @default("none")
+}
+```
+
+For example, if you run the following application code:
+
+```ts
+const orders = await prisma.order.findMany({
+  where: {
+    shippingAddress: {
+      is: {
+        street: '555 Candy Cane Lane',
+      },
+    },
+  },
+})
+```
+
+Then you get the following output:
+
+```
+field: "foo"
+```
+
+```
+await prisma.product.findMany({}), { depth: Infinity })
+```
+
+**Earlier versions:** Before v4.0.0, Prisma returned an error message similar to the following one: **!!! did it return an error message or a null? the source info is conflicting !!!\***
 
 ## Finding records that contain composite types with <inlinecode>find</inlinecode> and <inlinecode>findMany</inlinecode>
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -94,12 +94,12 @@ Conditions:
 
 - The composite type is [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields), and
 - the composite type has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value), and
-- the database read operation returns the value `undefined`.
+- the composite type is not present in the returned document or documents.
 
 Note:
 
 - This is the same behavior as with [model fields](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types).
-- Prisma Client inserts the default value into the result, but does not insert the default value into the database.
+- On read operations, Prisma Client inserts the default value into the result, but does not insert the default value into the database.
 
 In the example schema on this page, `photo` has two required fields with default values: `height` and `width`:
 
@@ -113,7 +113,7 @@ type Photo {
 ...
 ```
 
-The following application code returns the default value if any records have `undefined` in `height` or `width`:
+The following application code returns the default value if any records in the returned document have either `height` or `width` missing:
 
 ```ts
 console.dir(await prisma.product.findMany({}), { depth: Infinity })

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -9,7 +9,7 @@ tocDepth: 2
 
 <Admonition type="info">
 
-Composite types were available in Preview in versions `3.10.0` and later. They were made Generally Available in v3.12.0.
+We made composite types [Generally Available](/about/prisma/releases#generally-available-ga) in v3.12.0. Before this, they were available in [preview](concepts/components/preview-features) in v3.10.0.
 
 </Admonition>
 
@@ -92,54 +92,32 @@ There are currently some limitations when using composite types in the Prisma Cl
 
 ## Default values in required composite types
 
-From v4.0.0, if you carry out a database read on a composite type when the following criteria are true, then Prisma Client inserts the default value into the result:
+From v4.0.0, if you carry out a database read on a composite type when...
 
-- In your schema, the composite type is defined as [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields) and has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value).
-- The database read operation returns the value `undefined`.
+- the composite type is [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields), and
+- the composite type has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value), and
+- the database read operation returns the value `undefined`,
+
+... then Prisma Client inserts the default value into the result. ** !!! should this, and the mention above, say "default values" (plural) ? !!! **
 
 Note:
 
 - This is the same behavior as with [model fields](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types).
-- Prisma Client inserts the default value into the result, but it does not insert the default value into the database.
+- Prisma Client inserts the default value into the result, but does not insert the default value into the database.
 
-### Example of default values in required composite types
-
-Add the following line to your schema:
-
-```prisma file=schema.prisma
-type Photo {
-  height Int    @default(200)
-  width  Int    @default(100)
-  url    String
-+ description String @default("none")
-}
-```
-
-For example, if you run the following application code:
+In the example schema on this page, `photo` has two required fields, `height` and `width`, with default values. The following code returns the default value if any records have `undefined` in `height` or `width`:
 
 ```ts
-const orders = await prisma.order.findMany({
-  where: {
-    shippingAddress: {
-      is: {
-        street: '555 Candy Cane Lane',
-      },
-    },
-  },
-})
+console.dir(await prisma.product.findMany({}), { depth: Infinity })
 ```
 
-Then you get the following output:
+** Earlier versions **
+
+Before v4.0.0, Prisma returned an error message similar to the following:
 
 ```
-field: "foo"
+Invalid `prisma.product.findMany()` invocation ...
 ```
-
-```
-await prisma.product.findMany({}), { depth: Infinity })
-```
-
-**Earlier versions:** Before v4.0.0, Prisma returned an error message similar to the following one: **!!! did it return an error message or a null? the source info is conflicting !!!\***
 
 ## Finding records that contain composite types with <inlinecode>find</inlinecode> and <inlinecode>findMany</inlinecode>
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -98,33 +98,34 @@ Conditions:
 
 Note:
 
-- This is the same behavior as with [model fields](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types).
+- This is the same behavior as with [model fields](/reference/api-reference/prisma-schema-reference#model-field-scalar-types).
 - On read operations, Prisma Client inserts the default value into the result, but does not insert the default value into the database.
 
-In the example schema on this page, `photo` has two required fields with default values: `height` and `width`:
+In our example schema, suppose that you add a required field to `photo`. This field, `bitDepth`, has a default value:
 
-```prisma file=schema.prisma highlight=3-4;normal
+```prisma file=schema.prisma highlight=4;add
 ...
 type Photo {
-  height Int    @default(200)
-  width  Int    @default(100)
-  url    String
+  ...
+  bitDepth    Int    @default(8)
 }
 ...
 ```
 
-The following application code returns the default value if any records have either `height` or `width` missing on the composite:
+Suppose that you then run `npx prisma migrate deploy` to [deploy your database changes](/guides/deployment/deploy-database-changes-with-prisma-migrate) and regenerate your Prisma Client with `npx prisma generate`. Then, you run the following application code:
 
 ```ts
 console.dir(await prisma.product.findMany({}), { depth: Infinity })
 ```
+
+The `bitDepth` field has no content because you have only just added this field, so the query returns the default value of `8`.
 
 ** Earlier versions **
 
 Before version 4.0.0, Prisma threw a P2032 error as follows:
 
 ```
-Error converting field "height" of expected non-nullable
+Error converting field "bitDepth" of expected non-nullable
 type "int", found incompatible value of "null".
 ```
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -88,7 +88,7 @@ There are currently some limitations when using composite types in the Prisma Cl
 
 ## Default values for required fields on composite types
 
-From v4.0.0, if you carry out a database read on a composite type when all of the following conditions are true, then Prisma Client inserts the default value into the result.
+From version 4.0.0, if you carry out a database read on a composite type when all of the following conditions are true, then Prisma Client inserts the default value into the result.
 
 Conditions:
 
@@ -121,10 +121,11 @@ console.dir(await prisma.product.findMany({}), { depth: Infinity })
 
 ** Earlier versions **
 
-Before v4.0.0, Prisma returned an error message similar to the following:
+Before version 4.0.0, Prisma threw a P2032 error as follows:
 
 ```
-Invalid `prisma.product.findMany()` invocation ...
+Error converting field "height" of expected non-nullable
+type "int", found incompatible value of "null".
 ```
 
 ## Finding records that contain composite types with <inlinecode>find</inlinecode> and <inlinecode>findMany</inlinecode>

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -7,12 +7,6 @@ tocDepth: 2
 
 <TopBlock>
 
-<Admonition type="info">
-
-We made composite types [Generally Available](/about/prisma/releases#generally-available-ga) in v3.12.0. Before this, they were available in [preview](concepts/components/preview-features) in v3.10.0.
-
-</Admonition>
-
 <Admonition type="warning">
 
 Composite types are only available with MongoDB.
@@ -20,6 +14,8 @@ Composite types are only available with MongoDB.
 </Admonition>
 
 [Composite types](/concepts/components/prisma-schema/data-model#defining-composite-types), known as [embedded documents](https://docs.mongodb.com/manual/core/data-model-design/#std-label-data-modeling-embedding) in MongoDB, allow you to embed records within other records.
+
+We made composite types [Generally Available](/about/prisma/releases#generally-available-ga) in v3.12.0. They were previously available in [preview](concepts/components/preview-features) from v3.10.0.
 
 This page explains how to:
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -15,7 +15,7 @@ Composite types are only available with MongoDB.
 
 [Composite types](/concepts/components/prisma-schema/data-model#defining-composite-types), known as [embedded documents](https://docs.mongodb.com/manual/core/data-model-design/#std-label-data-modeling-embedding) in MongoDB, allow you to embed records within other records.
 
-We made composite types [Generally Available](/about/prisma/releases#generally-available-ga) in v3.12.0. They were previously available in [Preview](concepts/components/preview-features) from v3.10.0.
+We made composite types [Generally Available](/about/prisma/releases#generally-available-ga) in v3.12.0. They were previously available in [Preview](/concepts/components/preview-features) from v3.10.0.
 
 This page explains how to:
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -90,6 +90,10 @@ There are currently some limitations when using composite types in the Prisma Cl
 - [`findUnique`](/reference/api-reference/prisma-client-reference#findunique) can't filter on composite types
 - [`aggregrate`](/concepts/components/prisma-client/aggregation-grouping-summarizing#aggregate), [`groupBy`](/concepts/components/prisma-client/aggregation-grouping-summarizing#group-by), [`count`](/concepts/components/prisma-client/aggregation-grouping-summarizing#count) don’t support composite operations
 
+## Default values in required composite types
+
+From v4.0.0, if a a [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields) composite type has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value) defined and the value read back from the database is `undefined`, then Prisma inserts the default value into the read result. This is the same behavior as with model fields.
+
 ## Finding records that contain composite types with <inlinecode>find</inlinecode> and <inlinecode>findMany</inlinecode>
 
 Records can be filtered by a composite type within the `where` operation.

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -86,7 +86,7 @@ There are currently some limitations when using composite types in the Prisma Cl
 - [`findUnique`](/reference/api-reference/prisma-client-reference#findunique) can't filter on composite types
 - [`aggregrate`](/concepts/components/prisma-client/aggregation-grouping-summarizing#aggregate), [`groupBy`](/concepts/components/prisma-client/aggregation-grouping-summarizing#group-by), [`count`](/concepts/components/prisma-client/aggregation-grouping-summarizing#count) don’t support composite operations
 
-## Default values in required composite types
+## Default values on required composite types
 
 From v4.0.0, if you carry out a database read on a composite type when all of the following conditions are true, then Prisma Client inserts the default value into the result.
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -15,7 +15,7 @@ Composite types are only available with MongoDB.
 
 [Composite types](/concepts/components/prisma-schema/data-model#defining-composite-types), known as [embedded documents](https://docs.mongodb.com/manual/core/data-model-design/#std-label-data-modeling-embedding) in MongoDB, allow you to embed records within other records.
 
-We made composite types [Generally Available](/about/prisma/releases#generally-available-ga) in v3.12.0. They were previously available in [preview](concepts/components/preview-features) from v3.10.0.
+We made composite types [Generally Available](/about/prisma/releases#generally-available-ga) in v3.12.0. They were previously available in [Preview](concepts/components/preview-features) from v3.10.0.
 
 This page explains how to:
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -92,9 +92,9 @@ From v4.0.0, if you carry out a database read on a composite type when all of th
 
 Conditions:
 
-- The composite type is [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields), and
-- the composite type has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value), and
-- the composite type is not present in the returned document or documents.
+- A field on the composite type is [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields), and
+- this field has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value), and
+- this field is not present in the returned document or documents.
 
 Note:
 
@@ -113,7 +113,7 @@ type Photo {
 ...
 ```
 
-The following application code returns the default value if any records in the returned document have either `height` or `width` missing:
+The following application code returns the default value if any records have either `height` or `width` missing on the composite:
 
 ```ts
 console.dir(await prisma.product.findMany({}), { depth: Infinity })

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -86,7 +86,7 @@ There are currently some limitations when using composite types in the Prisma Cl
 - [`findUnique`](/reference/api-reference/prisma-client-reference#findunique) can't filter on composite types
 - [`aggregrate`](/concepts/components/prisma-client/aggregation-grouping-summarizing#aggregate), [`groupBy`](/concepts/components/prisma-client/aggregation-grouping-summarizing#group-by), [`count`](/concepts/components/prisma-client/aggregation-grouping-summarizing#count) don’t support composite operations
 
-## Default values on required composite types
+## Default values for required fields on composite types
 
 From v4.0.0, if you carry out a database read on a composite type when all of the following conditions are true, then Prisma Client inserts the default value into the result.
 

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -88,20 +88,32 @@ There are currently some limitations when using composite types in the Prisma Cl
 
 ## Default values in required composite types
 
-From v4.0.0, if you carry out a database read on a composite type when...
+From v4.0.0, if you carry out a database read on a composite type when all of the following conditions are true, then Prisma Client inserts the default value into the result.
 
-- the composite type is [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields), and
+Conditions:
+
+- The composite type is [required](/concepts/components/prisma-schema/data-model#optional-and-mandatory-fields), and
 - the composite type has a [default value](/concepts/components/prisma-schema/data-model#defining-a-default-value), and
-- the database read operation returns the value `undefined`,
-
-... then Prisma Client inserts the default value into the result. ** !!! should this, and the mention above, say "default values" (plural) ? !!! **
+- the database read operation returns the value `undefined`.
 
 Note:
 
 - This is the same behavior as with [model fields](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#model-field-scalar-types).
 - Prisma Client inserts the default value into the result, but does not insert the default value into the database.
 
-In the example schema on this page, `photo` has two required fields, `height` and `width`, with default values. The following code returns the default value if any records have `undefined` in `height` or `width`:
+In the example schema on this page, `photo` has two required fields with default values: `height` and `width`:
+
+```prisma file=schema.prisma highlight=3-4;normal
+...
+type Photo {
+  height Int    @default(200)
+  width  Int    @default(100)
+  url    String
+}
+...
+```
+
+The following application code returns the default value if any records have `undefined` in `height` or `width`:
 
 ```ts
 console.dir(await prisma.product.findMany({}), { depth: Infinity })


### PR DESCRIPTION
In the composite types page, I added a description of the new behavior for default values in composite types. I also updated the preview feature notice, and moved it down the page, because this notice is somewhat less important when the feature is GA.
