### PR TITLE
Add `@@ignore` as way to prevent client generating model

### DIFF
--- a/content/200-concepts/100-components/04-introspection.mdx
+++ b/content/200-concepts/100-components/04-introspection.mdx
@@ -357,4 +357,4 @@ Introspecting only a subset of your database schema is [not yet officially suppo
 
 However, you can achieve this by creating a new database user that only has access to the tables which you'd like to see represented in your Prisma schema, and then perform the introspection using that user. The introspection will then only include the tables the new user has access to.
 
-If your goal is to exclude certain models from the [Prisma Client generation](prisma-client/working-with-prismaclient/generating-prisma-client), you can also manually delete the models that should be excluded from your Prisma schema. Note however that they will be added again when you run `prisma db pull`.
+If your goal is to exclude certain models from the [Prisma Client generation](prisma-client/working-with-prismaclient/generating-prisma-client), you can add the [`@@ignore` attribute](../../reference/api-reference/prisma-schema-reference#ignore-1) to the model definition in your Prisma schema. Ignored models are excluded from the generated Prisma Client. 


### PR DESCRIPTION
Mention `@@ignore` as a way to prevent client generation for certain models

## Describe this PR

The introspection article currently suggests manually removing models from the prisma schema to prevent them from being generated by the client. However this is not an ideal workaround as: 

1. One can no longer use migrate as prisma would try to delete the table from the database next time one runs `prisma migrate dev` or `prisma db push` 
2. The table will be added back to the schema when one does `prisma db pull` 

The [@@ignore](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#ignore-1)  attribute provides a much cleaner solution to achieve the same thing. 


