### PR TITLE
Fix fragment for `seed` command

### DIFF
--- a/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
+++ b/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
@@ -81,7 +81,7 @@ Prisma is a lot more than "just another ORM". We are building a database toolkit
 - data modeling (in the [Prisma schema](/concepts/components/prisma-schema))
 - migrations (with [Prisma Migrate](/concepts/components/prisma-migrate))
 - prototyping (via [`prisma db push`](/reference/api-reference/command-reference#db-push))
-- seeding (via [`prisma db seed`](/reference/api-reference/command-reference#db-seed-preview))
+- seeding (via [`prisma db seed`](/reference/api-reference/command-reference#db-seed))
 - visual viewing and editing (with [Prisma Studio](https://prisma.io/studio))
 
 ### ... you value type-safety


### PR DESCRIPTION
## Describe this PR

The link fragment is currently `db-seed-preview`, which does not exist on the command reference page.

## Changes

This updates the fragment to `db-seed`.

## What issue does this fix?

N/A, this was such a small change an issue seems like too much

## Any other relevant information

N/A
