### PR TITLE
fix: add missing awaits in pagination page

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
@@ -59,7 +59,7 @@ const results = await prisma.post.findMany({
 The following query returns all records where the `email` field contains `Prisma`, and sorts the result by the `title` field. The query skips the first 200 records and returns records 201 - 220.
 
 ```ts line-number
-const results = prisma.post.findMany({
+const results = await prisma.post.findMany({
   skip: 200,
   take: 20,
   where: {
@@ -82,7 +82,7 @@ The following example returns the first 4 `Post` records that contain the word `
 > **Note**: Since this is the first query, there is no cursor to pass in.
 
 ```ts line-number
-const firstQueryResults = prisma.post.findMany({
+const firstQueryResults = await prisma.post.findMany({
   take: 4,
   where: {
     title: {
@@ -108,7 +108,7 @@ The following diagram shows the IDs of the first 4 results - or page 1. The curs
 The second query returns the first 4 `Post` records that contain the word `"Prisma"` **after the supplied cursor** (in other words - IDs that are larger than **29**):
 
 ```ts line-number
-const secondQueryResults = prisma.post.findMany({
+const secondQueryResults = await prisma.post.findMany({
   take: 4,
   skip: 1, // Skip the cursor
 |  cursor: {
@@ -175,7 +175,7 @@ No, cursor pagination does not use cursors in the underlying database ([e.g. Pos
 ### Example: Filtering and cursor-based pagination
 
 ```ts line-number
-const secondQuery = prisma.post.findMany({
+const secondQuery = await prisma.post.findMany({
   take: 4,
   cursor: {
     id: myCursor,
@@ -202,7 +202,7 @@ To page backwards, set `take` to a negative value. The following query returns 4
 ```ts line-number
 const myOldCursor = 200
 
-const firstQueryResults = prisma.post.findMany({
+const firstQueryResults = await prisma.post.findMany({
   take: -4,
   skip: 1,
   cursor: {


### PR DESCRIPTION

"await" is missing from several of the example code blocks on this page: https://www.prisma.io/docs/concepts/components/prisma-client/pagination#example-filtering-and-cursor-based-pagination

## Changes

- added awaits to missing example blocks

