### PR TITLE
Fix broken example `findUnique` snippets on 'Names in the underlying database' page

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -19,7 +19,7 @@ The [Prisma schema](./) includes mechanisms that allow you to define names of ce
 
 Sometimes the names used to describe entities in your database might not match the names you would prefer in your generated API. Mapping names in the Prisma schema allows you to influence the naming in your Client API without having to change the underlying database names.
 
-A common approach for naming tables/collections in databases for example is to use plural form and [snake_case](https://en.wikipedia.org/wiki/Snake_case) notation. Prisma on the other hand has recommended model [naming conventions (singular form, PascalCase)](/reference/api-reference/prisma-schema-reference#naming-conventions) <span class="api"></span> which differ from that. 
+A common approach for naming tables/collections in databases for example is to use plural form and [snake_case](https://en.wikipedia.org/wiki/Snake_case) notation. Prisma on the other hand has recommended model [naming conventions (singular form, PascalCase)](/reference/api-reference/prisma-schema-reference#naming-conventions) <span class="api"></span> which differ from that.
 
 `@map` and `@@map` allow you to [tune the shape of your Prisma Client API](../prisma-client/working-with-prismaclient/use-custom-model-and-field-names#using-map-and-map-to-rename-fields-and-models-in-the-prisma-client-api) by decoupling model and field names from table and column names in the underlying database.
 
@@ -76,9 +76,9 @@ enum Type {
 
 ## Constraint and index names
 
-In [2.29.0](https://github.com/prisma/prisma/releases/tag/2.29.0) and later, you can optionally use the `map` argument to define the **underlying constraint and index names** in the Prisma schema for the attributes [`@id`](/reference/api-reference/prisma-schema-reference#id), [`@@id`](/reference/api-reference/prisma-schema-reference#id-1), [`@unique`](/reference/api-reference/prisma-schema-reference#unique), [`@@unique`](/reference/api-reference/prisma-schema-reference#unique-1), [`@@index`](/reference/api-reference/prisma-schema-reference#index) and [`@relation`](/reference/api-reference/prisma-schema-reference#relation). 
+In [2.29.0](https://github.com/prisma/prisma/releases/tag/2.29.0) and later, you can optionally use the `map` argument to define the **underlying constraint and index names** in the Prisma schema for the attributes [`@id`](/reference/api-reference/prisma-schema-reference#id), [`@@id`](/reference/api-reference/prisma-schema-reference#id-1), [`@unique`](/reference/api-reference/prisma-schema-reference#unique), [`@@unique`](/reference/api-reference/prisma-schema-reference#unique-1), [`@@index`](/reference/api-reference/prisma-schema-reference#index) and [`@relation`](/reference/api-reference/prisma-schema-reference#relation).
 
-When introspecting a database, the `map` argument will _only_ be rendered in the schema if the name differs from Prisma's [default constraint naming convention for indexes and constraints](#prismas-default-naming-conventions-for-indexes-and-constraints). 
+When introspecting a database, the `map` argument will _only_ be rendered in the schema if the name differs from Prisma's [default constraint naming convention for indexes and constraints](#prismas-default-naming-conventions-for-indexes-and-constraints).
 
 <Admonition type="alert">
 
@@ -108,7 +108,6 @@ We always use the database names of entities when generating the default names. 
 
 Since most databases have a length limit for entity names, the names will be trimmed if necessary to not violate the database limits. We will shorten the part before the `_suffix` as necessary so that the full name is at most the maximum length permitted.
 
-
 ### Using default constraint names
 
 When no explicit names are provided via `map` arguments Prisma will assume they follow the default naming convention.
@@ -117,7 +116,7 @@ If you introspect a database the names for indexes and constraints will be added
 
 #### Example
 
-The following schema defines three constraints (`@id`, `@unique`, and `@relation`) and one index (`@@index`) that will 
+The following schema defines three constraints (`@id`, `@unique`, and `@relation`) and one index (`@@index`) that will
 
 ```prisma highlight=2,8,11,13;normal
 model User {
@@ -154,7 +153,7 @@ to render names because they already align with the convention.
 
 ### Using custom constraint / index names
 
-You can use the `map` argument to define **custom constraint and index names** in the underlying database. 
+You can use the `map` argument to define **custom constraint and index names** in the underlying database.
 
 #### Example
 
@@ -204,29 +203,25 @@ model User {
 the default API for selecting on that primary key uses a generated combination of the fields:
 
 ```ts
-prisma
-  .user
-  .findUnique({
-    where: {
-      firstName_lastName: {{
-        firstName: "Paul",
-        lastName: "Panther"
-    }
-  })
+const user = await prisma.user.findUnique({
+  where: {
+    firstName_lastName: {
+      firstName: 'Paul',
+      lastName: 'Panther',
+    },
+  },
+})
 ```
 
 Specifying `@@id([firstName, lastName], name: "fullName")` will change the Prisma Client API to this instead:
 
-
-```ts highlight=6;add|5;delete
-prisma
-  .user
-  .findUnique({
-    where: {
-      firstName_lastName: {
-      fullName: {
-        firstName: "Paul",
-        lastName: "Panther"
-    }
-  })
+```ts highlight=3;edit
+const user = await prisma.user.findUnique({
+  where: {
+    fullName: {
+      firstName: 'Paul',
+      lastName: 'Panther',
+    },
+  },
+})
 ```


### PR DESCRIPTION
## Describe this PR

I found a broken code snippet (mismatched brackets) while looking into #3453. Also tidied up the one below it. May as well fix these now instead of waiting for the release.

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
