### PR TITLE
Update cascading deletes docs

### DIFF
--- a/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/index.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/index.mdx
@@ -8,11 +8,26 @@ metaDescription: 'How to implement cascading deletes at database level.'
 
 Cascading deletes allow you to define how foreign key relationships should be handled when you delete a record. For example, when you delete a user, you might use a cascading delete to remove that user's extended profile from a related table. By contrast, you might _not_ want to delete that user's blog posts.
 
-The guides in this section describe how to implement cascading deletes manually in the database and verify the results in Prisma Client.
-
 <Admonition type="warning">
 
-In [3.0.1](https://github.com/prisma/prisma/releases/tag/3.0.1) and later it is possible to do cascading deletes using [Referential actions](/concepts/components/prisma-schema/relations/referential-actions). Be sure to follow the [upgrade guide](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) before using this feature.
+❗ If using version [3.0.1](https://github.com/prisma/prisma/releases/tag/3.0.1) or later, it is possible to do cascading deletes using [Referential actions](/concepts/components/prisma-schema/relations/referential-actions). Follow that link for more information.
+  Be sure to follow the [upgrade guide](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) before using this feature.
+  
+```prisma file=schema.prisma highlight=4;normal
+model Post {
+  id       Int    @id @default(autoincrement())
+  title    String
+  author   User   @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  authorId Int
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  posts Post[]
+}
+```
+  
+The guides in this section describe how to implement cascading deletes manually in the database and verify the results in Prisma Client.
 
 </Admonition>
 


### PR DESCRIPTION
Some changes to the cascading deletes docs to make the note about using referential actions more prominent.

When adding cascading deletes to my prisma project I scanned past the existing warning, I'm hoping this change will make the new referential actions option more prominent to other users.
