### PR TITLE
Update 650-caveats-when-deploying-to-aws-platforms.mdx

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/650-caveats-when-deploying-to-aws-platforms.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/650-caveats-when-deploying-to-aws-platforms.mdx
@@ -16,7 +16,7 @@ Prisma is compatible with AWS RDS Proxy. However, there is no benefit in using i
 
 > "Your connections to the proxy can enter a state known as pinning. When a connection is pinned, each later transaction uses the same underlying database connection until the session ends. Other client connections also can't reuse that database connection until the session ends. The session ends when the client connection is dropped." - [AWS RDS Proxy Docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy.html)
 
-Prepared statements (of any size) or query statements greater than 16 KB cause RDS Proxy to pin the session. Because Prisma uses prepared statements for all queries, you won't see any benefit when using RDS Proxy with Prisma.
+[Prepared statements (of any size) or query statements greater than 16 KB cause RDS Proxy to pin the session.](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy-managing.html#rds-proxy-pinning.all) Because Prisma uses prepared statements for all queries, you won't see any benefit when using RDS Proxy with Prisma.
 
 ## AWS Elastic Beanstalk
 


### PR DESCRIPTION
Added a link to the AWS docs that reference Prepared Statements wrt the RDS Proxy.

## Describe this PR

AWS RDS Proxy has a dedicated page that references disqualifiers for all DBMS engines. I added a link to make it easier to find why using RDS Proxy + Prisma isn't super helpful.

## Changes

- Added a link

## What issue does this fix?

N/A
