### PR TITLE
fix: rename deleteAll() to deleteMany()

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -331,6 +331,7 @@ When you run an Introspection, Prisma compares all the foreign keys in the datab
 After introspecting, you can review the non-default clauses in your schema. The most important clause to review is `onDelete`, which defaults to `Cascade` in 2.25.0 and earlier.
 
 <Admonition type="alert">
+
 If you are using either the [`delete()`](../../../prisma-client/crud#delete-a-single-record) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods, **[cascading deletes](#how-to-use-cascading-deletes) will now be performed** as the `referentialActions` preview feature **removed the safety net in Prisma Client that previously prevented cascading deletes at runtime**. Be sure to check your code and make any adjustments accordingly.
 
 </Admonition>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -332,7 +332,7 @@ After introspecting, you can review the non-default clauses in your schema. The 
 
 <Admonition type="alert">
 
-If you are using either the [`delete()`](../../../../../guides/database/advanced-database-tasks/cascading-deletes/postgresql#91-validating-restrict) or [`deleteAll()`](../../../prisma-client/crud#delete-all-records) methods, **[cascading deletes](#how-to-use-cascading-deletes) will now be performed** as the `referentialActions` preview feature **removed the safety net in Prisma Client that previously prevented cascading deletes at runtime**. Be sure to check your code and make any adjustments accordingly.
+If you are using either the [`delete()`](../../../../../guides/database/advanced-database-tasks/cascading-deletes/postgresql#91-validating-restrict) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods, **[cascading deletes](#how-to-use-cascading-deletes) will now be performed** as the `referentialActions` preview feature **removed the safety net in Prisma Client that previously prevented cascading deletes at runtime**. Be sure to check your code and make any adjustments accordingly.
 
 </Admonition>
 
@@ -482,7 +482,7 @@ main()
 
 The following behavior applies in 2.25.0 and earlier, and since 2.26.0 until 3.0.0 _without_ the `referentialActions` preview flag. That is, if the referential actions feature is **not** implemented.
 
-When invoking the [`delete()`](../../../../../guides/database/advanced-database-tasks/cascading-deletes/postgresql#91-validating-restrict) or [`deleteAll()`](../../../prisma-client/crud#delete-all-records) methods using the Prisma Client on required relations, a runtime check is performed and the deletion of records prevented if they are referencing related objects. **This prevents cascade behavior**.
+When invoking the [`delete()`](../../../../../guides/database/advanced-database-tasks/cascading-deletes/postgresql#91-validating-restrict) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods using the Prisma Client on required relations, a runtime check is performed and the deletion of records prevented if they are referencing related objects. **This prevents cascade behavior**.
 
 The current behavior, without upgrading and enabling the feature flag, does not allow setting referential actions at all.
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -331,7 +331,6 @@ When you run an Introspection, Prisma compares all the foreign keys in the datab
 After introspecting, you can review the non-default clauses in your schema. The most important clause to review is `onDelete`, which defaults to `Cascade` in 2.25.0 and earlier.
 
 <Admonition type="alert">
- 
 If you are using either the [`delete()`](../../../prisma-client/crud#delete-a-single-record) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods, **[cascading deletes](#how-to-use-cascading-deletes) will now be performed** as the `referentialActions` preview feature **removed the safety net in Prisma Client that previously prevented cascading deletes at runtime**. Be sure to check your code and make any adjustments accordingly.
 
 </Admonition>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -331,8 +331,8 @@ When you run an Introspection, Prisma compares all the foreign keys in the datab
 After introspecting, you can review the non-default clauses in your schema. The most important clause to review is `onDelete`, which defaults to `Cascade` in 2.25.0 and earlier.
 
 <Admonition type="alert">
-
-If you are using either the [`delete()`](../../../../../guides/database/advanced-database-tasks/cascading-deletes/postgresql#91-validating-restrict) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods, **[cascading deletes](#how-to-use-cascading-deletes) will now be performed** as the `referentialActions` preview feature **removed the safety net in Prisma Client that previously prevented cascading deletes at runtime**. Be sure to check your code and make any adjustments accordingly.
+ 
+If you are using either the [`delete()`](../../../prisma-client/crud#delete-a-single-record) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods, **[cascading deletes](#how-to-use-cascading-deletes) will now be performed** as the `referentialActions` preview feature **removed the safety net in Prisma Client that previously prevented cascading deletes at runtime**. Be sure to check your code and make any adjustments accordingly.
 
 </Admonition>
 
@@ -482,7 +482,7 @@ main()
 
 The following behavior applies in 2.25.0 and earlier, and since 2.26.0 until 3.0.0 _without_ the `referentialActions` preview flag. That is, if the referential actions feature is **not** implemented.
 
-When invoking the [`delete()`](../../../../../guides/database/advanced-database-tasks/cascading-deletes/postgresql#91-validating-restrict) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods using the Prisma Client on required relations, a runtime check is performed and the deletion of records prevented if they are referencing related objects. **This prevents cascade behavior**.
+When invoking the [`delete()`](../../../prisma-client/crud#delete-a-single-record) or [`deleteMany()`](../../../prisma-client/crud#delete-all-records) methods using the Prisma Client on required relations, a runtime check is performed and the deletion of records prevented if they are referencing related objects. **This prevents cascade behavior**.
 
 The current behavior, without upgrading and enabling the feature flag, does not allow setting referential actions at all.
 


### PR DESCRIPTION
Since `deleteAll()` method doesn't exist
