### PR TITLE
Document enforced `@unique` attribute on 1:1 and 1:n relations

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -6,7 +6,13 @@ tocDepth: 2
 
 <TopBlock>
 
-One-to-one (1-1) relations refer to relations where at most **one** record can be connected on both sides of the relation. In the example below, there's one 1-1-relation between `User` and `Profile`:
+This page introduces one-to-one relations and explains how to use them in your Prisma schema.
+
+</TopBlock>
+
+## Overview
+
+One-to-one (1-1) relations refer to relations where at most **one** record can be connected on both sides of the relation. In the example below, there is a one-to-one relation between `User` and `Profile`:
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>
@@ -43,12 +49,10 @@ model Profile {
 </tab>
 </TabbedContent>
 
-The `userId` relation scalar is a direct representation of the foreign key in the underlying database.This 1-1-relation expresses the following:
+The `userId` relation scalar is a direct representation of the foreign key in the underlying database. This one-to-one relation expresses the following:
 
 - "a user can have zero or one profiles" (because the `profile` field is [optional](/concepts/components/prisma-schema/data-model#type-modifiers) on `User`)
 - "a profile must always be connected to one user"
-
-</TopBlock>
 
 ## Multi-field relations in relational databases
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -95,7 +95,7 @@ model Profile {
 
 <Admonition type="warning">
 
-In MySQL, it is possible to create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
+In MySQL, you can create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -95,7 +95,7 @@ model Profile {
 
 <Admonition type="warning">
 
-In MySQL, you can create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
+In MySQL, you can create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation of this type it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -54,7 +54,7 @@ The `userId` relation scalar is a direct representation of the foreign key in th
 - "a user can have zero or one profiles" (because the `profile` field is [optional](/concepts/components/prisma-schema/data-model#type-modifiers) on `User`)
 - "a profile must always be connected to one user"
 
-In the previous example, the `user` relation field of the `Profile` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Profile`. In the following example, the `user` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
+In the previous example, the `user` relation field of the `Profile` model references the `id` field of the `User` model. You can also reference a different field. In this case, you need to mark the field with the `@unique` attribute, to guarantee that there is only a single `User` connected to each `Profile`. In the following example, the `user` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -54,7 +54,7 @@ The `userId` relation scalar is a direct representation of the foreign key in th
 - "a user can have zero or one profiles" (because the `profile` field is [optional](/concepts/components/prisma-schema/data-model#type-modifiers) on `User`)
 - "a profile must always be connected to one user"
 
-In this example, the `user` field of the `Profile` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Profile`. In the following example, the `user` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
+In the previous example, the `user` relation field of the `Profile` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Profile`. In the following example, the `user` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -54,6 +54,51 @@ The `userId` relation scalar is a direct representation of the foreign key in th
 - "a user can have zero or one profiles" (because the `profile` field is [optional](/concepts/components/prisma-schema/data-model#type-modifiers) on `User`)
 - "a profile must always be connected to one user"
 
+In this example, the `user` field of the `Profile` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Profile`. In the following example, the `user` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
+
+<TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
+<tab>
+
+```prisma
+model User {
+  id      Int      @id @default(autoincrement())
+  email   String   @unique // <-- add unique attribute
+  profile Profile?
+}
+
+model Profile {
+  id     Int  @id @default(autoincrement())
+  user   User @relation(fields: [userId], references: [email])
+  userId Int  @unique // relation scalar field (used in the `@relation` attribute above)
+}
+```
+
+</tab>
+<tab>
+
+```prisma
+model User {
+  id      String   @id @default(auto()) @map("_id") @db.ObjectId
+  email   String   @unique // <-- add unique attribute
+  profile Profile?
+}
+
+model Profile {
+  id     String @id @default(auto()) @map("_id") @db.ObjectId
+  user   User   @relation(fields: [userId], references: [email])
+  userId String @unique @db.ObjectId // relation scalar field (used in the `@relation` attribute above)
+}
+```
+
+</tab>
+</TabbedContent>
+
+<Admonition type="warning">
+
+In MySQL, it is possible to create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
+
+</Admonition>
+
 ## Multi-field relations in relational databases
 
 In **relational databases only**, you can also define use [multi-field IDs](/reference/api-reference/prisma-schema-reference#id-1) to define a 1-1 relation:

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -97,7 +97,7 @@ model Post {
 
 <Admonition type="warning">
 
-In MySQL, you can create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
+In MySQL, you can create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation of this type it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -97,7 +97,7 @@ model Post {
 
 <Admonition type="warning">
 
-In MySQL, it is possible to create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma version 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field. If this is not possible for any reason, please leave a comment on [our Github issue]().
+In MySQL, it is possible to create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -6,7 +6,13 @@ tocDepth: 2
 
 <TopBlock>
 
-One-to-many (1-n) relations refer to relations where one record on one side of the relation can be connected to zero or more records on the other side. In the following example, there is one 1-n-relation between `User` and `Post`:
+This page introduces one-to-many relations and explains how to use them in your Prisma schema.
+
+</TopBlock>
+
+## Overview
+
+One-to-many (1-n) relations refer to relations where one record on one side of the relation can be connected to zero or more records on the other side. In the following example, there is one one-to-many relation between the `User` and `Post` models:
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>
@@ -45,12 +51,10 @@ model Post {
 
 > **Note** The `posts` field does not "manifest" in the underlying database schema. On the other side of the relation, the [annotated relation field](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields) `author` and its relation scalar `authorId` represent the side of the relation that stores the foreign key in the underlying database.
 
-This 1-n-relation expresses the following:
+This one-to-many relation expresses the following:
 
 - "a user can have zero or more posts"
 - "a post must always have an author"
-
-</TopBlock>
 
 ## Multi-field relations in relational databases
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -97,7 +97,7 @@ model Post {
 
 <Admonition type="warning">
 
-In MySQL, it is possible to create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
+In MySQL, you can create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma versions 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -56,6 +56,51 @@ This one-to-many relation expresses the following:
 - "a user can have zero or more posts"
 - "a post must always have an author"
 
+In this example, the `author` field of the `Post` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Post`. In the following example, the `author` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
+
+<TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
+<tab>
+
+```prisma
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique // <-- add unique attribute
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id @default(autoincrement())
+  authorId Int
+  author   User @relation(fields: [authorId], references: [email])
+}
+```
+
+</tab>
+<tab>
+
+```prisma
+model User {
+  id    Int    @id @default(auto()) @map("_id") @db.ObjectId
+  email String @unique // <-- add unique attribute
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id @default(auto()) @map("_id") @db.ObjectId
+  authorId Int
+  author   User @relation(fields: [authorId], references: [email])
+}
+```
+
+</tab>
+</TabbedContent>
+
+<Admonition type="warning">
+
+In MySQL, it is possible to create a foreign key with only an index on the referenced side, and not a unique constraint. In Prisma version 4.0.0 and later, if you introspect a relation like this it will trigger a validation error. To fix this, you will need to add a `@unique` constraint to the referenced field. If this is not possible for any reason, please leave a comment on [our Github issue]().
+
+</Admonition>
+
 ## Multi-field relations in relational databases
 
 In **relational databases only**, you can also define this relation using [multi-field IDs](/reference/api-reference/prisma-schema-reference#id-1):

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -56,7 +56,7 @@ This one-to-many relation expresses the following:
 - "a user can have zero or more posts"
 - "a post must always have an author"
 
-In this example, the `author` field of the `Post` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Post`. In the following example, the `author` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
+In the previous example, the `author` relation field of the `Post` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Post`. In the following example, the `author` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -56,7 +56,7 @@ This one-to-many relation expresses the following:
 - "a user can have zero or more posts"
 - "a post must always have an author"
 
-In the previous example, the `author` relation field of the `Post` model references the `id` field of the `User` model. It is also possible to reference another field, as long as that field is marked with the `@unique` attribute. This is necessary to guarantee that there is only a single `User` connected to each `Post`. In the following example, the `author` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
+In the previous example, the `author` relation field of the `Post` model references the `id` field of the `User` model. You can also reference a different field. In this case, you need to mark the field with the `@unique` attribute, to guarantee that there is only a single `User` connected to each `Post`. In the following example, the `author` field references an `email` field in the `User` model, which is marked with the `@unique` attribute:
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>


### PR DESCRIPTION
## Describe this PR

- Add example where referenced field isn't the id
- Include admonition about MySQL behaviour

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #3319 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
