### PR TITLE
Isolation levels: Fix error and update order of isolation levels

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -299,7 +299,7 @@ In version 4.1.0 and earlier, you cannot configure the transaction isolation lev
 - [Default transaction isolation level in MySQL](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
   <br />
   <br />
-  CockroachDB and PlanetScale always use the <inlinecode>
+  CockroachDB and SQLite always use the <inlinecode>
     Serializable
   </inlinecode> isolation level.
 
@@ -322,11 +322,11 @@ await prisma.$transaction(
 
 Prisma Client supports the following isolation levels if they are available in the underlying database:
 
-- `ReadCommitted`
 - `ReadUncommitted`
+- `ReadCommitted`
 - `RepeatableRead`
-- `Serializable`
 - `Snapshot`
+- `Serializable`
 
 ##### Isolation levels by database
 


### PR DESCRIPTION
Based on community feedback:

1. Fix note about supported isolation level for SQLite. We fixed one place during the review, but missed the second one
2. Re-arranged isolation levels based on strength