### PR TITLE
Adding a note about using different port for pgbouncer=true which connects to pooling endpoint

### DIFF
--- a/content/300-guides/100-performance-and-optimization/150-connection-management/200-configure-pg-bouncer.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/200-configure-pg-bouncer.mdx
@@ -16,6 +16,8 @@ To use Prisma Client with PgBouncer from a serverless function, add the `?pgboun
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE?pgbouncer=true
 ```
 
+> Note: `PORT` specified for PgBouncer pooling sometimes different from the default `5432` port. Check database provider docs for the exact port number, otherwise adding `?pgbouncer=true` won't work.
+
 ## Set PgBouncer to transaction mode
 
 Additionally, for Prisma Client to work reliably, PgBouncer must run in [**Transaction mode**](https://www.pgbouncer.org/features.html).
@@ -41,5 +43,7 @@ Error querying the database: db error: ERROR: prepared statement "s0" already ex
 
 To work around this issue, you must connect directly to the database rather than going through PgBouncer. How to achieve this depends on your setup or provider:
 
-- [Connecting directly to a PostgreSQL database hosted on Digital Ocean](https://github.com/prisma/prisma/issues/6157)
+- [Connecting directly to a 
+
+SQL database hosted on Digital Ocean](https://github.com/prisma/prisma/issues/6157)
 - [Connecting directly to a PostgreSQL database hosted on ScaleGrid](https://github.com/prisma/prisma/issues/6701#issuecomment-824387959)

--- a/content/300-guides/100-performance-and-optimization/150-connection-management/200-configure-pg-bouncer.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/200-configure-pg-bouncer.mdx
@@ -43,5 +43,5 @@ Error querying the database: db error: ERROR: prepared statement "s0" already ex
 
 To work around this issue, you must connect directly to the database rather than going through PgBouncer. How to achieve this depends on your setup or provider:
 
-- [Connecting directly to a SQL database hosted on Digital Ocean](https://github.com/prisma/prisma/issues/6157)
+- [Connecting directly to a PostgreSQL database hosted on Digital Ocean](https://github.com/prisma/prisma/issues/6157)
 - [Connecting directly to a PostgreSQL database hosted on ScaleGrid](https://github.com/prisma/prisma/issues/6701#issuecomment-824387959)

--- a/content/300-guides/100-performance-and-optimization/150-connection-management/200-configure-pg-bouncer.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/200-configure-pg-bouncer.mdx
@@ -43,7 +43,5 @@ Error querying the database: db error: ERROR: prepared statement "s0" already ex
 
 To work around this issue, you must connect directly to the database rather than going through PgBouncer. How to achieve this depends on your setup or provider:
 
-- [Connecting directly to a 
-
-SQL database hosted on Digital Ocean](https://github.com/prisma/prisma/issues/6157)
+- [Connecting directly to a SQL database hosted on Digital Ocean](https://github.com/prisma/prisma/issues/6157)
 - [Connecting directly to a PostgreSQL database hosted on ScaleGrid](https://github.com/prisma/prisma/issues/6701#issuecomment-824387959)


### PR DESCRIPTION
## Describe this PR

Adding a note about checking port number with pgbouncer
The lack of info cost me some downtime because I thought just adding `?pgbouncer=true` will magically work with edge functions connected to supabase so I wish others won't face the same issue

## Changes

Mention checking port number for changes

## What issue does this fix?

## Any other relevant information
https://supabase.com/docs/guides/database/connecting-to-postgres#finding-the-connection-pool-config
