### PR TITLE
add tracing to Data proxy limitations

### DIFF
--- a/content/800-data-platform/03-data-proxy.mdx
+++ b/content/800-data-platform/03-data-proxy.mdx
@@ -153,7 +153,24 @@ You are now ready to try the Data Proxy. Go ahead and start your app!
 
 ### Limitations
 
-The Data Proxy does not support the preview features [Interactive Transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview), [Metrics](/concepts/components/prisma-client/metrics) or [OpenTelemetry tracing](/concepts/components/prisma-client/opentelemetry-tracing) yet. To use the Data Proxy, you must first remove `interactiveTransactions`, `metrics` and `tracing` from the `previewFeatures` section of your `schema.prisma` file. When you run `prisma generate --data-proxy`, you will receive an error if you have one of these preview features enabled.
+The Data Proxy does not yet support the following preview features:
+* [Interactive Transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview)
+* [Metrics](/concepts/components/prisma-client/metrics)
+* [OpenTelemetry tracing](/concepts/components/prisma-client/opentelemetry-tracing) 
+
+To use the Data Proxy, you must first remove `interactiveTransactions`, `metrics` and `tracing` from the `previewFeatures` section of your `schema.prisma` file.
+
+For example:
+
+```diff
+   generator client {
+     provider        = "prisma-client-js"
+-     previewFeatures = ["interactiveTransactions", "metrics", "tracing", "orderByNulls"]
++     previewFeatures = ["orderByNulls"]
+   }
+```
+
+When you run `prisma generate --data-proxy`, you will receive an error if you have one of the listed preview features enabled.
 
 ### Providing the connection string to Prisma Migrate
 

--- a/content/800-data-platform/03-data-proxy.mdx
+++ b/content/800-data-platform/03-data-proxy.mdx
@@ -153,7 +153,7 @@ You are now ready to try the Data Proxy. Go ahead and start your app!
 
 ### Limitations
 
-The Data Proxy does not support the preview features [Interactive Transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview) or [Metrics](/concepts/components/prisma-client/metrics) yet. To use the Data Proxy, you must first remove `interactiveTransactions` and `metrics` from the `previewFeatures` section of your `schema.prisma` file. When you run `prisma generate --data-proxy`, you will receive an error if you have either of these preview features enabled.
+The Data Proxy does not support the preview features [Interactive Transactions](/concepts/components/prisma-client/transactions#interactive-transactions-in-preview), [Metrics](/concepts/components/prisma-client/metrics) or [OpenTelemetry tracing](/concepts/components/prisma-client/opentelemetry-tracing) yet. To use the Data Proxy, you must first remove `interactiveTransactions`, `metrics` and `tracing` from the `previewFeatures` section of your `schema.prisma` file. When you run `prisma generate --data-proxy`, you will receive an error if you have one of these preview features enabled.
 
 ### Providing the connection string to Prisma Migrate
 

--- a/content/800-data-platform/03-data-proxy.mdx
+++ b/content/800-data-platform/03-data-proxy.mdx
@@ -165,8 +165,8 @@ For example:
 ```diff
    generator client {
      provider        = "prisma-client-js"
--     previewFeatures = ["interactiveTransactions", "metrics", "tracing", "orderByNulls"]
-+     previewFeatures = ["orderByNulls"]
+-     previewFeatures = ["interactiveTransactions", "metrics", "tracing"]
++     previewFeatures = []
    }
 ```
 

--- a/content/800-data-platform/03-data-proxy.mdx
+++ b/content/800-data-platform/03-data-proxy.mdx
@@ -170,7 +170,7 @@ For example:
    }
 ```
 
-When you run `prisma generate --data-proxy`, you will receive an error if you have one of the listed preview features enabled.
+When you run `prisma generate --data-proxy`, you will receive an error if you have one or more of the listed preview features enabled.
 
 ### Providing the connection string to Prisma Migrate
 

--- a/content/800-data-platform/03-data-proxy.mdx
+++ b/content/800-data-platform/03-data-proxy.mdx
@@ -170,7 +170,7 @@ For example:
    }
 ```
 
-When you run `prisma generate --data-proxy`, you will receive an error if you have one or more of the listed preview features enabled.
+When you run `prisma generate --data-proxy`, you will receive an error if you have one or more of these preview features enabled.
 
 ### Providing the connection string to Prisma Migrate
 


### PR DESCRIPTION
Since `tracing` is not compatible with the Data Proxy, I added it in the limitations