### PR TITLE
Fix typo in Custom Models documentation

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/064-custom-models.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/064-custom-models.mdx
@@ -64,7 +64,7 @@ type Signup = {
 }
 
 function Users(prismaUser: PrismaClient['user']) {
-  return Object.assign(prisma, {
+  return Object.assign(prismaUser, {
     /**
      * Signup the first user and create a new team of one. Return the User with
      * a full name and without a password


### PR DESCRIPTION
## Describe this PR

`prisma` variable doesn't exist in the scope of the function. `prismaUser` is probably what the author intended here.

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
