### PR TITLE
PDP: Update info about billing email address

### DIFF
--- a/content/200-concepts/150-data-platform/09-billing/07-payment-method-and-billing-information.mdx
+++ b/content/200-concepts/150-data-platform/09-billing/07-payment-method-and-billing-information.mdx
@@ -87,9 +87,11 @@ Your billing information will be included in the next invoice issued for your us
 
 ## Business billing information
 
-### Add a business email
+### Add a billing email address
 
-You can add your company email to your monthly invoices.
+By default, you receive invoices on the email address of your GitHub account that you use to log in to the Prisma Data Platform.
+
+You can receive invoices to an additional email (such your company email).
 
 **Steps**
 
@@ -100,7 +102,9 @@ You can add your company email to your monthly invoices.
 
 **Result**
 
-Your company email will appear in the next invoice.
+You will start receiving invoices to the billing email address in addition to the email address of your GitHub account.
+
+The billing email address will also appear in the contact details of your invoices.
 
 ### Receive business invoices with a tax ID
 

--- a/content/200-concepts/150-data-platform/09-billing/07-payment-method-and-billing-information.mdx
+++ b/content/200-concepts/150-data-platform/09-billing/07-payment-method-and-billing-information.mdx
@@ -91,7 +91,7 @@ Your billing information will be included in the next invoice issued for your us
 
 By default, you receive invoices on the email address of your GitHub account that you use to log in to the Prisma Data Platform.
 
-You can receive invoices to an additional email (such your company email).
+You can receive invoices to an additional email (such as your company email).
 
 **Steps**
 
@@ -103,8 +103,6 @@ You can receive invoices to an additional email (such your company email).
 **Result**
 
 You will start receiving invoices to the billing email address in addition to the email address of your GitHub account.
-
-The billing email address will also appear in the contact details of your invoices.
 
 ### Receive business invoices with a tax ID
 


### PR DESCRIPTION
## Describe this PR

Add details about setting the Billing email address in PDP. When you do so, the following results take place:

- In addition to the GitHub email, you now receive invoices also on the billing email
- The billing email that you configure also appears in the user's contact information in the invoices (technically, it replaces the GitHub email)

## Changes

Updated the contents of 07-payment-method-and-billing-information.mdx

## What issue does this fix?

n/a
