### PR TITLE
Tracing: capitalize model names in Prisma Schema

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/250-opentelemetry-tracing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/250-opentelemetry-tracing.mdx
@@ -253,12 +253,12 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model user {
+model User {
   id    Int    @id @default(autoincrement())
   email String @unique
 }
 
-model audit {
+model Audit {
   id     Int    @id
   table  String
   action String


### PR DESCRIPTION
## Describe this PR

Model names should be in PascalCase based on our [naming conventions](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#naming-conventions). 

## Changes

- Change model names to PascalCase in the example


