### PR TITLE
fix mongodb composite types example schema

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -38,7 +38,7 @@ We’ll use this schema for the examples that follow:
 model Product {
   id     String  @id @default(auto()) @map("_id") @db.ObjectId
   name   String  @unique
-  price  Decimal
+  price  Float
   colors Color[]
   sizes  Size[]
   photos Photo[]


### PR DESCRIPTION


## Changes


- Change type of `price` from `Decimal` (unsupported) to `Float` in the example schema. 


## What issue does this fix?

The MongoDB connector does not support the `Decimal` type. So this example would previous raise an error. [Reference](https://www.prisma.io/docs/concepts/database-connectors/mongodb#mapping-from-prisma-to-mongodb-types-on-migration) 


