### PR TITLE
Remove Early Access note from Deploying to CFW guide

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -12,13 +12,6 @@ This guide will cover Prisma, TypeScript, MongoDB, Prisma Data Proxy and Cloudfl
 
 </TopBlock>
 
-<Admonition type="warning">
-
-**Early Access Feature** <br />
-Please note that the Prisma Data Proxy is an early-stage product and should not be used in production environments.
-
-</Admonition>
-
 ## Prerequisites
 
 - Free [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) database with an accessible URL

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -236,11 +236,6 @@ Then you can hop back into your code editor and paste the connection string into
 
 You're all setup and ready to generate a Prisma Client!
 
-<Admonition type="warning">
-  Please be aware that the Data Proxy is in Early Access and should not be used
-  in production.
-</Admonition>
-
 ## 9. Generate a Prisma Client
 
 Next you'll generate a Prisma Client that connects through the [Data Proxy](/data-platform/data-proxy) over HTTP.


### PR DESCRIPTION
## Describe this PR

Remove the `Early Access Feature` note related to the Data Proxy in the Deploying to CFW guide.

## Changes

The same as the above.