### PR TITLE
Remove tracing limitation

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/250-opentelemetry-tracing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/250-opentelemetry-tracing.mdx
@@ -417,7 +417,3 @@ import express from 'express'
 ### Child traces start before parent traces
 
 We're still investigating [this issue](https://github.com/prisma/prisma/issues/14612).
-
-### Some traces show a timing measurement of 0μs
-
-This is most likely a precision bug. See [this issue](https://github.com/prisma/prisma/issues/14614) for updates.


### PR DESCRIPTION
This PR removes "Some traces show a timing measurement of 0μs" in the tracing docs.

Fixed by: https://github.com/prisma/prisma/issues/14614
