### PR TITLE
Update styling on AdmotionWrapper

### DIFF
--- a/src/components/customMdx/admonition.tsx
+++ b/src/components/customMdx/admonition.tsx
@@ -50,7 +50,6 @@ const ChildContainer = styled.div`
 const AdmonitionWrapper = styled.span<{ type?: string }>`
   font-family: Inter;
   font-style: normal;
-  font-weight: 600;
   font-size: 16px;
   line-height: 24px;
   color: ${theme.colors.gray600} !important;


### PR DESCRIPTION
## Describe this PR

When giving an `Admotion` component 2 lines of text, text turns bold when it shouldn't.

## Changes

- Update css styling on `AdmotionWrapper`

## What issue does this fix?

[Fixes #3241](https://github.com/prisma/docs/issues/3241)

## Any other relevant information

N/A