### PR TITLE
Document use of `findUnique` with MongoDB composite types

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -285,7 +285,7 @@ type Photo {
 }
 ```
 
-will change the Client API to the following:
+changes the Client API to the following:
 
 ```ts highlight=3;edit
 const product = await prisma.product.findUnique({

--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -234,7 +234,7 @@ Composite types are only available in MongoDB.
 
 </Admonition>
 
-In Prisma versions 4.3.0 and later, you can search on a multi-field constraint that contains composite types. For example, the following schema has a `Product` model, an embedded `Photo` composite type, and a multi-field unique constraint on the product `name` and photo `url`:
+In Prisma versions 4.3.0 and later, you can search on a single-field or multi-field constraint that contains composite types. For example, the following schema has a `Product` model, an embedded `Photo` composite type, and a multi-field unique constraint on the product `name` and photo `url`:
 
 ```prisma file=schema.prisma
 model Product {
@@ -252,6 +252,12 @@ type Photo {
 }
 ```
 
+<Admonition type="info">
+
+**Note:** In this example, we use a multi-field constraint, but you can also search on single-field constraints, such as `@@unique([photos.url])`.
+
+</Admonition>
+
 In this case , the default API to select on the constraint uses a generated combination of the model field name, and the type name and field. For example, the following query searches on `name_photo_url` to get the `Product` record with a given `name`, and containing a `Photo` composite type with a given `url`:
 
 ```ts
@@ -262,6 +268,20 @@ const product = await prisma.product.findUnique({
       photo: {
         url: '1.jpg',
       },
+    },
+  },
+})
+```
+
+When you filter on a multi-field constraint, you must include all fields in the constraint in your filter. For example, the following filter does not work:
+
+```ts
+// the following filter does not work, because the code does not
+// reference the 'url' field of the multi-field constraint
+const product = await prisma.product.findUnique({
+  where: {
+    name_photo_url: {
+      name: 'Forest Runners',
     },
   },
 })

--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -226,7 +226,7 @@ const user = await prisma.user.findUnique({
 })
 ```
 
-#### Filtering on composite types
+#### Filter on composite types
 
 <Admonition type="warning">
 
@@ -234,7 +234,7 @@ Composite types are only available in MongoDB.
 
 </Admonition>
 
-In Prisma versions 4.3.0 and later, you can search on a multi-field constraint containing composite types. As an example, take the following schema with a `Product` model, an embedded `Photo` composite type, and a multi-field unique constraint on the product `name` and photo `url`:
+In Prisma versions 4.3.0 and later, you can search on a multi-field constraint that contains composite types. For example, the following schema has a `Product` model, an embedded `Photo` composite type, and a multi-field unique constraint on the product `name` and photo `url`:
 
 ```prisma file=schema.prisma
 model Product {
@@ -252,7 +252,7 @@ type Photo {
 }
 ```
 
-In this case , the default API for selecting on the constraint uses a generated combination of the model field name, and the type name and field. For example, the following query searches on `name_photo_url` to get the `Product` record with a given `name`, and containing a `Photo` composite type with a given `url`:
+In this case , the default API to select on the constraint uses a generated combination of the model field name, and the type name and field. For example, the following query searches on `name_photo_url` to get the `Product` record with a given `name`, and containing a `Photo` composite type with a given `url`:
 
 ```ts
 const product = await prisma.product.findUnique({
@@ -267,7 +267,7 @@ const product = await prisma.product.findUnique({
 })
 ```
 
-To change the default name, use the `name` argument in the `@@unique` attribute. For example, changing the name to `nameandurl` in the schema:
+To change the default name, use the `name` argument in the `@@unique` attribute. For example, if you change the name to `nameandurl` in the schema as follows:
 
 ```prisma file=schema.prisma
 model Product {
@@ -285,7 +285,7 @@ type Photo {
 }
 ```
 
-changes the Client API to the following:
+This changes the Client API as follows:
 
 ```ts highlight=3;edit
 const product = await prisma.product.findUnique({

--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -234,7 +234,7 @@ Composite types are only available in MongoDB.
 
 </Admonition>
 
-In Prisma versions 4.2.0 and later, you can search on a multi-field constraint containing composite types. As an example, take the following schema with a `Product` model, an embedded `Photo` composite type, and a multi-field unique constraint on the product `name` and photo `url`:
+In Prisma versions 4.3.0 and later, you can search on a multi-field constraint containing composite types. As an example, take the following schema with a `Product` model, an embedded `Photo` composite type, and a multi-field unique constraint on the product `name` and photo `url`:
 
 ```prisma file=schema.prisma
 model Product {

--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -243,7 +243,7 @@ model Product {
   description String
   photos      Photo[]
 
-  @@unique([name, photos.url]) // multi-field unique constraint
+  @@unique([name, photos.url])
 }
 
 type Photo {

--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -19,7 +19,7 @@ The [Prisma schema](./) includes mechanisms that allow you to define names of ce
 
 Sometimes the names used to describe entities in your database might not match the names you would prefer in your generated API. Mapping names in the Prisma schema allows you to influence the naming in your Client API without having to change the underlying database names.
 
-A common approach for naming tables/collections in databases for example is to use plural form and [snake_case](https://en.wikipedia.org/wiki/Snake_case) notation. Prisma on the other hand has recommended model [naming conventions (singular form, PascalCase)](/reference/api-reference/prisma-schema-reference#naming-conventions) <span class="api"></span> which differ from that. 
+A common approach for naming tables/collections in databases for example is to use plural form and [snake_case](https://en.wikipedia.org/wiki/Snake_case) notation. Prisma on the other hand has recommended model [naming conventions (singular form, PascalCase)](/reference/api-reference/prisma-schema-reference#naming-conventions) <span class="api"></span> which differ from that.
 
 `@map` and `@@map` allow you to [tune the shape of your Prisma Client API](../prisma-client/working-with-prismaclient/use-custom-model-and-field-names#using-map-and-map-to-rename-fields-and-models-in-the-prisma-client-api) by decoupling model and field names from table and column names in the underlying database.
 
@@ -76,9 +76,9 @@ enum Type {
 
 ## Constraint and index names
 
-In [2.29.0](https://github.com/prisma/prisma/releases/tag/2.29.0) and later, you can optionally use the `map` argument to define the **underlying constraint and index names** in the Prisma schema for the attributes [`@id`](/reference/api-reference/prisma-schema-reference#id), [`@@id`](/reference/api-reference/prisma-schema-reference#id-1), [`@unique`](/reference/api-reference/prisma-schema-reference#unique), [`@@unique`](/reference/api-reference/prisma-schema-reference#unique-1), [`@@index`](/reference/api-reference/prisma-schema-reference#index) and [`@relation`](/reference/api-reference/prisma-schema-reference#relation). 
+In [2.29.0](https://github.com/prisma/prisma/releases/tag/2.29.0) and later, you can optionally use the `map` argument to define the **underlying constraint and index names** in the Prisma schema for the attributes [`@id`](/reference/api-reference/prisma-schema-reference#id), [`@@id`](/reference/api-reference/prisma-schema-reference#id-1), [`@unique`](/reference/api-reference/prisma-schema-reference#unique), [`@@unique`](/reference/api-reference/prisma-schema-reference#unique-1), [`@@index`](/reference/api-reference/prisma-schema-reference#index) and [`@relation`](/reference/api-reference/prisma-schema-reference#relation).
 
-When introspecting a database, the `map` argument will _only_ be rendered in the schema if the name differs from Prisma's [default constraint naming convention for indexes and constraints](#prismas-default-naming-conventions-for-indexes-and-constraints). 
+When introspecting a database, the `map` argument will _only_ be rendered in the schema if the name differs from Prisma's [default constraint naming convention for indexes and constraints](#prismas-default-naming-conventions-for-indexes-and-constraints).
 
 <Admonition type="alert">
 
@@ -108,7 +108,6 @@ We always use the database names of entities when generating the default names. 
 
 Since most databases have a length limit for entity names, the names will be trimmed if necessary to not violate the database limits. We will shorten the part before the `_suffix` as necessary so that the full name is at most the maximum length permitted.
 
-
 ### Using default constraint names
 
 When no explicit names are provided via `map` arguments Prisma will assume they follow the default naming convention.
@@ -117,7 +116,7 @@ If you introspect a database the names for indexes and constraints will be added
 
 #### Example
 
-The following schema defines three constraints (`@id`, `@unique`, and `@relation`) and one index (`@@index`) that will 
+The following schema defines three constraints (`@id`, `@unique`, and `@relation`) and one index (`@@index`) that will
 
 ```prisma highlight=2,8,11,13;normal
 model User {
@@ -154,7 +153,7 @@ to render names because they already align with the convention.
 
 ### Using custom constraint / index names
 
-You can use the `map` argument to define **custom constraint and index names** in the underlying database. 
+You can use the `map` argument to define **custom constraint and index names** in the underlying database.
 
 #### Example
 
@@ -186,7 +185,7 @@ The following table lists the name of each constraint and index in the underlyin
 | `@id` (on `Post` > `id` field)     | Yes                | `Post_pk`                            |
 | `@relation` (on `Post` > `author`) | Yes                | `Post_authorName_fkey`               |
 
-### Related: Naming indexes and primary keys for Prisma Client
+### Naming indexes and primary keys for Prisma Client
 
 Additionally to `map`, the `@@id` and `@@unique` attributes take an optional `name` argument that allows you to customize your Prisma Client API.
 
@@ -217,7 +216,6 @@ prisma
 
 Specifying `@@id([firstName, lastName], name: "fullName")` will change the Prisma Client API to this instead:
 
-
 ```ts highlight=6;add|5;delete
 prisma
   .user
@@ -229,4 +227,78 @@ prisma
         lastName: "Panther"
     }
   })
+```
+
+#### Filtering on composite types
+
+<Admonition type="warning">
+
+Composite types are only available in MongoDB.
+
+</Admonition>
+
+In Prisma versions 4.2.0 and later, you can search on a multi-field constraint containing composite types. As an example, take the following schema with a `Product` model, an embedded `Photo` composite type, and a multi-field unique constraint on the product `name` and photo `url`:
+
+```prisma file=schema.prisma
+model Product {
+  id          String  @id @default(auto()) @map("_id") @db.ObjectId
+  name        String  @unique
+  description String
+  photos      Photo[]
+
+  @@unique([name, photos.url]) // multi-field unique constraint
+}
+
+type Photo {
+  caption  String
+  url      String
+}
+```
+
+In this case , the default API for selecting on the constraint uses a generated combination of the model field name, and the type name and field. For example, the following query searches on `name_photo_url` to get the `Product` record with a given `name`, and containing a `Photo` composite type with a given `url`:
+
+```ts
+const product = await prisma.product.findUnique({
+  where: {
+    name_photo_url: {
+      name: 'Forest Runners',
+      photo: {
+        url: '1.jpg',
+      },
+    },
+  },
+})
+```
+
+To change the default name, use the `name` argument in the `@@unique` attribute. For example, changing the name to `nameandurl` in the schema:
+
+```prisma file=schema.prisma
+model Product {
+  id          String  @id @default(auto()) @map("_id") @db.ObjectId
+  name        String  @unique
+  description String
+  photos      Photo[]
+
+  @@unique([name, photos.url], name: "nameandurl") // multi-field unique constraint
+}
+
+type Photo {
+  caption  String
+  url      String
+}
+```
+
+will change the Client API to the following:
+
+```ts highlight=3;edit
+const product = await prisma.product.findUnique({
+  where: {
+    nameandurl: {
+      name: 'Forest Runners',
+      photo: {
+        url: '1.jpg',
+      },
+    },
+  },
+})
 ```

--- a/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/07-names-in-underlying-database.mdx
@@ -276,7 +276,7 @@ model Product {
   description String
   photos      Photo[]
 
-  @@unique([name, photos.url], name: "nameandurl") // multi-field unique constraint
+  @@unique([name, photos.url], name: "nameandurl") 
 }
 
 type Photo {

--- a/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/056-composite-types.mdx
@@ -19,10 +19,11 @@ We made composite types [Generally Available](/about/prisma/releases#generally-a
 
 This page explains how to:
 
-- [find](#finding-records-that-contain-composite-types-with-find-and-findmany) records that contain composite types using `findFirst` and `findMany`
-- [create](#creating-records-with-composite-types-using-create-and-createmany) new records with composite types using `create` and `createMany`
-- [update](#changing-composite-types-within-update-and-updatemany) composite types within existing records using `update` and `updateMany`
-- [delete](#deleting-records-that-contain-composite-types-with-delete-and-deletemany) records with composite types using `delete` and `deleteMany`
+- [find](#find-records-that-contain-composite-types-with-find-and-findmany) records that contain composite types, with `findFirst` and `findMany`
+- [find](#find-records-based-on-a-multi-field-constraint-that-contains-composite-types-with-findunique) records based on a multi-field constraint that contains composite types, with `findUnique`
+- [create](#create-records-with-composite-types-using-create-and-createmany) new records with composite types, with `create` and `createMany`
+- [update](#change-composite-types-within-update-and-updatemany) composite types within existing records, with `update` and `updateMany`
+- [delete](#delete-records-that-contain-composite-types-with-delete-and-deletemany) records with composite types, with `delete` and `deleteMany`
 
 </TopBlock>
 
@@ -138,13 +139,13 @@ Error converting field "bitDepth" of expected non-nullable
 type "int", found incompatible value of "null".
 ```
 
-## Finding records that contain composite types with <inlinecode>find</inlinecode> and <inlinecode>findMany</inlinecode>
+## Find records that contain composite types with <inlinecode>find</inlinecode> and <inlinecode>findMany</inlinecode>
 
 Records can be filtered by a composite type within the `where` operation.
 
 The following section describes the operations available for filtering by a single type or multiple types, and gives examples of each.
 
-### Filtering for one composite type
+### Filter for one composite type
 
 Use the `is`, `equals`, `isNot` and `isSet` operations to change a single composite type:
 
@@ -223,7 +224,7 @@ const orders = await prisma.order.findMany({
 })
 ```
 
-### Filtering for many composite types
+### Filter for many composite types
 
 Use the `equals`, `isEmpty`, `every`, `some` and `none` operations to filter for multiple composite types:
 
@@ -318,7 +319,11 @@ const product = prisma.product.findFirst({
 })
 ```
 
-## Creating records with composite types using <inlinecode>create</inlinecode> and <inlinecode>createMany</inlinecode>
+## Find records based on a multi-field constraint that contains composite types with `findUnique`
+
+In versions 4.3.0 and later, you can use `findUnique` to search on a multi-field constraint that contains composite types. [See an example](/reference/api-reference/prisma-client-reference#get-the-product-record-with-a-given-name-and-containing-a-photo-composite-type-with-a-given-url).
+
+## Create records with composite types using <inlinecode>create</inlinecode> and <inlinecode>createMany</inlinecode>
 
 Composite types can be created within a `create` or `createMany` method using the `set` operation. For example, you can use `set` within `create` to create an `Address` composite type inside an `Order`:
 
@@ -452,11 +457,11 @@ const product = await prisma.product.createMany({
 })
 ```
 
-## Changing composite types within <inlinecode>update</inlinecode> and <inlinecode>updateMany</inlinecode>
+## Change composite types within <inlinecode>update</inlinecode> and <inlinecode>updateMany</inlinecode>
 
 Composite types can be set, updated or removed within an `update` or `updateMany` method. The following section describes the operations available for updating a single type or multiple types at once, and gives examples of each.
 
-### Changing a single composite type
+### Change a single composite type
 
 Use the `set`, `unset` `update` and `upsert` operations to change a single composite type:
 
@@ -547,7 +552,7 @@ const orders = await prisma.order.updateMany({
 })
 ```
 
-### Changing multiple composite types
+### Change multiple composite types
 
 Use the `set`, `push`, `updateMany` and `deleteMany` operations to change a list of composite types:
 
@@ -642,7 +647,7 @@ const product = await prisma.product.upsert({
 })
 ```
 
-## Deleting records that contain composite types with <inlinecode>delete</inlinecode> and <inlinecode>deleteMany</inlinecode>
+## Delete records that contain composite types with <inlinecode>delete</inlinecode> and <inlinecode>deleteMany</inlinecode>
 
 To remove records which embed a composite type, use the `delete` or `deleteMany` methods. This will also remove the embedded composite type.
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -584,7 +584,7 @@ model Product {
   description String
   photos      Photo[]
 
-  @@unique([name, photos.url]) // multi-field unique constraint
+  @@unique([name, photos.url])
 }
 
 type Photo {

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -565,7 +565,7 @@ const result = await prisma.user.findUnique({
 })
 ```
 
-##### Get the <inlinecode>Product</inlinecode> record with a given <inlinecode>name</inlinecode>, and containing a <inlinecode>Photo</inlinecode> composite type with a given <inlinecode>url</inlinecode>
+##### Get the <inlinecode>Product</inlinecode> record with a specific <inlinecode>name</inlinecode>, and containing a <inlinecode>Photo</inlinecode> composite type with a specific <inlinecode>url</inlinecode>
 
 This example uses `findUnique` to find the `Product` record containing the `Photo` composite type that matches a given product `name` and photo `url`, where the `name` and `url` combination has been constrained to be unique with a multi-field `@@unique` constraint.
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -565,6 +565,49 @@ const result = await prisma.user.findUnique({
 })
 ```
 
+##### Get the <inlinecode>Product</inlinecode> record with a given <inlinecode>name</inlinecode>, and containing a <inlinecode>Photo</inlinecode> composite type with a given <inlinecode>url</inlinecode>
+
+This example uses `findUnique` to find the `Product` record containing the `Photo` composite type matching a given product `name` and photo `url`, where the `name` and `url` combination has been constrained to be unique using a multi-field `@@unique` constraint.
+
+<Admonition type="warning">
+
+Composite types are only available in MongoDB.<br /><br />Searching on a multi-field constraint containing composite types is available in the Prisma Client in versions 4.2.0 and later.
+
+</Admonition>
+
+<details><summary>Expand to see the example schema</summary>
+
+```prisma file=schema.prisma
+model Product {
+  id          String  @id @default(auto()) @map("_id") @db.ObjectId
+  name        String  @unique
+  description String
+  photos      Photo[]
+
+  @@unique([name, photos.url]) // multi-field unique constraint
+}
+
+type Photo {
+  caption  String
+  url      String
+}
+```
+
+</details>
+
+```ts
+const product = await prisma.product.findUnique({
+  where: {
+    name_photo_url: {
+      name: 'Forest Runners',
+      photo: {
+        url: '1.jpg',
+      },
+    },
+  },
+})
+```
+
 ### <inlinecode>findUniqueOrThrow</inlinecode>
 
 <Admonition type="info">

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -567,7 +567,7 @@ const result = await prisma.user.findUnique({
 
 ##### Get the <inlinecode>Product</inlinecode> record with a given <inlinecode>name</inlinecode>, and containing a <inlinecode>Photo</inlinecode> composite type with a given <inlinecode>url</inlinecode>
 
-This example uses `findUnique` to find the `Product` record containing the `Photo` composite type matching a given product `name` and photo `url`, where the `name` and `url` combination has been constrained to be unique using a multi-field `@@unique` constraint.
+This example uses `findUnique` to find the `Product` record containing the `Photo` composite type that matches a given product `name` and photo `url`, where the `name` and `url` combination has been constrained to be unique with a multi-field `@@unique` constraint.
 
 <Admonition type="warning">
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -571,7 +571,7 @@ This example uses `findUnique` to find the `Product` record containing the `Phot
 
 <Admonition type="warning">
 
-Composite types are only available in MongoDB.<br /><br />Searching on a multi-field constraint containing composite types is available in the Prisma Client in versions 4.2.0 and later.
+Composite types are only available in MongoDB.<br /><br />Searching on a multi-field constraint containing composite types is available in the Prisma Client in versions 4.3.0 and later.
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -571,7 +571,7 @@ This example uses `findUnique` to find the `Product` record containing the `Phot
 
 <Admonition type="warning">
 
-Composite types are only available in MongoDB.<br /><br />Searching on a multi-field constraint containing composite types is available in the Prisma Client in versions 4.3.0 and later.
+Composite types are only available in MongoDB.<br /><br />To search on a multi-field constraint that contains composite types, you need Prisma Client version 4.3.0 or later.
 
 </Admonition>
 


### PR DESCRIPTION
## Describe this PR

Added examples of using `findUnique` with a multi-field constraint containing a composite type to:
- the client reference entry for `findUnique`
- Names in the underlying database concepts page

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #3453 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
