### PR TITLE
Fix code snippet in raw-database-access

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -82,7 +82,7 @@ Be aware that:
 
   ```ts no-lines
   const ordering = 'desc'
-  await prisma.$queryRaw`SELECT * FROM Table ORDER BY ${desc};`
+  await prisma.$queryRaw`SELECT * FROM Table ORDER BY ${ordering};`
   ```
 
 #### Return type


### PR DESCRIPTION
## Describe this PR

Snippet under the `$queryRaw` section is referencing the wrong variable (`desc`), which should be `ordering` instead.
## Changes
Changed `desc` to `ordering` in the code snippet.

## What issue does this fix?
N/A

## Any other relevant information
N/A