### PR TITLE
Fix typo in migrate from TypeORM

### DIFF
--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -506,7 +506,7 @@ The models that were generated via introspection currently _exactly_ map to your
 
 All of these adjustment are entirely optional and you are free to skip to the next step already if you don't want to adjust anything for now. You can go back and make the adjustments at any later point.
 
-As opposed to the current snake_case notation of Prisma models, Prisma's naming conventions are:
+As opposed to the current snake_case notation of TypeORM models, Prisma's naming conventions are:
 
 - PascalCase for model names
 - camelCase for field names


### PR DESCRIPTION
## Describe this PR

The migrate from TypeORM docs page has a typo saying Prisma uses snake_case when it should be TypeORM uses snake_case since Prisma uses camelCase

## Changes

Fixed typo

## What issue does this fix?

N/A

## Any other relevant information

N/A
