### PR TITLE
fix: first test case of 'with-singleton.ts'

### DIFF
--- a/content/300-guides/150-testing/100-unit-testing.mdx
+++ b/content/300-guides/150-testing/100-unit-testing.mdx
@@ -285,6 +285,7 @@ test('should create new user ', async () => {
     id: 1,
     name: 'Rich',
     email: 'hello@prisma.io',
+    acceptTermsAndConditions: true,
   })
 })
 


### PR DESCRIPTION
The `expect()` part of test case 'should create new user' lacked `acceptTermsAndConditions: true` within the user object for comparison, which stopped it from passing the case.

## Describe this PR

The singleton demo of [Example unit tests](https://www.prisma.io/docs/guides/testing/unit-testing#example-unit-tests) cannot pass all test cases. And my modification fixes it.

## Changes

- Supplement `acceptTermsAndConditions: true,` to the comparison object of user.

## What issue does this fix?

I don't see any related issue. Should I open an issue first?

## Any other relevant information
