### PR TITLE
docs: fix heading number in docs

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -208,7 +208,7 @@ Great job, you just created your first database record with Prisma Client! 🎉
 
 In the next section, you'll learn how to read data from the database.
 
-### 4.1. Retrieve all `User` records
+### 4.2. Retrieve all `User` records
 
 Prisma Client offers various queries to read data from your database. In this section, you'll use the `findMany` query that returns _all_ the records in the database for a given model.
 


### PR DESCRIPTION
## Describe this PR

[Here](https://www.prisma.io/docs/getting-started/quickstart#41-retrieve-all-user-records) in the documentation the number of the heading should be `4.2` instead of `4.1` .

## Changes

I just changed the heading number to `4.2` .

[![image](https://user-images.githubusercontent.com/54427003/186869901-0b733545-ceaa-4b29-a11d-7a275115b0fa.png)](https://www.prisma.io/docs/getting-started/quickstart#41-retrieve-all-user-records)
Here it should be :point_down: 

### 4.2. Retrieve all `User` records


