### PR TITLE
Update 100-prisma-schema-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1046,10 +1046,9 @@ Makes a field a list.
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>
 
-```prisma highlight=4;normal
+```prisma highlight=3;normal
 model User {
   id             Int      @id @default(autoincrement())
-  posts          Post[]
   favoriteColors String[]
 }
 ```
@@ -1057,10 +1056,9 @@ model User {
 </tab>
 <tab>
 
-```prisma highlight=4;normal
+```prisma highlight=3;normal
 model User {
   id             String   @id @default(auto()) @map("_id") @db.ObjectId
-  posts          Post[]
   favoriteColors String[]
 }
 ```
@@ -1075,10 +1073,9 @@ Available in version 4.0.0 and later.
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>
 
-```prisma highlight=4;normal
+```prisma highlight=3;normal
 model User {
   id             Int      @id @default(autoincrement())
-  posts          Post[]
   favoriteColors String[] @default(["red", "blue", "green"])
 }
 ```
@@ -1086,10 +1083,9 @@ model User {
 </tab>
 <tab>
 
-```prisma highlight=4;normal
+```prisma highlight=3;normal
 model User {
   id             String   @id @default(auto()) @map("_id") @db.ObjectId
-  posts          Post[]
   favoriteColors String[] @default(["red", "blue", "green"])
 }
 ```

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -1046,7 +1046,7 @@ Makes a field a list.
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>
 
-```prisma highlight=3;normal
+```prisma highlight=4;normal
 model User {
   id             Int      @id @default(autoincrement())
   posts          Post[]
@@ -1057,7 +1057,7 @@ model User {
 </tab>
 <tab>
 
-```prisma highlight=3;normal
+```prisma highlight=4;normal
 model User {
   id             String   @id @default(auto()) @map("_id") @db.ObjectId
   posts          Post[]


### PR DESCRIPTION
Currently the wrong line is highlighted in the code sample which leads to user confusion as we include examples of both a relationship (`Post[]`) and a Scalar list (`String[]`)

## Changes

- Changed the highlighted line

## What issue does this fix?

<img width="790" alt="Screen Shot 2022-08-19 at 09 09 37" src="https://user-images.githubusercontent.com/5479270/185637401-90db9ad9-5611-4f24-9f04-01f39028a3e1.png">