### PR TITLE
Fix incorrect filename in getting-started/quickstart

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -123,7 +123,7 @@ Congratulations, you now have your database and tables ready. Let's go and learn
 To send queries to the database, you will need a TypeScript file to execute your Prisma Client queries. Create a new file called `script.ts` for this purpose:
 
 ```terminal
-touch index.ts
+touch script.ts
 ```
 
 Then, paste the following boilerplate into it:


### PR DESCRIPTION
## Describe this PR
There is an inconsistency in the filenames between the code-block and the text above in the getting started page. This pr fixes that. Since this is in the getting started page, this might throw off newbies.
<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes
Changed the filename in the code-block to `script.ts`
<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
