### PR TITLE
fixed Grammar Error in 'Is Prisma an ORM?'

### DIFF
--- a/content/200-concepts/050-overview/300-prisma-in-your-stack/03-is-prisma-an-orm.mdx
+++ b/content/200-concepts/050-overview/300-prisma-in-your-stack/03-is-prisma-an-orm.mdx
@@ -30,13 +30,13 @@ There are two common ORM patterns: [_Active Record_](https://en.wikipedia.org/wi
 
 #### Active Record
 
-_Active Record_ ORMs map model classes to database tables where the structure of the two representations is closely related, e.g. each field in the model class will have a matching column in the database table. Instances of the model classes wrap database rows and carry both the data and the access logic to handle persisting changes in the database. Additionally, model classes can carry business logic specific to on the data in the model.
+_Active Record_ ORMs map model classes to database tables where the structure of the two representations is closely related, e.g. each field in the model class will have a matching column in the database table. Instances of the model classes wrap database rows and carry both the data and the access logic to handle persisting changes in the database. Additionally, model classes can carry business logic specific to the data in the model.
 
 The model class typically has methods that do the following:
 
 - Construct an instance of the model from an SQL query.
 - Construct a new instance for later insertion into the table.
-- Methods to wrap commonly used SQL queries and return Active Record objects.
+- Wrap commonly used SQL queries and return Active Record objects.
 - Update the database and insert into it the data in the Active Record.
 - Get and set the fields.
 - Implement business logic.


### PR DESCRIPTION
## Describe this PR

On [Is Prisma an ORM?](https://www.prisma.io/docs/concepts/overview/prisma-in-your-stack/is-prisma-an-orm), there's a typo in the following sentence:

"Additionally, model classes can carry business logic specific to on the data in the model."

## Changes

- Fixed grammar errors in "Is Prisma an ORM" page

## What issue does this fix?

Fixes #3570 

## Any other relevant information

-
