### PR TITLE
chore: hide cookie banner for percy diffs

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -386,6 +386,6 @@ ul.toc-list > li.is-current > a {
   
   /* hide cookie banner */
   #onetrust-consent-sdk {
-    visibility: hidden;
+    display: none;
   }
 }

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -383,4 +383,9 @@ ul.toc-list > li.is-current > a {
   section img {
     visibility: hidden;
   }
+  
+  /* hide cookie banner */
+  #onetrust-consent-sdk {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
Reduce noise, easier to review diff / read text that can sometime hide behind

Closes https://github.com/prisma/docs/issues/3227