### PR TITLE
3265 dbnull jsonnull and anynull as symbols prisma 4

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -878,6 +878,12 @@ To differentiate between these possibilities, we've introduced three _null enums
 - `DbNull`: Selects the `NULL` value in the database.
 - `AnyNull`: Selects both `null` JSON values and `NULL` database values.
 
+<Admonition type="info">
+
+From v4.0.0, Prisma returns `JsonNull`, `DbNull`, and `AnyNull` as [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Before v4.0.0, Prisma returned them as [magic strings](https://en.wikipedia.org/wiki/Magic_string).
+
+</Admonition>
+
 For example:
 
 ```prisma
@@ -927,12 +933,6 @@ prisma.log.create({
 <Admonition type="info">
 
 These _null enums_ do not apply to MongoDB because there the difference between a JSON `null` and a database `NULL` does not exist. They also do not apply to the `array_contains` operator in all databases because there can only be a JSON `null` within a JSON array. Since there cannot be a database `NULL` within a JSON array, `{ array_contains: null }` is not ambiguous.
-
-</Admonition>
-
-<Admonition type="info">
-
-Before v4.0.0, `JsonNull` and `DbNull` were stored as string values. From v4.0.0, they are stored as symbols.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -932,7 +932,7 @@ prisma.log.create({
 
 <Admonition type="info">
 
-These _null enums_ do not apply to MongoDB because there the difference between a JSON `null` and a database `NULL` does not exist. They also do not apply to the `array_contains` operator in all databases because there can only be a JSON `null` within a JSON array. Since there cannot be a database `NULL` within a JSON array, `{ array_contains: null }` is not ambiguous.
+These _null enums_ do not apply to MongoDB because MongoDB does not differentiate between a JSON `null` and a database `NULL`. They also do not apply to the `array_contains` operator in all databases because there can only be a JSON `null` within a JSON array. Since there cannot be a database `NULL` within a JSON array, `{ array_contains: null }` is not ambiguous.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -880,7 +880,7 @@ To differentiate between these possibilities, we've introduced three _null enums
 
 <Admonition type="info">
 
-From v4.0.0, `JsonNull`, `DbNull`, and `AnyNull` are [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Before v4.0.0, they were strings.
+From v4.0.0, `JsonNull`, `DbNull`, and `AnyNull` are objects. Before v4.0.0, they were strings.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -880,7 +880,7 @@ To differentiate between these possibilities, we've introduced three _null enums
 
 <Admonition type="info">
 
-From v4.0.0, Prisma returns `JsonNull`, `DbNull`, and `AnyNull` as [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Before v4.0.0, Prisma returned them as [magic strings](https://en.wikipedia.org/wiki/Magic_string).
+From v4.0.0, Prisma returns `JsonNull`, `DbNull`, and `AnyNull` as [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Before v4.0.0, Prisma returned them as strings.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -880,7 +880,7 @@ To differentiate between these possibilities, we've introduced three _null enums
 
 <Admonition type="info">
 
-From v4.0.0, Prisma returns `JsonNull`, `DbNull`, and `AnyNull` as [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Before v4.0.0, Prisma returned them as strings.
+From v4.0.0, `JsonNull`, `DbNull`, and `AnyNull` are [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Before v4.0.0, they were strings.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -816,7 +816,11 @@ getUsers.forEach((user) => {
 
     if (Array.isArray(insuranceList)) {
       insuranceList.forEach((insuranceItem) => {
-        if (insuranceItem && typeof insuranceItem === 'object' && !Array.isArray(insuranceItem)) {
+        if (
+          insuranceItem &&
+          typeof insuranceItem === 'object' &&
+          !Array.isArray(insuranceItem)
+        ) {
           insuranceItem['status'] = 'expired' // is a  Prisma.JsonObject
         }
       })
@@ -922,9 +926,13 @@ prisma.log.create({
 
 <Admonition type="info">
 
-These _null enums_ do not apply to MongoDB because there the difference between a JSON `null` and a database `NULL` does not exist.
+These _null enums_ do not apply to MongoDB because there the difference between a JSON `null` and a database `NULL` does not exist. They also do not apply to the `array_contains` operator in all databases because there can only be a JSON `null` within a JSON array. Since there cannot be a database `NULL` within a JSON array, `{ array_contains: null }` is not ambiguous.
 
-They also do not apply to the `array_contains` operator in all databases because there can only be a JSON `null` within a JSON array. Since there cannot be a database `NULL` within a JSON array, `{ array_contains: null }` is not ambiguous.
+</Admonition>
+
+<Admonition type="info">
+
+Before v4.0.0, `JsonNull` and `DbNull` were stored as string values. From v4.0.0, they are stored as symbols.
 
 </Admonition>
 


### PR DESCRIPTION
I've added a brief mention of this in the docs. The detail for this belongs in the upgrade guide, because in the unlikely event it affects users, it will be when they upgrade to Prisma 4. Matt concurs with this approach. I'll work with Lucy on the upgrade guide material.

