### PR TITLE
Update down migration guide for failed migrations only

### DIFF
--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/180-generating-down-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/180-generating-down-migrations.mdx
@@ -15,7 +15,7 @@ This guide describes how to generate a down migration SQL file that reverses a g
 
 When generating a migration SQL file, you may wish to also create a "down migration" SQL file that reverses the schema changes in the corresponding "up migration" file.
 
-This guide explains how to use Prisma Migrate's [`migrate diff` command](/reference/api-reference/command-reference#migrate-diff) to create a down migration, and how to apply it to your production database with the [`db execute`](/reference/api-reference/command-reference#db-execute) command.
+This guide explains how to use Prisma Migrate's [`migrate diff` command](/reference/api-reference/command-reference#migrate-diff) to create a down migration, and how to apply it to your production database with the [`db execute`](/reference/api-reference/command-reference#db-execute) command in the case of a failed up migration.
 
 <Admonition type="info">
 
@@ -33,6 +33,7 @@ The `migrate diff` and `db execute` commands are available in Preview in version
 
 When generating a down migration file, there are some considerations to be aware of:
 
+- The down migration can be used to revert your database schema after a failed migration using the steps in [How to apply your down migration to a failed migration](#how-to-apply-your-down-migration-to-a-failed-migration). This requires the use of the `migrate resolve` command, which can only be used on failed migrations. If your up migration was successful and you want to revert it, you will instead need to revert your `prisma.schema` file to its state before the up migration, and generate a new migration with `migrate dev` to .
 - The down migration will revert your database schema, but other changes to data and application code that are carried out as part of the up migration will not be reverted. For example, if you have a script that changes data during the migration, this data will not be changed back when you run the down migration.
 - You will not be able to use `migrate diff` to revert manually changed or added SQL in your migration files. If you have any custom additions, such as a view or trigger, you will need to:
   - Create the down migration following [the instructions below](#how-to-generate-and-run-down-migrations)
@@ -42,7 +43,7 @@ When generating a down migration file, there are some considerations to be aware
 
 ## How to generate and run down migrations
 
-This section describes how to generate a down migration SQL file along with the corresponding up migration, and then run it on production.
+This section describes how to generate a down migration SQL file along with the corresponding up migration, and then run it to revert your database schema after a failed up migration on production.
 
 As an example, take the following Prisma schema with a `User` and `Post` model as a starting point:
 
@@ -129,9 +130,11 @@ You will need to create the down migration first, before creating the correspond
 
 4. Copy your `down.sql` file into the new directory along with the up migration file.
 
-### Applying the down migration
+### How to apply your down migration to a failed migration
 
-To apply the down migration on your production database:
+If your previous up migration failed, you can apply your down migration on your production database with the following steps:
+
+To apply the down migration on your production database after a failed up migration:
 
 1. Use `db execute` to run your `down.sql` file on the database server:
 


### PR DESCRIPTION
## Describe this PR

Updates the down migrations guide to clarify that the down migration can only be used after a failed up migration

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #3418 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
