### PR TITLE
fix documentation for findMany JSON AnyNull

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -885,9 +885,9 @@ import { Prisma } from '@prisma/client'
 
 prisma.log.findMany({
   where: {
-    data: {
-      meta: Prisma.AnyNull,
-    },
+     meta: {
+       equals: Prisma.AnyNull,
+     },
   },
 })
 ```


### PR DESCRIPTION
## Describe this PR

PR fixes mistake in documentation on query filter for JSON AnyNull.

## Changes

Fixes example on how to query for AnyNull on JSON column.

## What issue does this fix?

Fixes #3609 

## Any other relevant information

N/A
