### PR TITLE
Remove preview:true from Indexes concepts page metadata

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/09-indexes.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/09-indexes.mdx
@@ -3,7 +3,6 @@ title: 'Indexes'
 metaDescription: 'How to configure index functionality and add full text indexes'
 hidePage: false
 tocDepth: 2
-preview: true
 ---
 
 <TopBlock>


### PR DESCRIPTION
## Describe this PR

Remove 'preview' pill from contents bar for Indexes concepts page

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #3404 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
