### PR TITLE
add PRISMA_HIDE_PREVIEW_FLAG_WARNINGS

### DIFF
--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -50,6 +50,11 @@ See [Studio](./command-reference#studio) documentation for more information.
 
 ## Prisma CLI
 
+
+### <inlinecode>PRISMA_HIDE_PREVIEW_FLAG_WARNINGS</inlinecode>
+
+`PRISMA_HIDE_PREVIEW_FLAG_WARNINGS` is used to hide the warning message that a preview feature flag can be removed. It's a truthy value.
+
 ### <inlinecode>PRISMA_HIDE_UPDATE_MESSAGE</inlinecode>
 
 `PRISMA_HIDE_UPDATE_MESSAGE` is used to hide the update notification message that is shown when a newer Prisma CLI version is available. It's a truthy value.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -53,7 +53,7 @@ See [Studio](./command-reference#studio) documentation for more information.
 
 ### <inlinecode>PRISMA_HIDE_PREVIEW_FLAG_WARNINGS</inlinecode>
 
-`PRISMA_HIDE_PREVIEW_FLAG_WARNINGS` is used to hide the warning message that a preview feature flag can be removed. It's a truthy value.
+`PRISMA_HIDE_PREVIEW_FLAG_WARNINGS` is used to hide the warning message stating that a preview feature flag can be removed. It is a truthy value.
 
 ### <inlinecode>PRISMA_HIDE_UPDATE_MESSAGE</inlinecode>
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -50,7 +50,6 @@ See [Studio](./command-reference#studio) documentation for more information.
 
 ## Prisma CLI
 
-
 ### <inlinecode>PRISMA_HIDE_PREVIEW_FLAG_WARNINGS</inlinecode>
 
 `PRISMA_HIDE_PREVIEW_FLAG_WARNINGS` is used to hide the warning message stating that a preview feature flag can be removed. It is a truthy value.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -52,7 +52,7 @@ See [Studio](./command-reference#studio) documentation for more information.
 
 ### <inlinecode>PRISMA_HIDE_PREVIEW_FLAG_WARNINGS</inlinecode>
 
-`PRISMA_HIDE_PREVIEW_FLAG_WARNINGS` is used to hide the warning message stating that a preview feature flag can be removed. It is a truthy value.
+`PRISMA_HIDE_PREVIEW_FLAG_WARNINGS` hides the warning message that states that a preview feature flag can be removed. It is a truthy value.
 
 ### <inlinecode>PRISMA_HIDE_UPDATE_MESSAGE</inlinecode>
 


### PR DESCRIPTION
Technically it's applicable for both Prisma Client and the CLI, but I didn't know where to put it, I picked CLI 🤔 