### PR TITLE
Prisma 4 - additional guidance on upgrade documentation

### DIFF
--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -18,7 +18,7 @@ This section gives an overview of breaking changes in Prisma 4, grouped under [g
 
 We recommend to first address any Prisma schema validation errors, then pull your database to reflect new Prisma schema capabilities and finally fix any type errors in client and validate by running your test suite. 
 
-### Upgrade Prisma Schema
+### Upgrade your Prisma Schema
 
 1. carefully skim the list of changes and check if you are impacted by a breaking change
 2. review the Prisma schema validation errors (via `npx prisma validate` / or via the Prisma VS Code extension)
@@ -37,7 +37,7 @@ We recommend to first address any Prisma schema validation errors, then pull you
 5. review changes of the Prisma schema and verify validity
 6. continue with Prisma Client steps
 
-### Upgrade Prisma Client
+### Upgrade usage of Prisma Client
 
 1. carefully skim the list of changes to understand if you are impacted by a breaking change
     1. if yes, read the detailed upgrade instructions

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -23,15 +23,7 @@ We recommend to first address any Prisma schema validation errors, then pull you
 1. carefully skim the list of changes and check if you are impacted by a breaking change
 2. review the Prisma schema validation errors (via `npx prisma validate` / or via the Prisma VS Code extension)
     1. if you don't have validation errors, continue with step 3.
-    2. if you have validation errors
-        1. try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade.
-        2. it can only come from
-            1. Explicit unique constraints for 1:1 relations
-            2. Removed support for usage of `references` on implicit m:n relations
-            3. Enforcing uniqueness of referenced fields in the`references` argument in 1:1 and 1:m relations for MySQL
-            4. Removal of undocumented support for the `type` alias
-            5. Removal of the `sqlite` protocol for SQLite URLs
-            6. Better grammar for string literals
+    2. if you have validation errors, try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade. Vaidation errors can only come from the following changes: "Explicit unique constraints for 1:1 relations", "Removed support for usage of `references` on implicit m:n relations", "Enforcing uniqueness of referenced fields in the`references` argument in 1:1 and 1:m relations for MySQL", "Removal of undocumented support for the `type` alias", "Removal of the `sqlite` protocol for SQLite URLs" or "Better grammar for string literals"
 3. repeat until your Prisma schema is valid
 4. run `npx prisma db pull` to upgrade the Prisma schema to all new capabilities (e.g. `extendedIndexes`)
 5. review changes of the Prisma schema and verify validity

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -23,7 +23,15 @@ We recommend to first address any Prisma schema validation errors, then pull you
 1. carefully skim the list of changes and check if you are impacted by a breaking change
 2. review the Prisma schema validation errors (via `npx prisma validate` / or via the Prisma VS Code extension)
     1. if you don't have validation errors, continue with step 3.
-    2. if you have validation errors, try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade. Vaidation errors can only come from the following changes: "Explicit unique constraints for 1:1 relations", "Removed support for usage of `references` on implicit m:n relations", "Enforcing uniqueness of referenced fields in the`references` argument in 1:1 and 1:m relations for MySQL", "Removal of undocumented support for the `type` alias", "Removal of the `sqlite` protocol for SQLite URLs" or "Better grammar for string literals"
+    2. if you have validation errors
+        1. try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade.
+        2. it can only come from
+            - Explicit unique constraints for 1:1 relations
+            - Removed support for usage of `references` on implicit m:n relations
+            - Enforcing uniqueness of referenced fields in the `references` argument in 1:1 and 1:m relations for MySQL
+            - Removal of undocumented support for the `type` alias
+            - Removal of the `sqlite` protocol for SQLite URLs
+            - Better grammar for string literals
 3. repeat until your Prisma schema is valid
 4. run `npx prisma db pull` to upgrade the Prisma schema to all new capabilities (e.g. `extendedIndexes`)
 5. review changes of the Prisma schema and verify validity

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -20,29 +20,29 @@ We recommend to first address any Prisma schema validation errors, then pull you
 
 ### Upgrade your Prisma Schema
 
-1. carefully skim the list of changes and check if you are impacted by a breaking change
-2. review the Prisma schema validation errors (via `npx prisma validate` / or via the Prisma VS Code extension)
-    1. if you don't have validation errors, continue with step 3.
-    2. if you have validation errors
-        1. try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade.
-        2. it can only come from
+1. Carefully skim the list of changes and check if you are impacted by a breaking change.
+2. Review the Prisma schema validation errors (via `npx prisma validate` / or via the Prisma VS Code extension).
+    1. If you don't have validation errors, continue with step 3.
+    2. If you have validation errors:
+        1. Try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade.
+        2. It can only come from
             - Explicit unique constraints for 1:1 relations
             - Removed support for usage of `references` on implicit m:n relations
             - Enforcing uniqueness of referenced fields in the `references` argument in 1:1 and 1:m relations for MySQL
             - Removal of undocumented support for the `type` alias
             - Removal of the `sqlite` protocol for SQLite URLs
             - Better grammar for string literals
-3. repeat until your Prisma schema is valid
-4. run `npx prisma db pull` to upgrade the Prisma schema to all new capabilities (e.g. `extendedIndexes`)
-5. review changes of the Prisma schema and verify validity
-6. continue with Prisma Client steps
+3. Repeat until your Prisma schema is valid.
+4. Run `npx prisma db pull` to upgrade the Prisma schema to all new capabilities (e.g. `extendedIndexes`).
+5. Review changes of the Prisma schema and verify validity.
+6. Continue with Prisma Client steps.
 
 ### Upgrade usage of Prisma Client
 
-1. carefully skim the list of changes to understand if you are impacted by a breaking change
-    1. if yes, read the detailed upgrade instructions
-    2. if no, proceed with 2.
-2. some API changes in Prisma client are impacting runtime behavior, so please run your test suite
+1. Carefully skim the list of changes to understand if you are impacted by a breaking change.
+    1. If yes, read the detailed upgrade instructions.
+    2. If no, proceed with 2.
+2. Some API changes in Prisma client are impacting runtime behavior, so please run your test suite.
 
 Enjoy Prisma 4!
 

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -301,38 +301,6 @@ This is a breaking change for some existing schemas. After you upgrade to Prisma
 1. upgrade to the new Prisma 4 packages following [these instructions](#upgrade-the-prisma-and-prismaclient-packages-to-prisma-4)
 1. manually fix the validation errors in your Prisma schema.
 
-## Upgrade the <inlinecode>prisma</inlinecode> and <inlinecode>@prisma/client</inlinecode> packages to Prisma 4
-
-To upgrade to Prisma 4 from an earlier version, you need to update both the `prisma` and `@prisma/client` packages. Both the `prisma` and `@prisma/client` packages install with a caret `^` in their version number. This allows upgrades to new minor versions, but not major versions, to safeguard against breaking changes.
-
-To ignore the caret `^` and upgrade across major versions, you can use the `@4` tag when you upgrade with `npm`, or `yarn`:
-
-<Admonition type="alert">
-
-Before you upgrade, check each **breaking change** to see how the upgrade might affect your application.
-
-</Admonition>
-
-<TabbedContent tabs={[<FileWithIcon text="npm" icon="file"/>, <FileWithIcon text="yarn" icon="file"/>]}>
-
-<tab>
-
-```terminal
-npm install prisma@4 @prisma/client@4
-```
-
-</tab>
-
-<tab>
-
-```terminal
-yarn upgrade prisma@4 @prisma/client@4
-```
-
-</tab>
-
-</TabbedContent>
-
 ### Client changes
 
 This section includes changes that affect the Prisma Client.
@@ -471,3 +439,37 @@ Note:
 - This change does not affect the DMMF that Prisma passes to the generators.
 - You can use `getDmmf()`from `@prisma/internals` to access the schema property.
 - We still export `Prisma.dmmf.datamodel` into the generated Prisma Client.
+
+## Upgrade the <inlinecode>prisma</inlinecode> and <inlinecode>@prisma/client</inlinecode> packages to Prisma 4
+
+To upgrade to Prisma 4 from an earlier version, you need to update both the `prisma` and `@prisma/client` packages. Both the `prisma` and `@prisma/client` packages install with a caret `^` in their version number. This allows upgrades to new minor versions, but not major versions, to safeguard against breaking changes.
+
+To ignore the caret `^` and upgrade across major versions, you can use the `@4` tag when you upgrade with `npm`, or `yarn`:
+
+<Admonition type="alert">
+
+Before you upgrade, check each **breaking change** to see how the upgrade might affect your application.
+
+</Admonition>
+
+<TabbedContent tabs={[<FileWithIcon text="npm" icon="file"/>, <FileWithIcon text="yarn" icon="file"/>]}>
+
+<tab>
+
+```terminal
+npm install prisma@4 @prisma/client@4
+```
+
+</tab>
+
+<tab>
+
+```terminal
+yarn upgrade prisma@4 @prisma/client@4
+```
+
+</tab>
+
+</TabbedContent>
+
+

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -18,6 +18,34 @@ This section gives an overview of breaking changes in Prisma 4, grouped under [g
 
 We recommend to first address any Prisma schema validation errors, then pull your database to reflect new Prisma schema capabilities and finally fix any type errors in client and validate by running your test suite. 
 
+### Upgrade Prisma Schema
+
+1. carefully skim the list of changes and check if you are impacted by a breaking change
+2. review the Prisma schema validation errors (via `npx prisma validate` / or via the Prisma VS Code extension)
+    1. if you don't have validation errors, continue with step 3.
+    2. if you have validation errors
+        1. try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade.
+        2. it can only come from
+            - Explicit unique constraints for 1:1 relations
+            - Removed support for usage of `references` on implicit m:n relations
+            - Enforcing uniqueness of referenced fields in the`references` argument in 1:1 and 1:m relations for MySQL
+            - Removal of undocumented support for the `type` alias
+            - Removal of the `sqlite` protocol for SQLite URLs
+            - Better grammar for string literals
+3. repeat until your Prisma schema is valid
+4. run `npx prisma db pull` to upgrade the Prisma schema to all new capabilities (e.g. `extendedIndexes`)
+5. review changes of the Prisma schema and verify validity
+6. continue with Prisma Client steps
+
+### Upgrade Prisma Client
+
+1. carefully skim the list of changes to understand if you are impacted by a breaking change
+    1. if yes, read the detailed upgrade instructions
+    2. if no, proceed with 2.
+2. some API changes in Prisma client are impacting runtime behavior, so please run your test suite
+
+Enjoy Prisma 4 💫
+
 ### General changes
 
 This section includes changes that affect both the Prisma Schema and the Prisma Client.
@@ -27,145 +55,6 @@ This section includes changes that affect both the Prisma Schema and the Prisma 
 From Prisma version 4.0.0, the minimum version of Node.js that we support is 14.17.x. If you use an earlier version of Node.js, you will need to update it.
 
 See our [system requirements](/reference/system-requirements) for all minimum version requirements.
-
-### Client changes
-
-This section includes changes that affect the Prisma Client.
-
-#### Raw query type mapping: scalar values are now deserialized as their correct JavaScript types
-
-In versions 3.14.x and 3.15.x, [raw query type mapping](/concepts/components/prisma-client/raw-database-access#raw-query-type-mapping) was available with the Preview feature `improvedQueryRaw`. In version 4.0.0, we have made raw query type mapping Generally Available. You do not need to use `improvedQueryRaw` to get this functionality in versions 4.0.0 and later.
-
-Raw queries now deserialize scalar values to their corresponding JavaScript types. Note that Prisma infers types from the values themselves and not from the Prisma Schema types.
-
-Example query and response:
-
-```ts
-const res =
-  await prisma.$queryRaw`SELECT bigint, bytes, decimal, date FROM "Table";`
-console.log(res) // [{ bigint: BigInt("123"), bytes: Buffer.from([1, 2]), decimal: new Prisma.Decimal("12.34"), date: Date("<some_date>") }]
-```
-
-##### Upgrade path
-
-From version 4.0.0, some data types returned by `queryRaw` or `queryRawUnsafe` are different, as follows:
-
-| Data type  | Before version 4.0.0  | From version 4.0.0    |
-| ---------- | --------------------- | --------------------- |
-| `DateTime` | Returned as `String`  | Returned as `Date`    |
-| `Numeric`  | Returned as `Float`   | Returned as `Decimal` |
-| `Bytes`    | Returned as `String`  | Returned as `Buffer`  |
-| `Int64`    | Returned as `Integer` | Returned as `BigInt`  |
-
-If you use `queryRaw` or `queryRawUnsafe` to return any of the above data types, then you must change your code to handle the new types.
-
-For example, if you return `DateTime` data, then you need to take into account the following:
-
-- You no longer need to manually instantiate a `DateTime` object for the returned data.
-- If your code currently uses the returned `String` data, then you now need to convert the `DateTime` object to a `String`.
-
-You must make equivalent code changes for the other data types in the table above.
-
-#### Raw query mapping: PostgreSQL type-casts
-
-In versions 3.14.x and 3.15.x, [raw query type mapping](/concepts/components/prisma-client/raw-database-access#raw-query-type-mapping) was available with the Preview feature `improvedQueryRaw`. In version 4.0.0, we have made raw query type mapping Generally Available. You do not need to use `improvedQueryRaw` to get this functionality in versions 4.0.0 and later.
-
-Before version 4.0.0, many PostgreSQL type-casts did not work. We have tightened the type coercion rules so that all type-casts now work. As a result, some implicit casts now fail.
-
-##### Upgrade path
-
-We recommend that you re-test your use of `$queryRaw` to ensure that the types you pass into your raw queries match the types that PostgreSQL expects.
-
-For example, in version 4.0.0, the following query fails:
-
-```js
-await prisma.$queryRaw`select length(${42});`
-// ERROR: function length(integer) does not exist
-// HINT: No function matches the given name and argument types. You might need to add explicit type casts.
-```
-
-This is because PostgreSQL’s `length` function expects `text` as input. Prisma used to silently coerce `42` to `text`, but does not do this in version 4.0.0. To fix this, explicitly cast `42` to `text` as follows:
-
-```js
-await prisma.$queryRaw`select length(${42}::text);`
-```
-
-#### Raw query mapping: PostgreSQL and JavaScript integers
-
-In versions 3.14.x and 3.15.x, [raw query type mapping](/concepts/components/prisma-client/raw-database-access#raw-query-type-mapping) was available with the Preview feature `improvedQueryRaw`. In version 4.0.0, we have made raw query type mapping Generally Available. You do not need to use `improvedQueryRaw` to get this functionality in versions 4.0.0 and later.
-
-Prisma sends JavaScript integers to PostgreSQL as `INT8`. This might conflict with your user-defined functions that accept only `INT4` as input.
-
-##### Upgrade path
-
-If you use `$queryRaw` or parametrized `$queryRawUnsafe`queries with a PostgreSQL database, do one of the following:
-
-- Update the input types of any integers in your user-defined functions to `INT8`, or
-- Cast any integers in your query parameters to `INT4`.
-
-#### <inlineCode>DbNull</inlineCode>, <inlineCode>JsonNull</inlineCode> and <inlineCode>AnyNull</inlineCode> are now objects
-
-JavaScript `null` is ambiguous for JSON columns, so Prisma uses `DbNull`, `JsonNull`, and `AnyNull` to distinguish between the database `NULL` value and the JSON `null` value. Before version 4.0.0, `DbNull`, `JsonNull`, and `AnyNull` were string constants. From version 4.0.0, they are objects.
-
-See [Filtering by null values](/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values) for more information.
-
-##### Upgrade path
-
-1. If you use literal strings to address these values, then you must replace them with the following named constants:
-
-   - `DbNull`: replace with `Prisma.DbNull`
-   - `JsonNull`: replace with `Prisma.JsonNull`
-   - `AnyNull`: replace with `Prisma.AnyNull`
-
-   If you already use these named constants, then you do not need to take any action.
-
-1. If you now get a type error when you pass `Prisma.DbNull` as the value of a JSON field, then this probably indicates a bug in your code that our types did not catch before version 4.0.0. The field where you tried to store `DbNull` is probably not nullable in your schema. As a result, a literal `DbNull` string was stored in the database instead of `NULL`.
-1. You might now encounter a type error or runtime validation error when you use `Prisma.DbNull`, `Prisma.JsonNull`, or `Prisma.AnyNull` with MongoDB. This was never valid, but was silently accepted prior to Prisma 4. You need to review your data and change these fields to `null`.
-1. If you pass in dynamic JSON to a JSON column in Prisma Client (for example `prisma.findMany({where: { jsonColumn: someJson } })`), then you must check that `someJson`cannot be the string "DBNull", "JsonNull", or "AnyNull". If it is any of these values, then the query will return different results in version 4.0.0.
-
-#### Default fields on composite types in MongoDB
-
-From version 4.0.0, if you carry out a database read on a composite type when all of the following conditions are true, then Prisma Client inserts the default value into the result.
-
-Conditions:
-
-- A field on the composite type is required, and
-- this field has a default value, and
-- this field is not present in the returned document or documents.
-
-This behavior is now consistent with the behavior for model fields.
-
-To learn more, see [Default values on required composite types](/concepts/components/prisma-client/composite-types#default-values-on-required-composite-types).
-
-##### Upgrade path
-
-If you currently rely on a return value of `null`, then you need to refactor your code to handle the default value that is now returned in Prisma 4.
-
-#### Rounding errors on big numbers in SQLite
-
-SQLite is a loosely-typed database. If your schema has a field with type `Int`, then Prisma prevents you from inserting a value larger than an integer. However, nothing prevents the database from directly accepting a bigger number. These manually-inserted big numbers cause rounding errors when queried.
-
-To avoid this problem, Prisma version 4.0.0 and later checks numbers on the way out of the database to verify that they fit within the boundaries of an integer. If a number does not fit, then Prisma throws a P2023 error, such as:
-
-```
-Inconsistent column data: Conversion failed:
-Value 9223372036854775807 does not fit in an INT column,
-try migrating the 'int' column type to BIGINT
-```
-
-##### Upgrade path
-
-If you use Prisma in conjunction with SQLite, then you need to find any code that queries `Int` fields and ensure that it handles any P2023 errors that might be returned.
-
-#### Prisma no longer exports `Prisma.dmmf.schema` into the generated Prisma Client
-
-From version 4.0.0, Prisma no longer exports `Prisma.dmmf.schema` into the generated Prisma Client. This makes the generated Prisma Client much more efficient, and also avoids some memory leaks with Jest.
-
-Note:
-
-- This change does not affect the DMMF that Prisma passes to the generators.
-- You can use `getDmmf()`from `@prisma/internals` to access the schema property.
-- We still export `Prisma.dmmf.datamodel` into the generated Prisma Client.
 
 ### Schema changes
 
@@ -441,5 +330,144 @@ yarn upgrade prisma@4 @prisma/client@4
 ```
 
 </tab>
+
+### Client changes
+
+This section includes changes that affect the Prisma Client.
+
+#### Raw query type mapping: scalar values are now deserialized as their correct JavaScript types
+
+In versions 3.14.x and 3.15.x, [raw query type mapping](/concepts/components/prisma-client/raw-database-access#raw-query-type-mapping) was available with the Preview feature `improvedQueryRaw`. In version 4.0.0, we have made raw query type mapping Generally Available. You do not need to use `improvedQueryRaw` to get this functionality in versions 4.0.0 and later.
+
+Raw queries now deserialize scalar values to their corresponding JavaScript types. Note that Prisma infers types from the values themselves and not from the Prisma Schema types.
+
+Example query and response:
+
+```ts
+const res =
+  await prisma.$queryRaw`SELECT bigint, bytes, decimal, date FROM "Table";`
+console.log(res) // [{ bigint: BigInt("123"), bytes: Buffer.from([1, 2]), decimal: new Prisma.Decimal("12.34"), date: Date("<some_date>") }]
+```
+
+##### Upgrade path
+
+From version 4.0.0, some data types returned by `queryRaw` or `queryRawUnsafe` are different, as follows:
+
+| Data type  | Before version 4.0.0  | From version 4.0.0    |
+| ---------- | --------------------- | --------------------- |
+| `DateTime` | Returned as `String`  | Returned as `Date`    |
+| `Numeric`  | Returned as `Float`   | Returned as `Decimal` |
+| `Bytes`    | Returned as `String`  | Returned as `Buffer`  |
+| `Int64`    | Returned as `Integer` | Returned as `BigInt`  |
+
+If you use `queryRaw` or `queryRawUnsafe` to return any of the above data types, then you must change your code to handle the new types.
+
+For example, if you return `DateTime` data, then you need to take into account the following:
+
+- You no longer need to manually instantiate a `DateTime` object for the returned data.
+- If your code currently uses the returned `String` data, then you now need to convert the `DateTime` object to a `String`.
+
+You must make equivalent code changes for the other data types in the table above.
+
+#### Raw query mapping: PostgreSQL type-casts
+
+In versions 3.14.x and 3.15.x, [raw query type mapping](/concepts/components/prisma-client/raw-database-access#raw-query-type-mapping) was available with the Preview feature `improvedQueryRaw`. In version 4.0.0, we have made raw query type mapping Generally Available. You do not need to use `improvedQueryRaw` to get this functionality in versions 4.0.0 and later.
+
+Before version 4.0.0, many PostgreSQL type-casts did not work. We have tightened the type coercion rules so that all type-casts now work. As a result, some implicit casts now fail.
+
+##### Upgrade path
+
+We recommend that you re-test your use of `$queryRaw` to ensure that the types you pass into your raw queries match the types that PostgreSQL expects.
+
+For example, in version 4.0.0, the following query fails:
+
+```js
+await prisma.$queryRaw`select length(${42});`
+// ERROR: function length(integer) does not exist
+// HINT: No function matches the given name and argument types. You might need to add explicit type casts.
+```
+
+This is because PostgreSQL’s `length` function expects `text` as input. Prisma used to silently coerce `42` to `text`, but does not do this in version 4.0.0. To fix this, explicitly cast `42` to `text` as follows:
+
+```js
+await prisma.$queryRaw`select length(${42}::text);`
+```
+
+#### Raw query mapping: PostgreSQL and JavaScript integers
+
+In versions 3.14.x and 3.15.x, [raw query type mapping](/concepts/components/prisma-client/raw-database-access#raw-query-type-mapping) was available with the Preview feature `improvedQueryRaw`. In version 4.0.0, we have made raw query type mapping Generally Available. You do not need to use `improvedQueryRaw` to get this functionality in versions 4.0.0 and later.
+
+Prisma sends JavaScript integers to PostgreSQL as `INT8`. This might conflict with your user-defined functions that accept only `INT4` as input.
+
+##### Upgrade path
+
+If you use `$queryRaw` or parametrized `$queryRawUnsafe`queries with a PostgreSQL database, do one of the following:
+
+- Update the input types of any integers in your user-defined functions to `INT8`, or
+- Cast any integers in your query parameters to `INT4`.
+
+#### <inlineCode>DbNull</inlineCode>, <inlineCode>JsonNull</inlineCode> and <inlineCode>AnyNull</inlineCode> are now objects
+
+JavaScript `null` is ambiguous for JSON columns, so Prisma uses `DbNull`, `JsonNull`, and `AnyNull` to distinguish between the database `NULL` value and the JSON `null` value. Before version 4.0.0, `DbNull`, `JsonNull`, and `AnyNull` were string constants. From version 4.0.0, they are objects.
+
+See [Filtering by null values](/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values) for more information.
+
+##### Upgrade path
+
+1. If you use literal strings to address these values, then you must replace them with the following named constants:
+
+   - `DbNull`: replace with `Prisma.DbNull`
+   - `JsonNull`: replace with `Prisma.JsonNull`
+   - `AnyNull`: replace with `Prisma.AnyNull`
+
+   If you already use these named constants, then you do not need to take any action.
+
+1. If you now get a type error when you pass `Prisma.DbNull` as the value of a JSON field, then this probably indicates a bug in your code that our types did not catch before version 4.0.0. The field where you tried to store `DbNull` is probably not nullable in your schema. As a result, a literal `DbNull` string was stored in the database instead of `NULL`.
+1. You might now encounter a type error or runtime validation error when you use `Prisma.DbNull`, `Prisma.JsonNull`, or `Prisma.AnyNull` with MongoDB. This was never valid, but was silently accepted prior to Prisma 4. You need to review your data and change these fields to `null`.
+1. If you pass in dynamic JSON to a JSON column in Prisma Client (for example `prisma.findMany({where: { jsonColumn: someJson } })`), then you must check that `someJson`cannot be the string "DBNull", "JsonNull", or "AnyNull". If it is any of these values, then the query will return different results in version 4.0.0.
+
+#### Default fields on composite types in MongoDB
+
+From version 4.0.0, if you carry out a database read on a composite type when all of the following conditions are true, then Prisma Client inserts the default value into the result.
+
+Conditions:
+
+- A field on the composite type is required, and
+- this field has a default value, and
+- this field is not present in the returned document or documents.
+
+This behavior is now consistent with the behavior for model fields.
+
+To learn more, see [Default values on required composite types](/concepts/components/prisma-client/composite-types#default-values-on-required-composite-types).
+
+##### Upgrade path
+
+If you currently rely on a return value of `null`, then you need to refactor your code to handle the default value that is now returned in Prisma 4.
+
+#### Rounding errors on big numbers in SQLite
+
+SQLite is a loosely-typed database. If your schema has a field with type `Int`, then Prisma prevents you from inserting a value larger than an integer. However, nothing prevents the database from directly accepting a bigger number. These manually-inserted big numbers cause rounding errors when queried.
+
+To avoid this problem, Prisma version 4.0.0 and later checks numbers on the way out of the database to verify that they fit within the boundaries of an integer. If a number does not fit, then Prisma throws a P2023 error, such as:
+
+```
+Inconsistent column data: Conversion failed:
+Value 9223372036854775807 does not fit in an INT column,
+try migrating the 'int' column type to BIGINT
+```
+
+##### Upgrade path
+
+If you use Prisma in conjunction with SQLite, then you need to find any code that queries `Int` fields and ensure that it handles any P2023 errors that might be returned.
+
+#### Prisma no longer exports `Prisma.dmmf.schema` into the generated Prisma Client
+
+From version 4.0.0, Prisma no longer exports `Prisma.dmmf.schema` into the generated Prisma Client. This makes the generated Prisma Client much more efficient, and also avoids some memory leaks with Jest.
+
+Note:
+
+- This change does not affect the DMMF that Prisma passes to the generators.
+- You can use `getDmmf()`from `@prisma/internals` to access the schema property.
+- We still export `Prisma.dmmf.datamodel` into the generated Prisma Client.
 
 </TabbedContent>

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -26,12 +26,12 @@ We recommend to first address any Prisma schema validation errors, then pull you
     2. if you have validation errors
         1. try to map the validation error to a change from the list to understand which change caused the invalid Prisma schema. Now read the provided instructions how to upgrade.
         2. it can only come from
-            - Explicit unique constraints for 1:1 relations
-            - Removed support for usage of `references` on implicit m:n relations
-            - Enforcing uniqueness of referenced fields in the`references` argument in 1:1 and 1:m relations for MySQL
-            - Removal of undocumented support for the `type` alias
-            - Removal of the `sqlite` protocol for SQLite URLs
-            - Better grammar for string literals
+            1. Explicit unique constraints for 1:1 relations
+            2. Removed support for usage of `references` on implicit m:n relations
+            3. Enforcing uniqueness of referenced fields in the`references` argument in 1:1 and 1:m relations for MySQL
+            4. Removal of undocumented support for the `type` alias
+            5. Removal of the `sqlite` protocol for SQLite URLs
+            6. Better grammar for string literals
 3. repeat until your Prisma schema is valid
 4. run `npx prisma db pull` to upgrade the Prisma schema to all new capabilities (e.g. `extendedIndexes`)
 5. review changes of the Prisma schema and verify validity

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -323,6 +323,8 @@ yarn upgrade prisma@4 @prisma/client@4
 
 </tab>
 
+</TabbedContent>
+
 ### Client changes
 
 This section includes changes that affect the Prisma Client.
@@ -461,5 +463,3 @@ Note:
 - This change does not affect the DMMF that Prisma passes to the generators.
 - You can use `getDmmf()`from `@prisma/internals` to access the schema property.
 - We still export `Prisma.dmmf.datamodel` into the generated Prisma Client.
-
-</TabbedContent>

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -14,7 +14,9 @@ Prisma 4 introduces a number of **breaking changes** when you upgrade from an ea
 
 ## Breaking changes
 
-This section gives an overview of breaking changes in Prisma 4, grouped under [general changes](#general-changes) that affect both the Prisma Schema and the Prisma Client, [Client changes](#client-changes) and [Schema changes](#schema-changes).
+This section gives an overview of breaking changes in Prisma 4, grouped under [general changes](#general-changes) that affect both the Prisma Schema and the Prisma Client, [Schema changes](#schema-changes) and [Client changes](#client-changes).
+
+We recommend to first address any Prisma schema validation errors, then pull your database to reflect new Prisma schema capabilities and finally fix any type errors in client and validate by running your test suite. 
 
 ### General changes
 

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -44,7 +44,7 @@ We recommend to first address any Prisma schema validation errors, then pull you
     2. if no, proceed with 2.
 2. some API changes in Prisma client are impacting runtime behavior, so please run your test suite
 
-Enjoy Prisma 4 💫
+Enjoy Prisma 4!
 
 ### General changes
 


### PR DESCRIPTION
Add additional guidance to top section of Prisma 4 upgrade path:

- high level guidance for schema
- high level guidance for client
- changed order of grouping so schema comes first (as this is how users need to upgrade, schema first)