### PR TITLE
Updated supported binaryTargets in Prisma schema reference

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -210,6 +210,8 @@ The following tables list all supported operating systems with the name of platf
 | Ubuntu 18.04 (bionic) | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 19.04 (disco)  | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 20.04 (focal)  | `debian-openssl-1.1.x`   |  1.1.x  |
+| Ubuntu 22.04 (jammy)  | `debian-openssl-3.0.x`   |  3.0.x  |
+
 
 ##### Linux (CentOS)
 
@@ -225,6 +227,8 @@ The following tables list all supported operating systems with the name of platf
 | Fedora 28 | `rhel-openssl-1.1.x`     |  1.1.x  |
 | Fedora 29 | `rhel-openssl-1.1.x`     |  1.1.x  |
 | Fedora 30 | `rhel-openssl-1.1.x`     |  1.1.x  |
+| Fedora 36 | `rhel-openssl-3.0.x`     |  3.0.x  |
+
 
 ##### Linux (Linux Mint)
 
@@ -232,6 +236,7 @@ The following tables list all supported operating systems with the name of platf
 | :------------ | :----------------------- | :-----: |
 | Linux Mint 18 | `debian-openssl-1.0.x`   |  1.0.x  |
 | Linux Mint 19 | `debian-openssl-1.1.x`   |  1.1.x  |
+| Linux Mint 21 | `debian-openssl-3.0.x`   |  3.0.x  |
 
 ##### Linux (Arch Linux)
 
@@ -245,6 +250,7 @@ The following tables list all supported operating systems with the name of platf
 | :----------------------- | :-------------------------- | :-----: |
 | Linux ARM64-based distro | `linux-arm64-openssl-1.0.x` |  1.0.x  |
 | Linux ARM64-based distro | `linux-arm64-openssl-1.1.x` |  1.1.x  |
+| Linux ARM64-based distro | `linux-arm64-openssl-3.0.x` |  3.0.x  |
 
 ### Examples
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -210,6 +210,7 @@ The following tables list all supported operating systems with the name of platf
 | Ubuntu 18.04 (bionic) | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 19.04 (disco)  | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 20.04 (focal)  | `debian-openssl-1.1.x`   |  1.1.x  |
+| Ubuntu 21.04 (hirsute)  | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 22.04 (jammy)  | `debian-openssl-3.0.x`   |  3.0.x  |
 
 ##### Linux (CentOS)

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -212,7 +212,6 @@ The following tables list all supported operating systems with the name of platf
 | Ubuntu 20.04 (focal)  | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 22.04 (jammy)  | `debian-openssl-3.0.x`   |  3.0.x  |
 
-
 ##### Linux (CentOS)
 
 | Build OS | Prisma engine build name | OpenSSL |
@@ -228,7 +227,6 @@ The following tables list all supported operating systems with the name of platf
 | Fedora 29 | `rhel-openssl-1.1.x`     |  1.1.x  |
 | Fedora 30 | `rhel-openssl-1.1.x`     |  1.1.x  |
 | Fedora 36 | `rhel-openssl-3.0.x`     |  3.0.x  |
-
 
 ##### Linux (Linux Mint)
 


### PR DESCRIPTION
## Describe this PR

This PR adds the binary targets for OpenSSL 3.0.x based on changes from https://github.com/prisma/engines-wrapper/pull/362/files.

## Changes

`binaryTargets` section on the Prisma schema reference page.

## What issue does this fix?

N/A

## Any other relevant information

The Build OS columns were updated based on some quick research:

- Debian (OpenSSL 3 still unstable): https://tracker.debian.org/pkg/openssl
- Ubuntu: https://launchpad.net/ubuntu/jammy/+source/openssl (version 3 is not available on Impish: https://launchpad.net/ubuntu/impish/+source/openssl)
- Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1825937
- Linux Mint: https://linuxmint.com/download_all.php (21 is based on Ubuntu Jammy)
- Arch Linux: Seems to not have OpenSSL 3 support yet.

I have only tested the Ubuntu 22.04 on an AWS CodeBuild image.
