### PR TITLE
Did not instruct to install @prisma/client

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -51,6 +51,12 @@ Then, install the Prisma CLI as a development dependency in the project:
 npm install prisma --save-dev
 ```
 
+Then, install the Prisma Client:
+
+```terminal
+npm install @prisma/client
+```
+
 Finally, set up Prisma with the `init` command of the Prisma CLI:
 
 ```terminal


### PR DESCRIPTION
## Describe this PR

All the code uses the @prisma/client package to interact with prisma but it never gets said to install it from this specific docs

## Changes

Added a single instruction to install @prisma/client

## What issue does this fix?

No issue from the issues open on GitHub, but will help new devs get up and running with Prisma

## Any other relevant information

No
