### PR TITLE
docs: update sequelize comparison regarding to relation filters

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
+++ b/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
@@ -189,7 +189,7 @@ const posts = await Post.findAll({
 })
 ```
 
-> **Note**: Sequelize using [the '$nested.column$' syntax](https://sequelize.org/docs/v6/advanced-association-concepts/eager-loading/#complex-where-clauses-at-the-top-level) to perform relation filters.
+> **Note**: Sequelize using [the `$nested.column$` syntax](https://sequelize.org/docs/v6/advanced-association-concepts/eager-loading/#complex-where-clauses-at-the-top-level) to perform relation filters.
 
 ### Pagination
 

--- a/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
+++ b/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
@@ -177,7 +177,19 @@ const posts = await prisma.user.findMany({
 
 **Sequelize**
 
-Sequelize [doesn't offer a dedicated API for relation filters](https://github.com/sequelize/sequelize/issues/10943). You can get similar functionality by sending a raw SQL query to the database.
+```ts
+const posts = await Post.findAll({
+  where: {
+    '$Users.role$': { [Op.ne]: 'user' }
+  },
+  include: [{
+    model: User,
+    as: 'Users'
+  }]
+})
+```
+
+> **Note**: Sequelize using [the '$nested.column$' syntax](https://sequelize.org/docs/v6/advanced-association-concepts/eager-loading/#complex-where-clauses-at-the-top-level) to perform relation filters.
 
 ### Pagination
 


### PR DESCRIPTION
## Describe this PR

Sequelize use `the '$nested.column$' syntax.` to perform relation filters.

## Changes

- Update sequelize comparison regarding relation filters

## What issue does this fix?

-

## Any other relevant information

[Reference](https://sequelize.org/docs/v6/advanced-association-concepts/eager-loading/#complex-where-clauses-at-the-top-level)
