### PR TITLE
Contribution correct 1 crucial command starter npx

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -34,9 +34,9 @@ Prisma is a modern DB toolkit to query, migrate and model your database (https:/
 
 Usage
 
-  $ prisma [command]
+  $ [npx/pnpx/yarn] prisma [command]
 
-Commands
+Commands (
 
             init   Setup Prisma for your app
         generate   Generate artifacts (e.g. Prisma Client)


### PR DESCRIPTION
I correct 1 crucial command for starters or begginers,
always all commands must proceed with "npx/pnpx/yarn" at the beggining.