### PR TITLE
docs: fix typos in what-is-prisma

### DIFF
--- a/content/200-concepts/050-overview/100-what-is-prisma/index.mdx
+++ b/content/200-concepts/050-overview/100-what-is-prisma/index.mdx
@@ -153,7 +153,7 @@ prisma generate
 
 #### Using Prisma Client to send queries to your database
 
-Once Prisma Client has been generated, you can import in your code and send queries to your database. This is what the setup code looks like.
+Once Prisma Client has been generated, you can import it in your code and send queries to your database. This is what the setup code looks like.
 
 ##### Import and instantiate Prisma Client
 
@@ -263,7 +263,7 @@ To learn more about the Prisma Migrate workflow, see:
 
 ### SQL migrations and introspection
 
-If for some reasons, you can not or do not want to use Prisma Migrate, you can still use introspection to update your Prisma schema from your database schema.
+If for some reason, you can not or do not want to use Prisma Migrate, you can still use introspection to update your Prisma schema from your database schema.
 The typical workflow when using **SQL migrations and introspection** is slightly different:
 
 1. Manually adjust your database schema using SQL or a third-party migration tool


### PR DESCRIPTION
## Describe this PR

Fixes two minor typos in 'What is Prisma?'

## Changes

Two typos

## What issue does this fix?

N/A
