### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/content/200-concepts/100-components/05-prisma-cli/index.mdx
+++ b/content/200-concepts/100-components/05-prisma-cli/index.mdx
@@ -16,3 +16,13 @@ The Prisma command line interface (CLI) is the primary way to interact with your
 ## Prisma CLI command reference
 
 See [Prisma CLI command reference](/reference/api-reference/command-reference) <span class="api"></span> for a complete list of commands.
+
+## Autocomplete
+
+You can get IDE-style autocompletions for Prisma CLI using [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```


### PR DESCRIPTION
## Describe this PR

Hey there! [Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Prisma. It looks like this:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/4949076/181363191-109e1f2d-2954-4ef2-892c-e608f49d44a7.png">

We think this will make users more efficient with Prisma CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!

## Changes

Just edited the docs. 
