### PR TITLE
Update 030-upgrading-to-prisma-4.mdx

### DIFF
--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/030-upgrading-to-prisma-4.mdx
@@ -51,7 +51,9 @@ This section includes changes that affect both the Prisma Schema and the Prisma 
 
 #### Node.js minimum version change
 
-In Prisma version 4.0.0, we've changed the [minimum version of Node.js that we support](/reference/system-requirements). If you use an earlier version of Node.js, you will need to update it.
+From Prisma version 4.0.0, the minimum version of Node.js that we support is 14.17.x. If you use an earlier version of Node.js, you will need to update it.
+
+See our [system requirements](/reference/system-requirements) for all minimum version requirements.
 
 ### Schema changes
 


### PR DESCRIPTION
Version Added in explicit minimum version number for Node.js. The minimum number for Prisma 4 will always be Node.js 14.17.x. Therefore, the upgrade guide won't need to change, so we can explicitly mention the version number here (and it makes the docs self-contained, so it's the best option).
