### PR TITLE
Remove duplicate paragraphs and merge the relevant sections

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -207,9 +207,7 @@ The following entity relationship diagram represents the database that correspon
 
 ![The sample schema as an entity relationship diagram](sample-schema.png)
 
-## Terminology
-
-### Relation fields
+## Relation fields
 
 Relation [fields](/concepts/components/prisma-schema/data-model#defining-fields) are fields on a Prisma [model](/concepts/components/prisma-schema/data-model#defining-models) that do _not_ have a [scalar type](/concepts/components/prisma-schema/data-model#scalar-fields). Instead, their type is another model.
 
@@ -324,12 +322,6 @@ The following list of `Post` documents each have a `userId` field which referenc
   }
 ]
 ```
-
-## Relation fields
-
-Relation [fields](/concepts/components/prisma-schema/data-model#defining-fields) are fields on a Prisma [model](/concepts/components/prisma-schema/data-model#defining-models) that do _not_ have a [scalar type](/concepts/components/prisma-schema/data-model#scalar-fields). Instead, their type is another model.
-
-Every relation must have exactly two relation fields, one on each model. In case of 1-1 and 1-n relations, an additional _relation scalar field_ is required which gets linked by one of the two relation fields in the `@relation` attribute. This relation scalar is the direct representation of the _foreign key_ in the underlying database.
 
 Consider these two models:
 


### PR DESCRIPTION
## Describe this PR

The opening two paragraphs of the ‘Relation fields’ section are word for word copies of the opening two paragraphs in the ‘Terminology’ section.

I think the readability of this page would improve a lot if these two sections were merged together, for the reason stated above and because the ‘Terminology’ section is exclusively about relation fields anyway.

## Changes

<!-- What changes have you made? Keep it brief!

- Removed the duplicate paragraphs from 'Relation fields' section
- Merged the content from 'Terminology' section into the 'Relation fields' section
