### PR TITLE
Fixes Links in "Constraint names in relational databases" section

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -647,7 +647,7 @@ model User {
 <Admonition type="info">
 
 **Constraint names in relational databases** <br />
-You can optionally define a [custom primary key constraint name](/concepts/components/prisma-schema/names-in-underlying-database#constraint-and-index-names-preview) in the underlying database.
+You can optionally define a [custom primary key constraint name](/concepts/components/prisma-schema/names-in-underlying-database#constraint-and-index-names) in the underlying database.
 
 </Admonition>
 
@@ -815,7 +815,7 @@ model Post {
 <Admonition type="info">
 
 **Constraint names in relational databases** <br />
-You can optionally define a [custom unique constraint name](/concepts/components/prisma-schema/names-in-underlying-database#constraint-and-index-names-preview) in the underlying database.
+You can optionally define a [custom unique constraint name](/concepts/components/prisma-schema/names-in-underlying-database#constraint-and-index-names) in the underlying database.
 
 </Admonition>
 


### PR DESCRIPTION
The current links does not open the correct section and instead open the footer of the page.

## Changes

Links are corrected to open the correct section.
