### PR TITLE
Change the name of the squashed migration in the squashing docs

### DIFF
--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
@@ -95,7 +95,9 @@ Then follow these steps, either on your `main` branch or on a newly checked out 
 2. Create a new empty directory in the `./prisma/migrations` directory. In this guide this will be called `000000000000_squashed_migrations`. Inside this, add a new empty `migration.sql` file.
 
    <Admonition type="info">
+   
     We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Prisma Migrate assumes the lexicographic order of migrations in the directory is the same as the logic order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or  or `202207180000_squashed`.
+    
    </Admonition>
 
 3. Create a single migration that takes you:

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
@@ -96,7 +96,7 @@ Then follow these steps, either on your `main` branch or on a newly checked out 
 
    <Admonition type="info">
    
-    We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Prisma Migrate assumes the lexicographic order of migrations in the directory is the same as the logic order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or  or `202207180000_squashed`.
+    We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Migrate runs the migrations in the directory in lexicographic (alphabetical) order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or  or `202207180000_squashed`.
     
    </Admonition>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
@@ -76,7 +76,7 @@ Then follow these steps:
 
    - from the state of the `main` branch as described in your reset migration history
    - to the state of your local feature as described in your `./prisma/schema.prisma` file
-   - and outputs this to a new `migration.sql` file in the new directory ending with `squashed_migrations` (specified with the `--name` flag)
+   - and outputs this to a new `migration.sql` file in a new directory ending with `squashed_migrations` (specified with the `--name` flag)
 
 This single migration file can now be applied to production using `migrate deploy`.
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
@@ -76,7 +76,7 @@ Then follow these steps:
 
    - from the state of the `main` branch as described in your reset migration history
    - to the state of your local feature as described in your `./prisma/schema.prisma` file
-   - and outputs this to a new `migration.sql` file in the `squashed_migrations` directory (specified with the `--name` flag)
+   - and outputs this to a new `migration.sql` file in the new directory ending with `squashed_migrations` (specified with the `--name` flag)
 
 This single migration file can now be applied to production using `migrate deploy`.
 
@@ -92,7 +92,11 @@ Then follow these steps, either on your `main` branch or on a newly checked out 
 
 1. Delete all contents of the `./prisma/migrations` directory
 
-2. Create a new empty directory in the `./prisma/migrations` directory. In this guide this will be called `squashed_migrations`. Inside this, add a new empty `migration.sql` file.
+2. Create a new empty directory in the `./prisma/migrations` directory. In this guide this will be called `000000000000_squashed_migrations`. Inside this, add a new empty `migration.sql` file.
+
+   <Admonition type="info">
+    We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Prisma Migrate assumes the lexicographic order of migrations in the directory is the same as the logic order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or  or `202207180000_squashed`.
+   </Admonition>
 
 3. Create a single migration that takes you:
 
@@ -106,16 +110,16 @@ Then follow these steps, either on your `main` branch or on a newly checked out 
    npx prisma migrate diff \
     --from-empty \
     --to-schema-datamodel ./prisma/schema.prisma \
-    --script > ./prisma/migrations/squashed_migrations/migration.sql
+    --script > ./prisma/migrations/000000000000_squashed_migrations/migration.sql
    ```
 
 4. Mark this migration as having been applied on production, to prevent it from being run there:
 
-   You can do this using the [`migrate resolve`](/reference/api-reference/command-reference#migrate-resolve) command to mark the migration in the `squashed_migrations` directory as already applied:
+   You can do this using the [`migrate resolve`](/reference/api-reference/command-reference#migrate-resolve) command to mark the migration in the `000000000000_squashed_migrations` directory as already applied:
 
    ```terminal
    npx prisma migrate resolve \
-    --applied squashed_migrations
+    --applied 000000000000_squashed_migrations
    ```
 
 You should now have a single migration file that is marked as having been applied on production. New checkouts only get one single migration taking them to the state of the production database schema.

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/175-squashing-migrations.mdx
@@ -96,7 +96,7 @@ Then follow these steps, either on your `main` branch or on a newly checked out 
 
    <Admonition type="info">
    
-    We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Migrate runs the migrations in the directory in lexicographic (alphabetical) order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or  or `202207180000_squashed`.
+    We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Migrate runs the migrations in the directory in lexicographic (alphabetical) order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or `202207180000_squashed`.
     
    </Admonition>
 


### PR DESCRIPTION
Without number prefix, by default, new migrations coming after the
squashed migration in the logical order will be applied _before_ the
squashed migration, and that will not work. This PR adds a `0` prefix
to the migration name, so that doesn't happen, and explains why.

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

A user encountered this problem on the public slack: https://prisma.slack.com/archives/CA491RJH0/p1658174506918329

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
