### PR TITLE
(wip) Added new header to docs

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -10,7 +10,7 @@ import RightChevron from '../icons/RightChevron'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import { useLocation } from '@reach/router'
 import ExternalLink from '../icons/ExternalLink'
-import { WebsiteHeader } from '@prisma/lens/dist/web'
+import { WebsiteHeader } from './header/WebsiteHeader'
 
 type HeaderViewProps = {
   headerProps: HeaderProps
@@ -335,7 +335,7 @@ const HeaderSec = ({ headerProps }: HeaderViewProps) => {
       {/* Top level header */}
       <HeaderWrapper>
         <Container>
-          <WebsiteHeader notFixed={true} lightFont={true} />
+          <WebsiteHeader lightTheme={false} clearBg={true} notFixed={true} />
         </Container>
       </HeaderWrapper>
 

--- a/src/components/header/Container.tsx
+++ b/src/components/header/Container.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  box-sizing: border-box;
+  margin: auto;
+  width: 100%;
+  padding: 0 2rem;
+  @media only screen and (min-width: 940px) {
+    padding: 0 1.5rem;
+    max-width: 1248px; // 1200 plus 2 x padding
+  }
+`

--- a/src/components/header/WebsiteHeader.tsx
+++ b/src/components/header/WebsiteHeader.tsx
@@ -1,0 +1,573 @@
+import * as React from 'react'
+import { Container } from './Container'
+import { Button } from './ui/controls/Button'
+import { Label } from './ui/typography/Label'
+import * as DD from './ui/navigation/Dropdown'
+import * as NavBar from './ui/navigation/NavBar'
+import styled, { css } from 'styled-components'
+import { useEffect, useState } from 'react'
+import { defaultTheme, darkTheme } from './theme'
+
+interface HeaderProps {
+  className?: string
+  lightTheme?: boolean
+  clearBg?: boolean
+  notFixed?: boolean
+}
+
+const navPathnames = [
+  'product_client',
+  'product_migrate',
+  'product_data-platform',
+  'product_data-platform/proxy',
+  'developer_docs',
+  'developer_docs/getting-started',
+  'developer_dataguide',
+  'developer_stack',
+  'developer_support',
+  'developer_community',
+  'use-cases_showcase',
+  'use-cases_enterprise',
+  'company_about',
+  'company_blog',
+  'company_jobs',
+  'company_events',
+  'pricing',
+]
+
+const MobileHeader = styled.div<{ theme: any }>(
+  ({ theme }) => css`
+    width: 100%;
+    justify-content: space-between;
+    display: flex;
+    height: 96px;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 0 32px;
+    .menu-toggle-button {
+      display: inline-flex;
+      background-color: transparent;
+      border: none;
+      color: ${theme.header.mobileMenuButtonColor};
+    }
+    @media only screen and (min-width: ${theme.header.mobileNavigationBreakpoint}px) {
+      padding: 0;
+      display: initial;
+      height: auto;
+      width: auto;
+      .menu-toggle-button {
+        display: none;
+      }
+    }
+  `
+)
+
+const HeaderWrapper = ({
+  className,
+  lightTheme = true,
+  clearBg = false,
+  notFixed = false,
+}: HeaderProps) => {
+  let themeToUse = lightTheme ? defaultTheme : darkTheme
+  const [topNav, setTopNav] = useState('/')
+  const [activeNav, setActiveNav] = useState('/')
+  const headerAssets = 'https://prismalens.netlify.app/'
+
+  useEffect(() => {
+    const windowPath = navPathnames.filter((e) =>
+      e.includes(window.location.pathname.substring(1).replace('/', ''))
+    )
+    if (windowPath.length > 0 && window.location.pathname !== '/') {
+      handleNavClick(windowPath[0].split('_')[0], windowPath[0].split('_')[1] ?? '')
+    } else {
+      handleNavClick('', '')
+    }
+  }, [])
+
+  const handleNavClick = (top: string, bottom: string) => {
+    setTopNav(top)
+    setActiveNav(bottom)
+  }
+
+  return (
+    <NavBar.NavBar lightTheme={lightTheme}>
+      <NavBar.NavBarContext.Consumer>
+        {({ state: { mobileOpen } }) => (
+          <>
+            <div className={className + (mobileOpen ? ' open' : '')}>
+              <Container className="container">
+                <NavBar.NavBarInner>
+                  <MobileHeader theme={themeToUse}>
+                    <a href="https://www.prisma.io/">
+                      <img
+                        src={themeToUse.header.logoUrl}
+                        width={90}
+                        height={27}
+                        alt="prisma_logo"
+                        style={{ cursor: 'pointer', display: 'block' }}
+                      />
+                    </a>
+
+                    <NavBar.MenuButton />
+                  </MobileHeader>
+
+                  <NavBar.NavItemsContainer
+                    lightTheme={lightTheme}
+                    className={mobileOpen ? '' : 'hidden-on-mobile'}
+                  >
+                    <NavBar.NavItem
+                      lightTheme={lightTheme}
+                      title={'Product'}
+                      active={topNav === 'product'}
+                      dropdown={
+                        <DD.Panel lightTheme={lightTheme}>
+                          <DD.SectionHeader lightTheme={lightTheme}>Prisma ORM</DD.SectionHeader>
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'client'}
+                            onClick={() => handleNavClick('product', 'client')}
+                            href={'https://prisma.io/client/'}
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-Client.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Client"
+                              ></img>
+                            }
+                            title={'Client'}
+                            subtitle={'Write Queries the way you think'}
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'migrate'}
+                            onClick={() => handleNavClick('product', 'migrate')}
+                            href={'https://prisma.io/migrate/'}
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-Migrate.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Migrate"
+                              ></img>
+                            }
+                            title={'Migrate'}
+                            subtitle={'Generate customisable SQL migrations'}
+                          />
+
+                          <DD.SectionHeader lightTheme={lightTheme}>
+                            Prisma Data Platform
+                          </DD.SectionHeader>
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'data-platform'}
+                            onClick={() => handleNavClick('product', 'data-platform')}
+                            href={'https://prisma.io/data-platform/'}
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-DataBrowser.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Data Browser"
+                              ></img>
+                            }
+                            title={'Data Browser'}
+                            subtitle={'Explore and manipulate data in your projects'}
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'data-platform/proxy'}
+                            onClick={() => handleNavClick('product', 'data-platform/proxy')}
+                            href={'https://prisma.io/data-platform/proxy/'}
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-ServerlessDataProxy.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Data Proxy"
+                              ></img>
+                            }
+                            title={'Data Proxy'}
+                            subtitle={'Manage and scale your connection pool'}
+                          />
+                        </DD.Panel>
+                      }
+                    />
+
+                    <NavBar.NavItem
+                      lightTheme={lightTheme}
+                      href="https://prisma.io/pricing/"
+                      title={'Pricing'}
+                      active={topNav === 'pricing'}
+                      onClick={() => handleNavClick('pricing', '')}
+                    />
+
+                    <NavBar.NavItem
+                      lightTheme={lightTheme}
+                      title={'Developer'}
+                      active={topNav === 'developer'}
+                      dropdown={
+                        <DD.Panel lightTheme={lightTheme} width={461}>
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'docs'}
+                            onClick={() => handleNavClick('developer', 'docs')}
+                            href={'https://prisma.io/docs/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-Docs.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Data Proxy"
+                              ></img>
+                            }
+                            title={'Documentation'}
+                            subtitle={
+                              'Refer to our technical documentation to configure Prisma, access APIs, develop and deploy your app'
+                            }
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'docs/getting-started'}
+                            onClick={() => handleNavClick('developer', 'docs/getting-started')}
+                            href={'https://prisma.io/docs/getting-started/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-GetStarted.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Get Started"
+                              ></img>
+                            }
+                            title={'Get Started'}
+                            subtitle={'Set up Prisma for your project'}
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            href={'https://github.com/prisma/prisma-examples'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-PrismaExplained.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Prisma Examples"
+                              ></img>
+                            }
+                            title={'Prisma Examples ->'}
+                            subtitle={'Access dozens of ready-to-run Prisma example projects'}
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'dataguide'}
+                            onClick={() => handleNavClick('developer', 'dataguide')}
+                            href={'https://prisma.io/dataguide/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-DataGuide.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Data Guide"
+                              ></img>
+                            }
+                            title={'Data Guide'}
+                            subtitle={'Refer to expert articles on how databases work'}
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'stack'}
+                            onClick={() => handleNavClick('developer', 'stack')}
+                            href={'https://prisma.io/stack/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-PrismaInYourStack.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Prisma in your Stack"
+                              ></img>
+                            }
+                            title={'Prisma in your Stack'}
+                            subtitle={
+                              'Learn about Prisma’s integration with modern technology stacks, platforms, and applications'
+                            }
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'support'}
+                            onClick={() => handleNavClick('developer', 'support')}
+                            href={'https://prisma.io/support/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-Support.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Support"
+                              ></img>
+                            }
+                            title={'Support'}
+                            subtitle={'Find resources and get help from our support team'}
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'community'}
+                            onClick={() => handleNavClick('developer', 'community')}
+                            href={'https://prisma.io/community/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-Community.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Community"
+                              ></img>
+                            }
+                            title={'Community'}
+                            subtitle={'Join the growing Prisma community'}
+                          />
+                        </DD.Panel>
+                      }
+                    />
+
+                    <NavBar.NavItem
+                      lightTheme={lightTheme}
+                      title={'Use Cases'}
+                      active={topNav === 'use-cases'}
+                      dropdown={
+                        <DD.Panel lightTheme={lightTheme} width={441}>
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'showcase'}
+                            onClick={() => handleNavClick('use-cases', 'showcase')}
+                            href={'https://prisma.io/showcase/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-CustomerStories.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Data Proxy"
+                              ></img>
+                            }
+                            title={'Customer Stories'}
+                            subtitle={'Learn about applications built with Prisma'}
+                          />
+                          <DD.IconLink
+                            lightTheme={lightTheme}
+                            active={activeNav === 'enterprise'}
+                            onClick={() => handleNavClick('use-cases', 'enterprise')}
+                            href={'https://prisma.io/enterprise/'}
+                            titleOnlyOnMobile
+                            icon={
+                              <img
+                                src={headerAssets + `/header/icons/Icon-Enterprise.svg`}
+                                className="image"
+                                height={16}
+                                width={16}
+                                alt="Data Proxy"
+                              ></img>
+                            }
+                            title={'Enterprise'}
+                            subtitle={'Up-level your applications with our Data Platform'}
+                          />
+                        </DD.Panel>
+                      }
+                    />
+
+                    <NavBar.NavItem
+                      lightTheme={lightTheme}
+                      title={'Company'}
+                      active={topNav === 'company'}
+                      dropdown={
+                        <DD.Panel lightTheme={lightTheme} width={621}>
+                          <div className="company-dropdown-container">
+                            <div className="company-links">
+                              <DD.Link
+                                lightTheme={lightTheme}
+                                active={activeNav === 'about'}
+                                onClick={() => handleNavClick('company', 'about')}
+                                href={'https://prisma.io/about/'}
+                              >
+                                About
+                              </DD.Link>
+                              <DD.Link
+                                lightTheme={lightTheme}
+                                active={activeNav === 'blog'}
+                                onClick={() => handleNavClick('company', 'blog')}
+                                href={'https://prisma.io/blog/'}
+                              >
+                                Blog
+                              </DD.Link>
+                              <DD.Link
+                                lightTheme={lightTheme}
+                                active={activeNav === 'jobs'}
+                                onClick={() => handleNavClick('company', 'jobs')}
+                                href={'https://prisma.io/jobs/'}
+                              >
+                                Careers{' '}
+                                <Label type={'secondary'} css={{ fontSize: 12 }}>
+                                  We&apos;re Hiring
+                                </Label>
+                              </DD.Link>
+                              <DD.Link
+                                lightTheme={lightTheme}
+                                active={activeNav === 'events'}
+                                onClick={() => handleNavClick('company', 'events')}
+                                href={'https://prisma.io/events/'}
+                              >
+                                Events
+                              </DD.Link>
+                              <DD.Link
+                                active={activeNav === 'causes'}
+                                lightTheme={lightTheme}
+                                href={'https://pris.ly/causes'}
+                              >{`Causes ->`}</DD.Link>
+                            </div>
+
+                            <DD.VerticalDivider />
+
+                            <div className="articles">
+                              <DD.ArticlesHeader>Latest from the blog</DD.ArticlesHeader>
+
+                              <DD.ArticleLink
+                                href={
+                                  'https://www.prisma.io/blog/nestjs-prisma-rest-api-7D056s1BmOL0'
+                                }
+                                image={
+                                  <img
+                                    src={headerAssets + `/header/blogpost1.webp`}
+                                    alt="Landscape picture"
+                                    width={148}
+                                    height={83}
+                                    style={{ borderRadius: '4px' }}
+                                  />
+                                }
+                                title={'Building a REST API with NestJS and Prisma'}
+                              />
+
+                              <DD.ArticleLink
+                                href={'https://www.prisma.io/blog/cockroach-ga-5JrD9XVWQDYL'}
+                                image={
+                                  <img
+                                    src={headerAssets + `/header/blogpost2.webp`}
+                                    alt="Landscape picture"
+                                    width={148}
+                                    height={83}
+                                    style={{ borderRadius: '4px' }}
+                                  />
+                                }
+                                title={'Prisma Support for CockroachDB Is Production Ready'}
+                              />
+                            </div>
+                          </div>
+                        </DD.Panel>
+                      }
+                    />
+                  </NavBar.NavItemsContainer>
+
+                  <div className={'header-cta-container' + (mobileOpen ? '' : ' hidden-on-mobile')}>
+                    <Button href={'https://prisma.io/docs/getting-started/quickstart'}>
+                      Get Started
+                    </Button>
+                  </div>
+                </NavBar.NavBarInner>
+              </Container>
+            </div>
+          </>
+        )}
+      </NavBar.NavBarContext.Consumer>
+    </NavBar.NavBar>
+  )
+}
+
+const WebsiteHeader = styled(HeaderWrapper)(
+  ({ lightTheme = true, clearBg = false, notFixed = false }: HeaderProps) => {
+    const themeToUse = lightTheme ? defaultTheme : darkTheme
+    const clearHeader = clearBg
+    const fixedHeader = !notFixed
+    return css`
+      position: ${fixedHeader ? 'fixed' : 'relative'};
+      top: 0;
+      left: 0;
+      background-color: ${clearHeader ? 'transparent' : themeToUse.header.backgroundColor};
+      width: 100%;
+      z-index: 9999;
+      border-bottom: none;
+      @media only screen and (max-width: ${themeToUse.header.mobileNavigationBreakpoint - 1}px) {
+        background-color: ${themeToUse.header.backgroundColor};
+        border-bottom: 1px solid ${themeToUse.header.mobileLinkDividerColor};
+      }
+
+      &.open {
+        height: 100vh;
+        overflow: scroll;
+      }
+
+      .container {
+        @media only screen and (max-width: ${themeToUse.header.mobileNavigationBreakpoint - 1}px) {
+          padding: 0;
+        }
+      }
+
+      .hidden-on-mobile {
+        @media only screen and (max-width: ${themeToUse.header.mobileNavigationBreakpoint - 1}px) {
+          display: none;
+        }
+      }
+
+      .header-cta-container {
+        width: 100%;
+        a {
+          width: 100%;
+        }
+        padding: 24px 24px 24px;
+        @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+          padding: 0;
+          width: auto;
+          a {
+            width: auto;
+          }
+        }
+      }
+
+      .company-dropdown-container {
+        display: flex;
+        flex-direction: row;
+        .company-links {
+          flex-shrink: 0;
+          width: 100%;
+          @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+            padding: 0 12px 0 20px;
+            box-sizing: content-box;
+            width: 187px;
+          }
+        }
+        .articles {
+          padding: 0 24px;
+          display: none;
+          @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+            display: block;
+          }
+        }
+      }
+    `
+  }
+)
+
+export { WebsiteHeader }

--- a/src/components/header/theme/@types/image.d.ts
+++ b/src/components/header/theme/@types/image.d.ts
@@ -1,0 +1,9 @@
+declare module '*.svg' {
+  const content: any
+  export default content
+}
+
+declare module '*.webp' {
+  const content: any
+  export default content
+}

--- a/src/components/header/theme/@types/index.d.ts
+++ b/src/components/header/theme/@types/index.d.ts
@@ -1,0 +1,9 @@
+import { CSSProp } from 'styled-components'
+
+interface MyTheme {}
+
+declare module 'react' {
+  interface Attributes {
+    css?: CSSProp<MyTheme>
+  }
+}

--- a/src/components/header/theme/breakpoints.ts
+++ b/src/components/header/theme/breakpoints.ts
@@ -1,0 +1,5 @@
+export const mobile = 360
+export const tabletVertical = 768
+export const desktopSmall = 940
+export const tabletHorizontal = 1024
+export const desktopLarge = 1440

--- a/src/components/header/theme/components/buttons.ts
+++ b/src/components/header/theme/components/buttons.ts
@@ -1,0 +1,200 @@
+import * as t from '../primitives'
+import { blueGray } from '../primitives'
+
+const buttonDefault = {
+  transition: 'background-color .1s ease, color .2s ease',
+  backgroundColor: 'transparent', // t.gray['500']
+  color: t.colors.text,
+  fontFamily: t.fonts.text,
+  fontWeight: 500,
+  hover: {
+    backgroundColor: 'transparent', // t.gray['600']
+  },
+}
+
+export const buttonsDefault = {
+  primary: {
+    ...buttonDefault,
+    color: 'white',
+    backgroundColor: t.indigo[600],
+    border: `1px solid ${t.indigo[600]}`,
+    hover: {
+      border: `1px solid ${t.indigo[700]}`,
+      backgroundColor: t.indigo[700],
+      color: 'white',
+    },
+    active: {
+      border: `1px solid ${t.indigo[800]}`,
+      backgroundColor: t.indigo[800],
+      color: 'white',
+    },
+    indigo: {
+      backgroundColor: t.indigo[600],
+      color: 'white',
+      border: `1px solid ${t.indigo[600]}`,
+      hover: {
+        border: `1px solid ${t.indigo[700]}`,
+        backgroundColor: t.indigo[700],
+        color: 'white',
+      },
+      active: {
+        border: `1px solid ${t.indigo[800]}`,
+        backgroundColor: t.indigo[800],
+        color: 'white',
+      },
+    },
+    teal: {
+      backgroundColor: t.teal[600],
+      color: 'white',
+      border: `1px solid ${t.teal[600]}`,
+      hover: {
+        border: `1px solid ${t.teal[700]}`,
+        backgroundColor: t.teal[700],
+        color: 'white',
+      },
+      active: {
+        border: `1px solid ${t.teal[800]}`,
+        backgroundColor: t.teal[800],
+        color: 'white',
+      },
+    },
+    white: {
+      backgroundColor: 'white',
+      color: t.indigo[600],
+      border: `1px solid white`,
+      hover: {
+        border: `1px solid white`,
+        backgroundColor: 'white',
+        color: t.indigo[700],
+      },
+      active: {
+        border: `1px solid white`,
+        backgroundColor: 'white',
+        color: t.indigo[800],
+      },
+    },
+  },
+
+  secondary: {
+    ...buttonDefault,
+    color: t.indigo[600],
+    border: `1px solid ${t.indigo[600]}`,
+    hover: {
+      backgroundColor: 'white',
+      color: t.indigo[700],
+      border: `1px solid ${t.indigo[700]}`,
+    },
+    active: {
+      backgroundColor: 'white',
+      color: t.indigo[800],
+      border: `1px solid ${t.indigo[800]}`,
+    },
+    indigo: {
+      backgroundColor: 'white',
+      color: t.indigo[600],
+      border: `1px solid ${t.indigo[600]}`,
+      hover: {
+        backgroundColor: 'white',
+        border: `1px solid ${t.indigo[700]}`,
+        color: t.indigo[700],
+      },
+      active: {
+        backgroundColor: 'white',
+        border: `1px solid ${t.indigo[800]}`,
+        color: t.indigo[800],
+      },
+    },
+    teal: {
+      backgroundColor: 'white',
+      color: t.teal[600],
+      border: `1px solid ${t.teal[600]}`,
+      hover: {
+        border: `1px solid ${t.teal[700]}`,
+        backgroundColor: 'white',
+        color: t.teal[700],
+      },
+      active: {
+        border: `1px solid ${t.teal[800]}`,
+        backgroundColor: 'white',
+        color: t.teal[800],
+      },
+    },
+    white: {
+      backgroundColor: 'white',
+      color: t.indigo[600],
+      border: `1px solid ${t.indigo[600]}`,
+      hover: {
+        backgroundColor: 'white',
+        border: `1px solid ${t.indigo[700]}`,
+        color: t.indigo[700],
+      },
+      active: {
+        backgroundColor: 'white',
+        border: `1px solid ${t.indigo[800]}`,
+        color: t.indigo[800],
+      },
+    },
+  },
+
+  link: {
+    ...buttonDefault,
+    backgroundColor: 'transparent',
+    color: t.indigo[600],
+    border: 'none',
+    hover: {
+      backgroundColor: 'transparent',
+      color: t.indigo[800],
+      border: 'none',
+    },
+    active: {
+      backgroundColor: 'transparent',
+      color: t.indigo[800],
+      border: 'none',
+    },
+    indigo: {
+      backgroundColor: 'transparent',
+      color: t.indigo[600],
+      border: 'none',
+      hover: {
+        backgroundColor: 'transparent',
+        color: t.indigo[800],
+        border: 'none',
+      },
+      active: {
+        backgroundColor: 'transparent',
+        color: t.indigo[800],
+        border: 'none',
+      },
+    },
+    teal: {
+      backgroundColor: 'transparent',
+      color: t.teal[600],
+      border: 'none',
+      hover: {
+        backgroundColor: 'transparent',
+        color: t.teal[800],
+        border: 'none',
+      },
+      active: {
+        backgroundColor: 'transparent',
+        color: t.teal[800],
+        border: 'none',
+      },
+    },
+    white: {
+      backgroundColor: 'transparent',
+      border: 'none',
+      color: t.indigo[600],
+      hover: {
+        backgroundColor: 'transparent',
+        color: t.indigo[800],
+        border: 'none',
+      },
+      active: {
+        backgroundColor: 'transparent',
+        color: t.indigo[800],
+        border: 'none',
+      },
+    },
+  },
+}

--- a/src/components/header/theme/components/header.ts
+++ b/src/components/header/theme/components/header.ts
@@ -1,0 +1,33 @@
+import * as t from '../primitives'
+
+export const headerDefault = {
+  backgroundColor: 'white',
+  mobileNavigationBreakpoint: 940,
+  logoUrl: 'https://website-v9.vercel.app/logo-dark.svg',
+  navItemColor: t.gray['800'],
+  navItemHoverColor: t.indigo[600],
+
+  mobileMenuButtonColor: t.gray['800'],
+  mobileLinkDividerColor: t.gray['300'],
+  // Dropdown Panel on Mobile
+  mobileDropdownPanelBackgroundColor: t.blueGray['100'],
+  mobileDropdownPanelHeadingColor: t.gray['600'],
+  mobileDropdownPanelLinkTitleColor: t.gray['800'],
+  mobileDropdownPanelLinkSubTitleColor: t.blueGray['600'],
+}
+
+export const headerDark: typeof headerDefault = {
+  backgroundColor: t.black,
+  logoUrl: 'https://website-v9.vercel.app/logo-white.svg',
+  mobileNavigationBreakpoint: 940,
+  navItemColor: 'white',
+  navItemHoverColor: t.indigo[300],
+
+  mobileLinkDividerColor: t.gray['700'],
+  mobileMenuButtonColor: 'white',
+  // Dropdown Panel on Mobile
+  mobileDropdownPanelBackgroundColor: t.gray['800'],
+  mobileDropdownPanelHeadingColor: t.gray['400'],
+  mobileDropdownPanelLinkTitleColor: 'white',
+  mobileDropdownPanelLinkSubTitleColor: 'white',
+}

--- a/src/components/header/theme/components/labels.ts
+++ b/src/components/header/theme/components/labels.ts
@@ -1,0 +1,15 @@
+import * as t from '../primitives'
+
+const labelDefault = {
+  backgroundColor: t.gray[500],
+  color: 'white',
+  fontSize: t.fontSizes[14],
+  padding: `${t.baseSpace[5]} ${t.baseSpace[8]}`,
+  borderRadius: '4px',
+}
+
+export const labelsDefault = {
+  default: labelDefault,
+  primary: { ...labelDefault, backgroundColor: t.indigo[600] },
+  secondary: { ...labelDefault, backgroundColor: t.teal[500] },
+}

--- a/src/components/header/theme/css/button.ts
+++ b/src/components/header/theme/css/button.ts
@@ -1,0 +1,173 @@
+import { css } from 'styled-components'
+import * as t from '../primitives'
+
+type ColorType = 'indigo' | 'teal' | 'white'
+type TypeBtn = 'primary' | 'secondary' | 'link'
+
+export const buttonCss = (
+  type: TypeBtn,
+  color: ColorType,
+  icon: undefined | 'left' | 'right',
+  disabled: boolean,
+  theme: any
+) => {
+  const btnType = theme.buttons[type]
+  return css`
+    display: inline-flex;
+    justify-content: center;
+    z-index: 1000;
+    margin: 4px;
+    width: max-content;
+    align-items: center;
+    box-sizing: border-box;
+    border-radius: 6px;
+    text-decoration: none;
+    height: 48px;
+    cursor: ${disabled ? 'auto' : 'pointer'};
+    position: relative;
+    line-height: 1;
+    transition: ${theme.buttons[type].transition};
+    font-family: ${theme.buttons[type].fontFamily};
+    font-weight: ${theme.buttons[type].fontWeight};
+    font-size: 18px;
+    border: none;
+    ${!disabled && `border: ${color ? btnType[color]?.border : theme.buttons[type].border};`}
+    background-color: ${disabled
+      ? t.colors.gray[300]
+      : color
+      ? btnType[color]?.backgroundColor
+      : theme.buttons[type].backgroundColor};
+    color: ${disabled
+      ? t.colors.gray[600]
+      : color
+      ? btnType[color]?.color
+      : theme.buttons[type].color};
+    padding: ${type !== 'link'
+      ? icon && !disabled
+        ? icon === 'left'
+          ? '16px 24px 16px 48px'
+          : '16px 48px 16px 24px'
+        : '16px 24px'
+      : '0 20px 0 0'};
+    ${!disabled
+      ? `
+    &:hover {
+      ${
+        type !== 'link' &&
+        `border: ${color ? btnType[color]?.hover.border : theme.buttons[type].hover.border};`
+      }
+      background-color: ${
+        color ? btnType[color]?.hover.backgroundColor : theme.buttons[type].hover.backgroundColor
+      };
+      color: ${btnType[color]?.hover.color};
+      ${type !== 'primary' ? `border-color: ${btnType[color]?.hover.color};` : ``}
+      &:before {
+        background-color: ${color ? btnType[color]?.hover.color : theme.buttons[type].hover.color};
+      }
+      > span {
+        transform: translateX(4px);
+        &:before {
+          background-color: ${
+            color ? btnType[color]?.hover.color : theme.buttons[type].hover.color
+          };
+        }
+        &:after {
+          border-color: ${color ? btnType[color]?.hover.color : theme.buttons[type].hover.color};
+        }
+      }
+  };`
+      : ``}
+    &:focus {
+      &:after {
+        content: '';
+        position: absolute;
+        width: calc(100% + 8px);
+        height: calc(100% + 8px);
+        left: -4px;
+        top: -4px;
+        border-radius: 8px;
+        border: 2px solid ${t.colors.indigo[700]};
+      }
+    }
+    &:active {
+      ${type !== 'link' &&
+      `border: ${color ? btnType[color]?.active.border : theme.buttons[type].active.border};`}
+      background-color: ${color
+        ? btnType[color]?.active.backgroundColor
+        : theme.buttons[type].active.backgroundColor};
+      color: ${btnType[color]?.active.color};
+      ${type !== 'primary' ? `border-color: ${btnType[color]?.active.color};` : ``}
+      &:before {
+        background-color: ${color
+          ? btnType[color]?.active.color
+          : theme.buttons[type].active.color};
+      }
+      > span {
+        transform: translateX(4px);
+        &:before {
+          background-color: ${color
+            ? btnType[color]?.active.color
+            : theme.buttons[type].active.color};
+        }
+        &:after {
+          border-color: ${color ? btnType[color]?.active.color : theme.buttons[type].active.color};
+        }
+      }
+    }
+    ${type === 'link' &&
+    `
+    &:before {
+      content: "";
+      position: absolute;
+      height: 2px;
+      width: calc(100% + 6px);
+      left: 0;
+      bottom: -4px;
+      background-color: ${color ? btnType[color]?.color : theme.buttons[type].color};
+    };
+  `}
+  `
+}
+
+export const arrowIcon = (
+  type: TypeBtn,
+  color: ColorType,
+  icon: undefined | 'left' | 'right',
+  disabled: boolean,
+  theme: any
+) => {
+  const btnType = theme.buttons[type]
+  return css`
+    ${!disabled || type === 'link'
+      ? `
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    transition: transform 200ms;
+    &:before {
+      content: "";
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 12px;
+      ${icon === 'left' ? `left: 24px` : type === 'link' ? `right: 0` : `right: 19px`};
+      height: 1.5px;
+      background-color: ${color ? btnType[color]?.color : theme.buttons[type].color};
+    }
+    &:after {
+      content: "";
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      top: 50%;
+      border-top: 1.5px solid ${color ? btnType[color]?.color : theme.buttons[type].color};
+      border-right: 1.5px solid ${color ? btnType[color]?.color : theme.buttons[type].color};
+      transform: translateY(-50%) rotate(45deg);
+      ${icon === 'left' ? `left: 24px` : type === 'link' ? `right: 0` : `right: 19px`};
+    }
+  `
+      : ``}
+  `
+}

--- a/src/components/header/theme/dark.ts
+++ b/src/components/header/theme/dark.ts
@@ -1,0 +1,24 @@
+import * as t from './primitives'
+import { buttonsDefault } from './components/buttons'
+import { labelsDefault } from './components/labels'
+import { headerDark } from './components/header'
+import * as breakpoints from './breakpoints'
+
+const theme = {
+  breakpoints,
+
+  bodyBackgroundColor: 'white',
+
+  header: headerDark,
+
+  labels: labelsDefault,
+
+  buttons: buttonsDefault,
+
+  fonts: t.fonts,
+  fontSizes: t.fontSizes,
+  colors: t.colors,
+  space: t.space,
+}
+
+export default theme

--- a/src/components/header/theme/default.ts
+++ b/src/components/header/theme/default.ts
@@ -1,0 +1,24 @@
+import * as t from './primitives'
+import { buttonsDefault } from './components/buttons'
+import { labelsDefault } from './components/labels'
+import { headerDefault } from './components/header'
+import * as breakpoints from './breakpoints'
+
+const theme = {
+  breakpoints,
+
+  bodyBackgroundColor: 'white',
+
+  header: headerDefault,
+
+  labels: labelsDefault,
+
+  buttons: buttonsDefault,
+
+  fonts: t.fonts,
+  fontSizes: t.fontSizes,
+  colors: t.colors,
+  space: t.space,
+}
+
+export default theme

--- a/src/components/header/theme/index.ts
+++ b/src/components/header/theme/index.ts
@@ -1,0 +1,2 @@
+export { default as defaultTheme } from './default'
+export { default as darkTheme } from './dark'

--- a/src/components/header/theme/primitives.ts
+++ b/src/components/header/theme/primitives.ts
@@ -1,0 +1,134 @@
+export const gray = {
+  100: '#F7FAFC',
+  300: '#E2E8F0',
+  400: '#CBD5E0',
+  500: '#A0AEC0',
+  600: '#718096',
+  700: '#4A5568',
+  800: '#2D3748',
+}
+
+export const black = '#1A202C'
+
+export const blueGray = {
+  100: '#F7FAFC',
+  200: '#EDF2F7',
+  300: '#E2E8F0',
+  400: '#CBD5E0',
+  500: '#A0AEC0',
+  600: '#718096',
+  700: '#4A5568',
+  800: '#2D3748',
+  900: '#1A202C',
+}
+
+export const teal = {
+  500: '#38B2AC',
+  600: '#319795',
+  700: '#187367',
+  800: '#154F47',
+}
+
+export const indigo = {
+  100: '#EBF4FF',
+  200: '#C3DAFE',
+  300: '#A3BFFA',
+  400: '#7F9CF5',
+  500: '#667EEA',
+  600: '#5A67D8',
+  700: '#4C51BF',
+  800: '#434190',
+}
+
+export const red = {
+  700: '#C53030',
+}
+
+export const colors = {
+  gray,
+  red,
+  indigo,
+  teal,
+  blueGray,
+  text: gray[800],
+  textSecondary: gray[600],
+}
+
+export const fonts = {
+  text: `"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+  display: `"Barlow", system-ui,  Arial, sans-serif`,
+  mono: `"JetBrains Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+  heading: `'Barlow', sans-serif`,
+}
+
+export const baseFontSizes = {
+  12: '.75rem',
+  14: '.875rem',
+  16: '1rem',
+  18: '1.125rem',
+  20: '1.25rem',
+  22: '1.375rem',
+  24: '1.5rem',
+  26: '1.625rem',
+  28: '1.75rem',
+  30: '1.875rem',
+  32: '2rem',
+  36: '2.25rem',
+  38: '2.375rem',
+  40: '2.5rem',
+  48: '3rem',
+  56: '3.5rem',
+  64: '4rem',
+  72: '4.5rem',
+}
+
+export const fontSizes = {
+  ...baseFontSizes,
+  small: baseFontSizes[14],
+  body: baseFontSizes[16],
+  large: baseFontSizes[20],
+  display: baseFontSizes[48],
+  displaySmall: baseFontSizes[24],
+  displayLarge: baseFontSizes[72],
+}
+
+export const baseSpace = {
+  0: '0rem',
+  1: '1px',
+  2: '0.125rem',
+  4: '0.25rem',
+  5: `${5 / 16}rem`, // Maybe don't use this even though it's from design?
+  6: `${6 / 16}rem`, // Maybe don't use this even though it's from design?
+  8: '0.5rem',
+  12: '0.75rem',
+  14: '0.875rem',
+  15: `${15 / 16}rem`,
+  16: '1rem',
+  18: '1.125rem',
+  20: '1.25rem',
+  22: '1.375rem',
+  24: '1.5rem',
+  26: `${26 / 16}rem`,
+  30: `${30 / 16}rem`,
+  32: '2rem',
+  40: '2.5rem',
+  45: `${45 / 16}rem`,
+  48: '3rem',
+  64: '4rem',
+  80: '5rem',
+  96: '6rem',
+  128: '8rem',
+  160: '10rem',
+  192: '12rem',
+  224: '14rem',
+  256: '16rem',
+}
+
+export const space = {
+  ...baseSpace,
+  none: baseSpace[0],
+  one: baseSpace[1],
+  small: baseSpace[8],
+  medium: baseSpace[12],
+  large: baseSpace[20],
+}

--- a/src/components/header/ui/controls/Button.tsx
+++ b/src/components/header/ui/controls/Button.tsx
@@ -1,0 +1,45 @@
+import { AnchorHTMLAttributes, HTMLAttributes } from 'react'
+import { css } from 'styled-components'
+import { buttonCss, arrowIcon } from '../../theme/css/button'
+import { defaultTheme } from '../../theme'
+import * as React from 'react'
+
+type ColorType = 'indigo' | 'teal' | 'white'
+type TypeBtn = 'primary' | 'secondary' | 'link'
+
+type BtnType = {
+  type?: TypeBtn
+  color?: ColorType
+  icon?: undefined | 'left' | 'right'
+  disabled?: boolean
+  href?: string
+}
+
+type ButtonProps = HTMLAttributes<HTMLButtonElement> &
+  AnchorHTMLAttributes<HTMLAnchorElement> &
+  BtnType
+
+export const Button = ({
+  type = 'primary',
+  color = 'indigo',
+  icon = undefined,
+  disabled = false,
+  href = undefined,
+  ...rest
+}: ButtonProps) => {
+  return href ? (
+    <a css={buttonCss(type, color, icon, disabled, defaultTheme)} href={href} {...rest}>
+      {rest.children}
+      {(type === 'link' || icon) && (
+        <span css={arrowIcon(type, color, icon, disabled, defaultTheme)} />
+      )}
+    </a>
+  ) : (
+    <button css={buttonCss(type, color, icon, disabled, defaultTheme)} {...rest}>
+      {rest.children}
+      {(type === 'link' || icon) && (
+        <span css={arrowIcon(type, color, icon, disabled, defaultTheme)} />
+      )}
+    </button>
+  )
+}

--- a/src/components/header/ui/controls/mailchimp.ts
+++ b/src/components/header/ui/controls/mailchimp.ts
@@ -1,0 +1,20 @@
+/**
+ * Subscribe to mailchimp
+ *
+ * TODO: better align with mailchimp, this is using an undocumented API
+ * https://stackoverflow.com/questions/5188418/jquery-ajax-post-not-working-with-mailchimp/16369887#16369887
+ */
+
+export default async function subscribe(email: string): Promise<any> {
+  await fetch(
+    `https://coo.us14.list-manage.com/subscribe/post-json?u=dbacf466dc6e90901d8936391&amp;id=83e066a034&EMAIL=${encodeURIComponent(
+      email
+    )}&c=?`,
+    {
+      method: 'GET',
+      mode: 'no-cors',
+    }
+  )
+  // no-cors doesn't give us any information, so this is just a fire & pray
+  return
+}

--- a/src/components/header/ui/controls/valid.ts
+++ b/src/components/header/ui/controls/valid.ts
@@ -1,0 +1,13 @@
+/**
+ * Test for an invalid email
+ */
+
+export function email(email: string): string | Error {
+  email = email.toLowerCase()
+  const re =
+    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+  if (!re.test(email)) {
+    return new Error(`invalid email: ${email}`)
+  }
+  return email
+}

--- a/src/components/header/ui/navigation/Dropdown.tsx
+++ b/src/components/header/ui/navigation/Dropdown.tsx
@@ -1,0 +1,270 @@
+import styled, { css } from 'styled-components'
+import * as React from 'react'
+import { AnchorHTMLAttributes } from 'react'
+import * as NT from './Typography'
+import * as t from '../../theme/primitives'
+import theme from '../../theme/default'
+import { defaultTheme, darkTheme } from '../../theme'
+
+export const Panel = styled.div<{ width?: number; lightTheme: boolean }>(
+  ({ width, lightTheme }) => {
+    const themeToUse = lightTheme ? defaultTheme : darkTheme
+    return css`
+      width: ${width || 407}px;
+      box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.06);
+      border-radius: 20px;
+      padding: ${t.space['20']} 0 ${t.space['20']};
+      background-color: ${themeToUse.header.mobileDropdownPanelBackgroundColor};
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        background-color: white;
+      }
+    `
+  }
+)
+
+export const SectionHeader = styled(NT.Heading.withComponent('h4'))<{
+  lightTheme: boolean
+}>(({ lightTheme }) => {
+  const themeToUse = lightTheme ? defaultTheme : darkTheme
+  return css`
+    margin-top: ${33 / 16}rem;
+    margin-bottom: ${t.space['18']};
+    padding: 0 ${t.space['24']};
+    color: ${themeToUse.header.mobileDropdownPanelHeadingColor};
+    @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+      padding: 0 ${t.space['32']};
+      color: ${t.gray['600']};
+    }
+    &:first-child {
+      margin-top: ${t.space['12']};
+    }
+  `
+})
+
+export const ArticlesHeader = styled(NT.Heading.withComponent('h4'))`
+  margin-top: 12px;
+  margin-bottom: 32px;
+`
+
+export const Link = styled(NT.Link.withComponent('a'))<{
+  lightTheme: boolean
+  active?: boolean
+}>(({ lightTheme, active }) => {
+  const themeToUse = lightTheme ? defaultTheme : darkTheme
+  return css`
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    padding: 15px 24px;
+    transition: color 0.1s ease;
+    font-weight: 500;
+    color: ${active ? t.indigo['600'] : themeToUse.header.mobileDropdownPanelLinkTitleColor};
+    @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+      padding: 12px 12px;
+      font-weight: 600;
+      color: ${active ? t.indigo['600'] : t.colors.gray[800]};
+    }
+    &:hover {
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        color: ${t.indigo['600']};
+      }
+    }
+  `
+})
+
+const IconLinkStyles = styled.a<{
+  titleOnlyOnMobile: boolean
+  lightTheme: boolean
+}>(({ titleOnlyOnMobile, lightTheme }) => {
+  const themeToUse: any = lightTheme ? defaultTheme : darkTheme
+  return css`
+    cursor: pointer;
+    display: flex;
+    gap: 12px;
+    align-items: start;
+    text-decoration: none;
+
+    padding: ${t.space['15']} ${t.space['24']} ${t.space['15']} ${t.space['24']};
+    @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+      padding: ${t.space['12']} ${t.space['16']} ${t.space['12']} ${t.space['32']};
+      margin-bottom: ${t.space['6']};
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    .link-icon {
+      justify-content: center;
+      align-items: center;
+      flex-shrink: 0;
+      transition: background-color 0.1s ease;
+      background-color: ${t.colors.blueGray['100']};
+      border-radius: 5px;
+      width: 38px;
+      height: 38px;
+      display: none;
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        display: flex;
+      }
+      > img {
+        width: 100%;
+        height: 100%;
+      }
+    }
+    .link-title {
+      transition: color 0.1s ease;
+      line-height: 1;
+      color: ${themeToUse.header.mobileDropdownPanelLinkTitleColor};
+      margin-bottom: ${titleOnlyOnMobile ? 0 : t.space['4']};
+      font-weight: ${titleOnlyOnMobile ? 500 : 600};
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        color: ${t.colors.gray['800']};
+        font-weight: 600;
+        margin-bottom: ${t.space['4']};
+      }
+    }
+    .link-subtitle {
+      transition: color 0.1s ease;
+      font-weight: 400;
+      line-height: ${18 / 14};
+      font-size: ${t.fontSizes['14']};
+      display: ${titleOnlyOnMobile ? 'none' : 'initial'};
+      color: ${themeToUse.header.mobileDropdownPanelLinkSubTitleColor};
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        color: ${t.colors.gray['600']};
+        display: initial;
+      }
+    }
+
+    &:hover {
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        .link-icon {
+          background-color: ${t.colors.indigo['100']};
+        }
+        .link-title {
+          color: ${t.colors.indigo['600']};
+        }
+        .link-subtitle {
+          color: ${t.colors.indigo['400']};
+        }
+      }
+    }
+
+    &.active-link {
+      .link-icon {
+        background-color: ${t.colors.indigo['100']};
+      }
+      .link-title {
+        color: ${t.colors.indigo['600']};
+      }
+      .link-subtitle {
+        color: ${t.colors.indigo['400']};
+      }
+    }
+  `
+})
+const LinkTitle = NT.Link.withComponent('div')
+type IconLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href: string
+  icon: React.ReactNode
+  title: React.ReactNode
+  subtitle: React.ReactNode
+  titleOnlyOnMobile?: boolean
+  active?: boolean
+  lightTheme: boolean
+}
+export const IconLink = ({
+  href,
+  icon,
+  title,
+  subtitle,
+  titleOnlyOnMobile = false,
+  active,
+  lightTheme,
+  ...rest
+}: IconLinkProps) => {
+  return (
+    <IconLinkStyles
+      {...rest}
+      href={href}
+      lightTheme={lightTheme}
+      titleOnlyOnMobile={titleOnlyOnMobile}
+      className={active ? 'active-link' : ''}
+    >
+      <div className="link-icon">{icon}</div>
+      <div>
+        <LinkTitle className="link-title">{title}</LinkTitle>
+        <div className="link-subtitle">{subtitle}</div>
+      </div>
+    </IconLinkStyles>
+  )
+}
+
+const ArticleLinkStyles = styled.a`
+  display: flex;
+  gap: 18px;
+  margin-bottom: 32px;
+  text-decoration: none;
+  align-items: center;
+  &:last-child {
+    margin-bottom: 0;
+  }
+  .article-image {
+    flex-shrink: 0;
+    width: 148px;
+  }
+  p {
+    transition: color 0.1s ease;
+    margin: 0;
+  }
+  &:hover {
+    p {
+      color: ${t.indigo['600']};
+    }
+  }
+`
+const ArticleTitle = NT.Text.withComponent('p')
+type ArticleLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  image: React.ReactNode
+  title: React.ReactNode
+}
+export const ArticleLink = ({ image, title, ...rest }: ArticleLinkProps) => {
+  return (
+    <ArticleLinkStyles {...rest}>
+      <div className="article-image">{image}</div>
+      <ArticleTitle>{title}</ArticleTitle>
+    </ArticleLinkStyles>
+  )
+}
+
+export const HorizontalDivider = styled.div`
+  height: 1px;
+  margin: ${t.space['24']} ${t.space['32']} ${t.space['32']};
+  background-color: ${t.colors.blueGray['300']};
+  display: none;
+  @media only screen and (min-width: ${defaultTheme.header.mobileNavigationBreakpoint}px) {
+    display: block;
+  }
+`
+
+export const VerticalDivider = styled.div`
+  width: 1px;
+  background-color: ${t.colors.blueGray['300']};
+  margin: ${t.space['12']} 0;
+  display: none;
+  @media only screen and (min-width: ${defaultTheme.header.mobileNavigationBreakpoint}px) {
+    display: block;
+  }
+`
+
+export const Spacer = styled.div<{ height?: number; width?: number }>(
+  ({ width, height }) => css`
+    display: none;
+    height: ${height + 'px' || 'initial'};
+    width: ${width + 'px' || 'initial'};
+    @media only screen and (min-width: ${defaultTheme.header.mobileNavigationBreakpoint}px) {
+      display: block;
+    }
+  `
+)

--- a/src/components/header/ui/navigation/NavBar.tsx
+++ b/src/components/header/ui/navigation/NavBar.tsx
@@ -1,0 +1,319 @@
+import styled, { css } from 'styled-components'
+import { HTMLAttributes, useContext, useEffect, useReducer, useRef } from 'react'
+import * as React from 'react'
+import _ from 'lodash'
+import * as NT from './Typography'
+import * as t from '../../theme/primitives'
+import { ChevronDown, Menu, X } from 'react-feather'
+import { Button } from '../controls/Button'
+import { darkTheme, defaultTheme } from '../../theme'
+
+type NavBarState = {
+  mobileOpen: boolean
+  navItems: { [key: string | number]: boolean }
+}
+type NavBarAction =
+  | { type: 'TOGGLE_NAV_ITEM'; navItemKey: string | number }
+  | { type: 'TOGGLE_MOBILE_MENU' }
+  | { type: 'CLOSE' }
+function navBarReducer(state: NavBarState, action: NavBarAction): NavBarState {
+  switch (action.type) {
+    case 'TOGGLE_MOBILE_MENU':
+      return {
+        ...state,
+        mobileOpen: !state.mobileOpen,
+        navItems: { ..._.mapValues(state.navItems, () => false) },
+      }
+    case 'TOGGLE_NAV_ITEM':
+      return {
+        ...state,
+        navItems: {
+          ..._.mapValues(state.navItems, () => false),
+          [action.navItemKey]: !state.navItems[action.navItemKey],
+        },
+      }
+    case 'CLOSE':
+      return {
+        ...state,
+        navItems: _.mapValues(state.navItems, () => false),
+        mobileOpen: false,
+      }
+    default:
+      return state
+  }
+}
+let lastId = 0
+function _nextId() {
+  lastId++
+  return lastId
+}
+type NavBarContextType = {
+  nextId: typeof _nextId
+  state: NavBarState
+  dispatch: React.Dispatch<NavBarAction>
+  lightTheme: boolean
+}
+export const NavBarContext = React.createContext<NavBarContextType>({} as NavBarContextType)
+type NavBarProps = { children: React.ReactNode; lightTheme: boolean }
+export const NavBar = (props: NavBarProps) => {
+  const themeToUse = props.lightTheme ? defaultTheme : darkTheme
+  const [state, dispatch] = useReducer(navBarReducer, {
+    navItems: {},
+    mobileOpen: false,
+  })
+
+  useEffect(() => {
+    console.log(state.navItems)
+    console.log(_.mapValues(state.navItems, () => false))
+  }, [state])
+  useEffect(() => {
+    const resize = () => {
+      if (window.innerWidth >= themeToUse.header.mobileNavigationBreakpoint) {
+        dispatch({ type: 'CLOSE' })
+      }
+    }
+    window.addEventListener('resize', resize)
+    return () => {
+      window.removeEventListener('resize', resize)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (state.mobileOpen) {
+      window.document.body.classList.add('mobile-nav-opened')
+    } else {
+      window.document.body.classList.remove('mobile-nav-opened')
+    }
+  }, [state.mobileOpen])
+
+  return (
+    <NavBarContext.Provider
+      value={{ lightTheme: props.lightTheme, nextId: _nextId, state, dispatch }}
+    >
+      {props.children}
+    </NavBarContext.Provider>
+  )
+}
+
+export const NavBarInner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: column;
+  @media only screen and (min-width: ${defaultTheme.header.mobileNavigationBreakpoint}px) {
+    padding: 8px 0;
+    flex-direction: row;
+    width: auto;
+  }
+`
+
+type NavLinksProps = HTMLAttributes<HTMLDivElement> & { lightTheme: boolean }
+export const NavItemsContainer = styled(({ lightTheme, ...rest }: NavLinksProps) => (
+  <div {...rest} />
+))(({ lightTheme }) => {
+  const themeToUse = lightTheme ? defaultTheme : darkTheme
+  return css`
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    flex-direction: column;
+    width: 100%;
+    @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+      gap: 10px;
+      flex-direction: row;
+      width: auto;
+    }
+    .item {
+      width: 100%;
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        width: auto;
+      }
+
+      &:after {
+        display: block;
+        content: '';
+        background-color: ${themeToUse.header.mobileLinkDividerColor};
+        width: auto;
+        height: 1px;
+        margin: -1px 24px 0;
+        box-sizing: content-box;
+        @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+          display: none;
+        }
+      }
+
+      &:last-child:after {
+        display: none;
+      }
+
+      & > a {
+        color: ${themeToUse.header.navItemColor};
+        cursor: pointer;
+        display: flex;
+        height: 100%;
+        align-items: center;
+        line-height: ${24 / 16};
+        position: relative;
+        justify-content: space-between;
+        padding: 31px 24px;
+        align-items: center;
+        @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+          padding: 12px 16px;
+          min-height: 48px;
+        }
+        &:after {
+          @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+            display: block;
+            transition: opacity 0.1s ease;
+            content: '';
+            height: 2px;
+            opacity: 0;
+            background-color: ${themeToUse.header.navItemHoverColor};
+            position: absolute;
+            left: 16px;
+            right: 16px;
+            bottom: -14px;
+          }
+        }
+        &.has-dropdown {
+          &:after {
+            right: 22px;
+          }
+        }
+      }
+
+      @media only screen and (max-width: ${themeToUse.header.mobileNavigationBreakpoint - 1}px) {
+        .panel-spacer {
+          & > div {
+            width: 100%;
+            max-width: 100%;
+            box-shadow: none;
+            border-radius: 0;
+          }
+        }
+      }
+
+      .panel-outer {
+        display: none;
+      }
+      @media only screen and (min-width: ${themeToUse.header.mobileNavigationBreakpoint}px) {
+        .panel-outer {
+          position: relative;
+          display: none;
+          z-index: 1;
+        }
+        .panel-inner {
+          position: absolute;
+          left: 50%;
+          transform: translateX(-50%);
+          top: 0;
+        }
+        .panel-spacer {
+          padding-top: 28px;
+        }
+
+        &:hover {
+          .panel-outer {
+            display: block;
+          }
+          & > a {
+            color: ${themeToUse.header.navItemHoverColor};
+            &:after {
+              opacity: 1;
+            }
+
+            &.has-dropdown {
+              .item-chevron {
+                transform: scaleY(-1);
+              }
+            }
+          }
+        }
+        &.active-el > a {
+          color: ${themeToUse.header.navItemHoverColor};
+        }
+      }
+
+      @media only screen and (max-width: ${themeToUse.header.mobileNavigationBreakpoint - 1}px) {
+        &.open {
+          .has-dropdown {
+            .item-chevron {
+              transform: scaleY(-1);
+            }
+          }
+          .panel-outer {
+            display: block;
+          }
+        }
+      }
+    }
+  `
+})
+
+type DropdownPositionedProps = {
+  children: React.ReactNode
+  className?: string
+  lightTheme?: boolean
+}
+const DropdownPositioned = ({ children, className }: DropdownPositionedProps) => (
+  <div className={`panel-outer ${className}`}>
+    <div className="panel-inner">
+      <div className="panel-spacer">{children}</div>
+    </div>
+  </div>
+)
+
+const NavLink = styled(NT.Link.withComponent('a'))`
+  transition: color 0.1s ease;
+  &:hover {
+    @media only screen and (min-width: ${defaultTheme.header.mobileNavigationBreakpoint}px) {
+      color: ${t.indigo['600']};
+    }
+  }
+`
+
+type NavItemProps = {
+  href?: string
+  title: React.ReactNode
+  dropdown?: React.ReactNode
+  active?: boolean
+  onClick?: () => void
+  lightTheme: boolean
+}
+export const NavItem = ({ href, title, dropdown, active, onClick, lightTheme }: NavItemProps) => {
+  const instanceRef = useRef({ id: 0 })
+  const context = useContext(NavBarContext)
+
+  const navlink = (href?: string) => (
+    <NavLink
+      href={href ? href : undefined}
+      className={dropdown ? 'has-dropdown' : '' + lightTheme ? ' light' : ''}
+    >
+      {title}
+      {dropdown && <ChevronDown className="item-chevron" strokeWidth={1} />}
+    </NavLink>
+  )
+
+  return (
+    <div className={'item' + (active ? ' active-el' : '')} onClick={onClick}>
+      {navlink(href)}
+
+      {dropdown && <DropdownPositioned>{dropdown}</DropdownPositioned>}
+    </div>
+  )
+}
+
+export const MenuButton = () => {
+  const {
+    state: { mobileOpen },
+    dispatch,
+  } = useContext(NavBarContext)
+  return (
+    <Button
+      onClick={() => dispatch({ type: 'TOGGLE_MOBILE_MENU' })}
+      className={'menu-toggle-button'}
+    >
+      {mobileOpen ? <X /> : <Menu />}
+    </Button>
+  )
+}

--- a/src/components/header/ui/navigation/Typography.tsx
+++ b/src/components/header/ui/navigation/Typography.tsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components'
+import * as t from '../../theme/primitives'
+
+export const Heading = styled.span`
+  color: ${t.colors.gray[600]};
+  font-family: ${t.fonts.heading};
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  text-transform: uppercase;
+  margin: 0;
+`
+
+export const Text = styled.span`
+  font-weight: 500;
+  font-family: ${t.fonts.text};
+  font-size: ${t.fontSizes['16']};
+  line-height: 1.3;
+  color: ${t.colors.blueGray['600']};
+`
+
+export const Link = styled.span`
+  text-decoration: none;
+  font-weight: 600;
+  font-family: ${t.fonts.text};
+  font-size: ${t.fontSizes['16']};
+  color: ${t.colors.gray[800]};
+  line-height: 1;
+`

--- a/src/components/header/ui/typography/Label.tsx
+++ b/src/components/header/ui/typography/Label.tsx
@@ -1,0 +1,28 @@
+import { css } from 'styled-components'
+import * as React from 'react'
+import { HTMLAttributes } from 'react'
+import theme from '../../theme/default'
+
+type LabelType = 'default' | 'primary' | 'secondary'
+type LabelProps = HTMLAttributes<HTMLSpanElement> & {
+  type?: LabelType
+}
+
+export const Label = ({ type = 'default', ...rest }: LabelProps) => {
+  const label = theme.labels[type]
+  return (
+    <span
+      css={css`
+        border-radius: ${label.borderRadius};
+        background-color: ${label.backgroundColor};
+        padding: ${label.padding};
+        color: ${label.color};
+        font-size: ${label.fontSize};
+        line-height: 1;
+        display: inline-block;
+        font-weight: 600;
+      `}
+      {...rest}
+    />
+  )
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": false,
     "skipLibCheck": true,
+    "esModuleInterop": true,
     "baseUrl": "."
   },
   "exclude": ["node_modules"],


### PR DESCRIPTION
## Describe this PR

Docs is not taking up WebsiteHeader from lens as it should in production- stylesheets are breaking and there may be a more specific underlying issue unrelated directly to lens inside the docs repo that makes it so. Previews in vercel look as they should but production does not.

[PDP CP also can't handle a lens upgrade in docs without the upgrade playing well with PDP CP. ](https://prisma-company.slack.com/archives/C5Z9TH6N9/p1661327282097559?thread_ts=1661184267.009259&cid=C5Z9TH6N9)

This PR implements the website header almost exactly as it does in lens, only it's internal. Usage of `@emotion` packages has been switched to `styled-components`- a library already in use in the repo, to safeguard any possible issue with compatibility.

## Changes

Layout is now rendered with a whole new website header.

## What issue does this fix?

A lot of navigation and performance issues are handled in this PR.

## Any other relevant information

N/A
