### PR TITLE
docs: update sequelize comparison regarding cursor pagination

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
+++ b/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
@@ -205,6 +205,23 @@ const cc = prisma.post.findMany({
 
 **Sequelize**
 
+Cursor pagination:
+
+```ts
+const posts = await Post.findAll({
+    limit: 20,
+    where: {
+        id: {
+            [Op.gt]: 242
+        }
+    }
+});
+```
+
+> **Note**: Sequelize use the [Sequelize operators](https://sequelize.org/docs/v6/core-concepts/model-querying-basics/#operators) to perform cursor pagination.
+
+Offset pagination:
+
 ```ts
 const posts = await Post.findAll({
   offset: 5,


### PR DESCRIPTION
## Describe this PR

Sequelize use the [Sequelize operators](https://sequelize.org/docs/v6/core-concepts/model-querying-basics/#operators) to perform cursor pagination.

## Changes

- Update sequelize comparison regarding relation cursor pagination.

## What issue does this fix?

-

## Any other relevant information

[Reference](https://sequelize.org/docs/v6/core-concepts/model-querying-basics/#operators)
