### PR TITLE
Cascading deletes: clarify the version differences and direct users on newer versions to referential actions

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -15,8 +15,8 @@ From version 2.26.0, you can define referential actions on the relation fields i
 
 **Version differences**
 
-- If you use version 3.0.0 or later, you can use referential actions as described on this page.
-- If you use a version between 2.26.0 and 2.30.3, you can use referential actions as described on this page, but you must [enable the preview feature flag](/concepts/components/preview-features/client-preview-features#enabling-a-prisma-client-preview-feature) `referentialActions`.
+- If you use version 3.0.1 or later, you can use referential actions as described on this page.
+- If you use a version between 2.26.0 and 3.0.0, you can use referential actions as described on this page, but you must [enable the preview feature flag](/concepts/components/preview-features/client-preview-features#enabling-a-prisma-client-preview-feature) `referentialActions`.
 - If you use version 2.25.0 or earlier, you can do cascading deletes [manually in the database](/guides/database/advanced-database-tasks/cascading-deletes).
 
 </Admonition>

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -7,7 +7,16 @@ tocDepth: 2
 
 <TopBlock>
 
-Referential actions determine what happens to a record when a related record is deleted or updated. In [2.26.0](https://github.com/prisma/prisma/releases/tag/2.26.0) and later (before 3.0.0 with a preview feature flag `referentialActions`, afterwards without), you can define referential actions on your relation fields in your Prisma schema.
+Referential actions determine what happens to a record when a related record is deleted or updated. From version 2.26.0, you can define referential actions on the relation fields in your Prisma schema, which allows you to do cascading deletes and updates.
+
+<Admonition type="info">
+
+**Before Prisma version 3.0.0**
+
+- If you use version 2.26.0 or later, but before version 3.0.0, you can use referential actions as described on this page, but you must enable the preview feature flag `referentialActions`.
+- If you use version 2.25.0 or earlier, you can do cascading deletes [manually in the database](/concepts/components/prisma-schema/relations/referential-actions).
+
+</Admonition>
 
 In the following example, adding `onDelete: Cascade` to the `author` field on the `Post` model means that deleting the `User` record will also delete all related `Post` records.
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -7,14 +7,17 @@ tocDepth: 2
 
 <TopBlock>
 
-Referential actions determine what happens to a record when a related record is deleted or updated. From version 2.26.0, you can define referential actions on the relation fields in your Prisma schema, which allows you to do cascading deletes and updates.
+Referential actions determine what happens to a record when your application deletes or updates a related record.
+
+From version 2.26.0, you can define referential actions on the relation fields in your Prisma schema. This allows you to do cascading deletes and cascading updates.
 
 <Admonition type="info">
 
-**Before Prisma version 3.0.0**
+**Version differences**
 
-- If you use version 2.26.0 or later, but before version 3.0.0, you can use referential actions as described on this page, but you must enable the preview feature flag `referentialActions`.
-- If you use version 2.25.0 or earlier, you can do cascading deletes [manually in the database](/concepts/components/prisma-schema/relations/referential-actions).
+- If you use version 3.0.0 or later, you can use referential actions as described on this page.
+- If you use a version between 2.26.0 and 2.30.3, you can use referential actions as described on this page, but you must [enable the preview feature flag](/concepts/components/preview-features/client-preview-features#enabling-a-prisma-client-preview-feature) `referentialActions`.
+- If you use version 2.25.0 or earlier, you can do cascading deletes [manually in the database](/guides/database/advanced-database-tasks/cascading-deletes).
 
 </Admonition>
 
@@ -41,7 +44,7 @@ If you do not specify a referential action, Prisma [uses a default](#referential
 <Admonition type="alert">
 
 If you upgrade from a version earlier than 2.26.0:
-It is extremely important that you check the [upgrade paths for referential actions](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) section if you upgrade from a version before 2.26.0. Prisma support of referential actions **removes the safety net in Prisma Client that prevents cascading deletes at runtime**. If you use the feature _without upgrading your database_, the [old default action](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions#prisma-2x-default-referential-actions) - `ON DELETE CASCADE` - becomes active. This may result in cascading deletes that you did not expect.
+It is extremely important that you check the [upgrade paths for referential actions](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) section. Prisma support of referential actions **removes the safety net in Prisma Client that prevents cascading deletes at runtime**. If you use the feature _without upgrading your database_, the [old default action](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions#prisma-2x-default-referential-actions) - `ON DELETE CASCADE` - becomes active. This might result in cascading deletes that you did not expect.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/425-referential-actions/index.mdx
@@ -9,7 +9,7 @@ tocDepth: 2
 
 Referential actions determine what happens to a record when your application deletes or updates a related record.
 
-From version 2.26.0, you can define referential actions on the relation fields in your Prisma schema. This allows you to do cascading deletes and cascading updates.
+From version 2.26.0, you can define referential actions on the relation fields in your Prisma schema. This allows you to define referential actions like cascading deletes and cascading updates at a Prisma level.
 
 <Admonition type="info">
 

--- a/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/01-postgresql.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/01-postgresql.mdx
@@ -8,13 +8,13 @@ metaDescription: 'Learn how to configure cascading deletes with Prisma and Postg
 
 <Admonition type="warning">
 
-In [3.0.1](https://github.com/prisma/prisma/releases/tag/3.0.1) and later it is possible to do cascading deletes using [Referential actions](/concepts/components/prisma-schema/relations/referential-actions). Be sure to follow the [upgrade guide](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) before using this feature.
+This page describes how to do cascading deletes with PostgreSQL before Prisma version 2.26.0. If you use version 2.26.0 or later, we recommend that you do cascading deletes with [Referential actions](/concepts/components/prisma-schema/relations/referential-actions).
 
 </Admonition>
 
 This page explains how to configure cascading deletes on [foreign key constraints](https://www.postgresql.org/docs/8.2/ddl-constraints.html#DDL-CONSTRAINTS-FK) (relations) in your PostgreSQL database.
 
-Cascading deletes allow you to configure deletion behavior on relations (e.g. specify a rule like "when a user is deleted, all their posts should be automatically deleted too"). The database will then enforce this behavior when records are deleted.
+Cascading deletes allow you to configure deletion behavior on relations (for example to specify a rule like "when a user is deleted, all their posts should be automatically deleted too"). The database then enforces this behavior when records are deleted.
 
 There generally are five options for configuring deletion behavior in PostgreSQL (quoting from the [PostgreSQL docs](https://www.postgresql.org/docs/8.2/ddl-constraints.html#DDL-CONSTRAINTS-FK)):
 

--- a/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/02-mysql.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/02-mysql.mdx
@@ -8,7 +8,7 @@ metaDescription: 'Learn how to configure cascading deletes with Prisma and MySQL
 
 <Admonition type="warning">
 
-In [3.0.1](https://github.com/prisma/prisma/releases/tag/3.0.1) and later it is possible to do cascading deletes using [Referential actions](/concepts/components/prisma-schema/relations/referential-actions). Be sure to follow the [upgrade guide](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) before using this feature.
+This page describes how to do cascading deletes with MySQL before Prisma version 2.26.0. If you use version 2.26.0 or later, we recommend that you do cascading deletes with [Referential actions](/concepts/components/prisma-schema/relations/referential-actions).
 
 </Admonition>
 

--- a/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/03-sqlite.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/03-sqlite.mdx
@@ -8,7 +8,7 @@ metaDescription: 'Learn how to configure cascading deletes with Prisma and SQLit
 
 <Admonition type="warning">
 
-In [3.0.1](https://github.com/prisma/prisma/releases/tag/3.0.1) and later it is possible to do cascading deletes using [Referential actions](/concepts/components/prisma-schema/relations/referential-actions). Be sure to follow the [upgrade guide](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) before using this feature.
+This page describes how to do cascading deletes with SQLite before Prisma version 2.26.0. If you use version 2.26.0 or later, we recommend that you do cascading deletes with [Referential actions](/concepts/components/prisma-schema/relations/referential-actions).
 
 </Admonition>
 

--- a/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/index.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/index.mdx
@@ -6,15 +6,15 @@ metaDescription: 'How to implement cascading deletes at database level.'
 
 <TopBlock>
 
+<Admonition type="warning">
+
+This section describes how to do cascading deletes before version 2.26.0. If you yse version 2.26.0 or later, you can do cascading deletes with [Referential actions](/concepts/components/prisma-schema/relations/referential-actions).
+
+</Admonition>
+
 Cascading deletes allow you to define how foreign key relationships should be handled when you delete a record. For example, when you delete a user, you might use a cascading delete to remove that user's extended profile from a related table. By contrast, you might _not_ want to delete that user's blog posts.
 
 The guides in this section describe how to implement cascading deletes manually in the database and verify the results in Prisma Client.
-
-<Admonition type="warning">
-
-In [3.0.1](https://github.com/prisma/prisma/releases/tag/3.0.1) and later it is possible to do cascading deletes using [Referential actions](/concepts/components/prisma-schema/relations/referential-actions). Be sure to follow the [upgrade guide](/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions) before using this feature.
-
-</Admonition>
 
 ![](cascading-deletes/cascading-deletes-illustration.png)
 

--- a/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/index.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/06-cascading-deletes/index.mdx
@@ -8,7 +8,7 @@ metaDescription: 'How to implement cascading deletes at database level.'
 
 <Admonition type="warning">
 
-This section describes how to do cascading deletes before version 2.26.0. If you yse version 2.26.0 or later, you can do cascading deletes with [Referential actions](/concepts/components/prisma-schema/relations/referential-actions).
+This section describes how to do cascading deletes before Prisma version 2.26.0. If you use version 2.26.0 or later, we recommend that you do cascading deletes with [Referential actions](/concepts/components/prisma-schema/relations/referential-actions).
 
 </Admonition>
 


### PR DESCRIPTION
Emphasize new method of doing cascading deletes