### PR TITLE
3333 p4 post publish hotfixes

### DIFF
--- a/content/200-concepts/200-database-connectors/05-sqlite.mdx
+++ b/content/200-concepts/200-database-connectors/05-sqlite.mdx
@@ -86,7 +86,3 @@ datasource db {
   url      = "file:/Users/janedoe/dev.db"
 }
 ```
-
-```
-
-```

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -52,9 +52,7 @@ This section includes changes that affect both the Prisma Schema and the Prisma 
 
 #### Node.js minimum version change
 
-From Prisma version 4.0.0, the minimum version of Node.js that we support is 14.17.x. If you use an earlier version of Node.js, you will need to update it.
-
-See our [system requirements](/reference/system-requirements) for all minimum version requirements.
+In Prisma version 4.0.0, we've changed the [minimum version of Node.js that we support](/reference/system-requirements). If you use an earlier version of Node.js, you will need to update it.
 
 ### Schema changes
 

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/08-upgrade-from-mongodb-beta.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/08-upgrade-from-mongodb-beta.mdx
@@ -20,8 +20,8 @@ We unfortunately can't cover all possible scenarios or changes required, but thi
 ## Requirements
 
 - Must be running MongoDB 4.2+ as a replica set (MongoDB Atlas does this for you automatically)
-- Node.js 14.17.x or later, or Node.js 16.x or later
-- TypeScript 4.1.x or later
+- Node.js: see [system requirements](/reference/system-requirements)
+- TypeScript: see [system requirements](/reference/system-requirements)
 
 ## Installing Prisma 3.12.0 or later
 


### PR DESCRIPTION
This is a couple of post-publish hotfixes:

- SqLite page: removed a stray code block
- Prisma 4 upgrade guide: Removed the explicit reference to our minimum Node.js supported version, and emphasized the link to our minimum requirements page

This is done and merged