### PR TITLE
Update 100-soft-delete-middleware.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/053-middleware/100-soft-delete-middleware.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-middleware/100-soft-delete-middleware.mdx
@@ -582,6 +582,8 @@ Number of SOFT deleted posts: 95
 
 - Not obvious from API that you aren't getting all records and that `{ where: { deleted: false } }` is part of the default query
 - Return type `update` affected because middleware changes the query to `updateMany`
+- Doesn't handle complex queries with `AND`, `OR`, `every`, etc...
+- Doesn't handle filtering when using `include` from another model.
 
 ## FAQ
 


### PR DESCRIPTION
## Describe this PR

Soft deletes aren't handled by prisma natively. [This article](https://github.com/prisma/docs/blob/main/content/200-concepts/100-components/02-prisma-client/053-middleware/100-soft-delete-middleware.mdx) talks about a workaround using middlewares.

There are two clear drawbacks of this approach that should be better documented in the "cons" list:

1. Can't handle complex queries with `AND`, `every`, etc (@chrissisura's [comment]
2. Can't handle `include`

Examples where soft deleted `rooms` would be returned in queries:

```typescript
const rooms = await prisma.room.findMany({
    where: {
        AND: [
            {
                something: true
            },
        ],
    },
})
```

```typescript
const building = await prisma.building.findUnique({
    where: {
        id: 1
    },
    include: {
        rooms: true
    }
})
```

## Changes

Added two drawbacks in the const list

## What issue does this fix?

Doesn't fix an issue, but it is discussed in #3398

