### PR TITLE
docs: clarify restriction on template variables in strings

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -54,7 +54,7 @@ const result = await prisma.$queryRaw(
 
 Be aware that:
 
-- Template variables cannot be used inside strings. For example, the following query would **not** work:
+- Template variables cannot be used inside SQL string literals. For example, the following query would **not** work:
 
   ```ts no-lines
   const name = 'Bob'
@@ -263,7 +263,7 @@ Be aware that:
 - `$executeRaw` does not support multiple queries in a single string (for example, `ALTER TABLE` and `CREATE TABLE` together).
 - Prisma Client submits prepared statements, and prepared statements only allow a subset of SQL statements. For example, `START TRANSACTION` is not permitted. You can learn more about [the syntax that MySQL allows in Prepared Statements here](https://dev.mysql.com/doc/refman/8.0/en/sql-prepared-statements.html).
 - [`PREPARE` does not support `ALTER`](https://www.postgresql.org/docs/current/sql-prepare.html) - see the [workaround](#alter-limitation-postgresql).
-- Template variables cannot be used inside strings. For example, the following query would **not** work:
+- Template variables cannot be used inside SQL string literals. For example, the following query would **not** work:
 
   ```ts no-lines
   const name = 'Bob'


### PR DESCRIPTION
## Describe this PR

Adds clarification that this bit about "strings" means "SQL string literals".

## Changes

"strings" -> "SQL string literals"

## What issue does this fix?

I had to reread the line + code example a few times to infer/understand what it meant exactly, since the code contains both TS strings and SQL strings. The example just a little bit before this one appeared to use template variables inside a string, so the restriction appeared to be potentially contradictory at first.
