### PR TITLE
Encourage using UUID primary keys in CockroachDB

### DIFF
--- a/content/300-guides/050-database/860-using-prisma-with-cockroachdb.mdx
+++ b/content/300-guides/050-database/860-using-prisma-with-cockroachdb.mdx
@@ -74,7 +74,7 @@ For a full list of type mappings, see our [connector documentation](/concepts/da
 
 When generating unique identifiers for records in a distributed database like CockroachDB, it is best to use randomly generated IDs such as UUIDs rather than sequential IDs – for more information on this, see CockroachDB's [blog post on choosing index keys](https://cockroachlabs.com/blog/how-to-choose-db-index-keys).
 
-To generate random UUIDs in Prisma, Prisma's [`dbgenerated()`](/reference/api-reference/prisma-schema-reference#dbgenerated) attribute function can be used in conjunction with CockroachDB's [`gen_random_uuid()` function](https://www.cockroachlabs.com/docs/stable/serial.html). For example, the following `User` model has an `id` primary key, generated using the `dbgenerated()` function:
+To generate random UUIDs in Prisma, Prisma's [`dbgenerated()`](/reference/api-reference/prisma-schema-reference#dbgenerated) attribute function can be used in conjunction with CockroachDB's [`gen_random_uuid()` function](https://www.cockroachlabs.com/docs/v22.1/uuid.html). For example, the following `User` model has an `id` primary key, generated using the `dbgenerated()` function:
 
 ```prisma file=schema.prisma
 model User {

--- a/content/300-guides/050-database/860-using-prisma-with-cockroachdb.mdx
+++ b/content/300-guides/050-database/860-using-prisma-with-cockroachdb.mdx
@@ -36,7 +36,7 @@ There are some CockroachDB-specific differences to be aware of when working with
 
 - **Cockroach-specific native types:** Prisma's `cockroachdb` database connector provides support for CockroachDB's native data types. To learn more, see [How to use CockroachDB's native types](#how-to-use-cockroachdbs-native-types).
 
-- **Creating database keys:** Prisma allows you to generate a unique identifier for each record using the [`autoincrement()`](/reference/api-reference/prisma-schema-reference#autoincrement) function. For more information, see [How to use database keys with CockroachDB](#how-to-use-database-keys-with-cockroachdb).
+- **Creating database keys:** Prisma allows you to generate a unique identifier for each record using the [`dbgenerated()`](/reference/api-reference/prisma-schema-reference#dbgenerated) function. For more information, see [How to use database keys with CockroachDB](#how-to-use-database-keys-with-cockroachdb).
 
 ## How to use Prisma with CockroachDB
 
@@ -50,7 +50,7 @@ As a demonstration of this, say you create a `User` table in your CockroachDB da
 
 ```sql
 CREATE TABLE public."Post" (
-  "id" INT8 NOT NULL,
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
   "title" VARCHAR(200) NOT NULL,
   CONSTRAINT "Post_pkey" PRIMARY KEY ("id" ASC),
   FAMILY "primary" ("id", "title")
@@ -61,7 +61,7 @@ After introspecting your database with `npx prisma db pull`, you will have a new
 
 ```prisma file=schema.prisma
 model Post {
-  id    BigInt @id
+  id    String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   title String @db.String(200)
 }
 ```
@@ -72,18 +72,18 @@ For a full list of type mappings, see our [connector documentation](/concepts/da
 
 ### How to use database keys with CockroachDB
 
-When generating unique identifiers for records in a distributed database like CockroachDB, it is best to avoid using sequential IDs – for more information on this, see CockroachDB's [blog post on choosing index keys](https://cockroachlabs.com/blog/how-to-choose-db-index-keys).
+When generating unique identifiers for records in a distributed database like CockroachDB, it is best to use randomly generated IDs such as UUIDs rather than sequential IDs – for more information on this, see CockroachDB's [blog post on choosing index keys](https://cockroachlabs.com/blog/how-to-choose-db-index-keys).
 
-Instead, Prisma provides the [`autoincrement()`](/reference/api-reference/prisma-schema-reference#autoincrement) attribute function, which uses CockroachDB's [`unique_rowid()` function](https://www.cockroachlabs.com/docs/stable/serial.html) for generating unique identifiers. For example, the following `User` model has an `id` primary key, generated using the `autoincrement()` function:
+To generate random UUIDs in Prisma, Prisma's [`dbgenerated()`](/reference/api-reference/prisma-schema-reference#dbgenerated) attribute function can be used in conjunction with CockroachDB's [`gen_random_uuid()` function](https://www.cockroachlabs.com/docs/stable/serial.html). For example, the following `User` model has an `id` primary key, generated using the `dbgenerated()` function:
 
 ```prisma file=schema.prisma
 model User {
-  id   BigInt @id @default(autoincrement())
+  id   String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name String
 }
 ```
 
-For compatibility with existing databases, you may sometimes still need to generate a fixed sequence of integer key values. In these cases, you can use Prisma's inbuilt [`sequence()`](/reference/api-reference/prisma-schema-reference#sequence) function for CockroachDB. For a list of available options for the `sequence()` function, see our [reference documentation](/reference/api-reference/prisma-schema-reference#sequence).
+For compatibility with existing databases, you may sometimes still need to generate a fixed sequence of integers. In these cases, you can use Prisma's inbuilt [`sequence()`](/reference/api-reference/prisma-schema-reference#sequence) function for CockroachDB. For a list of available options for the `sequence()` function, see our [reference documentation](/reference/api-reference/prisma-schema-reference#sequence).
 
 For more information on generating database keys, see CockroachDB's [Primary key best practices](https://www.cockroachlabs.com/docs/v21.2/schema-design-table#primary-key-best-practices) guide.
 

--- a/content/300-guides/050-database/860-using-prisma-with-cockroachdb.mdx
+++ b/content/300-guides/050-database/860-using-prisma-with-cockroachdb.mdx
@@ -72,7 +72,7 @@ For a full list of type mappings, see our [connector documentation](/concepts/da
 
 ### How to use database keys with CockroachDB
 
-When generating unique identifiers for records in a distributed database like CockroachDB, it is best to use randomly generated IDs such as UUIDs rather than sequential IDs – for more information on this, see CockroachDB's [blog post on choosing index keys](https://cockroachlabs.com/blog/how-to-choose-db-index-keys).
+When generating unique identifiers for records in a distributed database like CockroachDB, it is best to avoid using sequential IDs – for more information on this, see CockroachDB's [blog post on choosing index keys](https://cockroachlabs.com/blog/how-to-choose-db-index-keys). Consider using UUIDs if you want to explicitly plan for avoiding hotspots, where all writes are trying to go the same place.
 
 To generate random UUIDs in Prisma, Prisma's [`dbgenerated()`](/reference/api-reference/prisma-schema-reference#dbgenerated) attribute function can be used in conjunction with CockroachDB's [`gen_random_uuid()` function](https://www.cockroachlabs.com/docs/v22.1/uuid.html). For example, the following `User` model has an `id` primary key, generated using the `dbgenerated()` function:
 


### PR DESCRIPTION
Randomly-generated identifiers like UUIDs provide more even distribution of data to prevent hotspots in distributed databases like CockroachDB.