### PR TITLE
Count of relations is possible from 3.0.1, not 2.22.0

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/035-select-fields.mdx
@@ -314,4 +314,4 @@ For more information about querying relations, refer to the following documentat
 
 ## Relation count
 
-In [2.20.0](https://github.com/prisma/prisma/releases/2.20.0) and later, you can [`include` or `select` a count of relations](aggregation-grouping-summarizing#count-relations) alongside fields - for example, a user's post count.
+In [3.0.1](https://github.com/prisma/prisma/releases/3.0.1) and later, you can [`include` or `select` a count of relations](aggregation-grouping-summarizing#count-relations) alongside fields - for example, a user's post count.

--- a/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
@@ -366,7 +366,7 @@ const getUser = await prisma.user.findUnique({
 
 ### Relation count
 
-In [2.20.0](https://github.com/prisma/prisma/releases/2.20.0) and later, you can [`include` or `select` a count of relations](aggregation-grouping-summarizing#count-relations) alongside fields - for example, a user's post count.
+In [3.0.1](https://github.com/prisma/prisma/releases/3.0.1) and later, you can [`include` or `select` a count of relations](aggregation-grouping-summarizing#count-relations) alongside fields - for example, a user's post count.
 
 ### Filter a list of relations
 

--- a/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
@@ -329,7 +329,7 @@ const userCount = await prisma.user.count()
 
 ### Count relations
 
-The ability to count relations is available in version [2.20.0](https://github.com/prisma/prisma/releases/2.20.0) and later.
+The ability to count relations is available in version [3.0.1](https://github.com/prisma/prisma/releases/3.0.1) and later.
 
 <Admonition type="tip">
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1528,7 +1528,7 @@ const groupUsers = await prisma.user.groupBy({
 #### Remarks
 
 - You cannot combine `select` and `include` on the same level.
-- In [2.20.0](https://github.com/prisma/prisma/releases/2.20.0) and later, you can [select a `_count` of relations](#select-a-_count-of-relations).
+- In [3.0.1](https://github.com/prisma/prisma/releases/3.0.1) and later, you can [select a `_count` of relations](#select-a-_count-of-relations).
 
 #### Reference
 


### PR DESCRIPTION
Changed several docs to state that count of relations is possible from Prisma version 3.0.1, not 2.20.0 as previously stated.
