### PR TITLE
fix: add error handling for allMdx

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -100,6 +100,11 @@ exports.createPages = ({ graphql, actions }) => {
         }
       }
     `).then((result) => {
+      // For example, a `SyntaxError` might show up here.
+      if (result.errors) {
+        return reject(result.errors)
+      }
+
       result.data.allMdx.edges.forEach(({ node }) => {
         const { langSwitcher, dbSwitcher } = node.frontmatter
         if (langSwitcher && dbSwitcher) {
@@ -152,8 +157,11 @@ exports.createPages = ({ graphql, actions }) => {
           })
         }
       })
+
       resolve()
+
       const redirects = result.data.site.siteMetadata.redirects
+
       redirects
         .filter((redirect) => !redirect.from.includes('#'))
         .map((redirect) =>


### PR DESCRIPTION
Running `npm run build` now changes from

before
```
 ERROR 

UNHANDLED REJECTION Cannot read properties of null (reading 'allMdx')

  TypeError: Cannot read properties of null (reading 'allMdx')
  
  - gatsby-node.js:108 
    /Users/j42/Dev/docs/gatsby-node.js:108:19
  
  - runMicrotasks
  
  - task_queues:96 processTicksAndRejections
    node:internal/process/task_queues:96:5
  
  - task_queues:65 runNextTicks
    node:internal/process/task_queues:65:3
  
  - timers:437 processImmediate
    node:internal/timers:437:9
  

not finished Generating image thumbnails - 53.909s
not finished createPages - 30.075s
```

after
```
 ERROR #11321  PLUGIN

"gatsby-node.js" threw an error while running the createPages lifecycle:

/Users/j42/Dev/docs/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading
-to-prisma-4.mdx: Expected corresponding JSX closing tag for <section>. (398:5)

  396 | <li parentName="ul">{`You can use `}<inlineCode 
parentName="li">{`getDmmf()`}</inlineCode>{`from `}<inlineCode 
parentName="li">{`@prisma/internals`}</inlineCode>{` to access the schema property.`}</li>
  397 | <li parentName="ul">{`We still export `}<inlineCode 
parentName="li">{`Prisma.dmmf.datamodel`}</inlineCode>{` into the generated Prisma
Client.`}</li>
> 398 | </ul></TabbedContent></section></section></section>
      |      ^
  399 |
  400 |     </MDXLayout>
  401 |   )



  SyntaxError: 
/Users/j42/Dev/docs/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-
upgrading-to-prisma-4.mdx: Expected corresponding JSX closing tag for <section>. (398:5)
    396 | <li parentName="ul">{`You can use `}<inlineCode par
entName="li">{`getDmmf()`}</inlineCode>{`from `}<inlineCode parentNa
me="li">{`@prisma/internals`}</inlineCode>{` to access the sche  ma property.`}</li>
    397 | <li parentName="ul">{`We still export `}<  inlineCode 
parentName="li">{`Prisma.dmmf.datamodel`}</inli  neCode>{` into the generated Prisma
Client.`}</li>  m
  > 398 | </ul></TabbedContent></section></section></section>  [39m
        |      ^
    399 |
    400 |     </MDXLayout>
    401 |   )
  
  - credentials.js:61 instantiate
    [docs]/[@babel]/parser/src/parse-error/credentials.js:61:22
  
  - parse-error.js:58 toParseError
    [docs]/[@babel]/parser/src/parse-error.js:58:12
  
  - index.js:1736 Object.raise
    [docs]/[@babel]/parser/src/tokenizer/index.js:1736:19
  
  - index.js:524 Object.jsxParseElementAt
    [docs]/[@babel]/parser/src/plugins/jsx/index.js:524:18
  
  - index.js:477 Object.jsxParseElementAt
    [docs]/[@babel]/parser/src/plugins/jsx/index.js:477:34
  
  - index.js:477 Object.jsxParseElementAt
    [docs]/[@babel]/parser/src/plugins/jsx/index.js:477:34
  
  - index.js:477 Object.jsxParseElementAt
    [docs]/[@babel]/parser/src/plugins/jsx/index.js:477:34
  
  - index.js:477 Object.jsxParseElementAt
    [docs]/[@babel]/parser/src/plugins/jsx/index.js:477:34
  
  - index.js:558 Object.jsxParseElement
    [docs]/[@babel]/parser/src/plugins/jsx/index.js:558:19
  
  - index.js:574 Object.parseExprAtom
    [docs]/[@babel]/parser/src/plugins/jsx/index.js:574:21
  
  - expression.js:684 Object.parseExprSubscripts
    [docs]/[@babel]/parser/src/parser/expression.js:684:23
  
  - expression.js:663 Object.parseUpdate
    [docs]/[@babel]/parser/src/parser/expression.js:663:21
  
  - expression.js:632 Object.parseMaybeUnary
    [docs]/[@babel]/parser/src/parser/expression.js:632:23
  
  - expression.js:384 Object.parseMaybeUnaryOrPrivate
    [docs]/[@babel]/parser/src/parser/expression.js:384:14
  
  - expression.js:394 Object.parseExprOps
    [docs]/[@babel]/parser/src/parser/expression.js:394:23
  
  - expression.js:352 Object.parseMaybeConditional
    [docs]/[@babel]/parser/src/parser/expression.js:352:23
  

not finished Generating image thumbnails - 61.496s
failed createPages - 34.914s
```

No error handling made it hard to know what was broken during the following PR
https://github.com/prisma/docs/pull/3335