### PR TITLE
Docs style guide: added a link to schema naming conventions; various small improvements

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
@@ -74,7 +74,7 @@ When you use jargon, follow these guidelines:
 
 - Only link on the first instance of a jargon term in a logical section of the docs.
 
-  A logical section is a section of the docs that we might expect someone to read at one time. Typically, it is a page, or a self-contained part of a page comprising one or more headed sections.
+  A logical section is a section of the docs that we might expect someone to read at one time. Typically, it is a page, or a self-contained part of a page that comprises one or more headed sections.
 
 - When you link to an external definition, choose a credible source. Wikipedia is acceptable, and official third-party documentation is better.
 

--- a/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
@@ -74,7 +74,7 @@ When you use jargon, follow these guidelines:
 
 - Only link on the first instance of a jargon term in a logical section of the docs.
 
-  A logical section is a section of the docs that we might expect someone to read at one time. Typically, it is a page, or a self-contained section of a page comprising one or more headings.
+  A logical section is a section of the docs that we might expect someone to read at one time. Typically, it is a page, or a self-contained part of a page comprising one or more headed sections.
 
 - When you link to an external definition, choose a credible source. Wikipedia is acceptable, and official third-party documentation is better.
 

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -216,8 +216,6 @@ If you must use it, ensure you use the correct form. Remember to check in code s
 
 ### Prisma product and component names
 
-**To be done: Tana would like the product/component names to be split out into a dedicated page or section.**
-
 Use the following forms:
 
 - The Prisma Data Platform (or just "PDP" - no definite article - after the first mention)

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -144,7 +144,7 @@ Avoid the following common words in English, because they are ambiguous to many 
 | Since (to mean "because")        | Can mean "after" (as in "since you upgraded") | "Because"                                                                            |
 | May                              | Can mean "might" or "is permitted to"         | "Might"                                                                              |
 | Should                           | Can mean "ought to" or "might happen"         | "Must": "You must rebuild Prisma Client", or <br></br>Omit: "Rebuild Prisma Client." |
-| Once (to mean "when" or "after") | Can mean "happens once"                       | "When"                                                                               |
+| Once (to mean "when" or "after") | Can mean "happens once"                       | "When": "When the build completes..."                                                |
 
 ## Use clear hyperlinks
 
@@ -207,6 +207,12 @@ Use the term "terminal window". Do not use "command prompt" or "shell". Example:
 ```
 Open a terminal window.
 ```
+
+### Set up/setup
+
+This can be a noun ("setup") or verb ("set up") and as such can cause confusion. Try to avoid, and use an alternative term. For example, "configure" or "enable".
+
+If you must use it, ensure you use the correct form. Remember to check in code comments in code snippets, where it often lurks!
 
 ### Prisma product and component names
 

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -212,7 +212,7 @@ Open a terminal window.
 
 This can be a noun ("setup") or verb ("set up") and as such can cause confusion. Try to avoid, and use an alternative term. For example, "configure" or "enable".
 
-If you must use it, ensure you use the correct form. Remember to check in code comments in code snippets, where it often lurks!
+If you must use it, ensure you use the correct form. Remember to check in code snippets, where it might lurk in the code comments.
 
 ### Prisma product and component names
 

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -13,15 +13,17 @@ For even more inclusive docs, avoid phrases that assume a reader’s experience 
 
 ## Avoid Latin terms
 
-These are problematic for non-first-language speakers, and some of them can be confusing even to native English speakers.
+These are common in English, but can be problematic for non-first-language speakers. Some of them can be confusing even to native English speakers.
 
 For example:
 
-- et al (use "and others")
-- etc. (use "and so on", or list all of the cases)
-- i.e. (use "in other words")
-- e.g. (use "such as" or "for example")
-- via (use "with" or other equivalent, as in "Now you can start to send queries with the generated Prisma Client API")
+| Avoid | Good                                                                                                        |
+| ----- | ----------------------------------------------------------------------------------------------------------- |
+| et al | "and others"                                                                                                |
+| etc.  | "and so on", or list all of the cases                                                                       |
+| i.e.  | "in other words"                                                                                            |
+| e.g.  | "such as" or "for example"                                                                                  |
+| via   | "with" or other equivalent, as in "Now you can start to send queries with the generated Prisma Client API") |
 
 ## Avoid gerunds ("ing" verb forms)
 
@@ -35,6 +37,7 @@ Examples:
 | Excluding fields                                | Exclude fields                            |
 | If you are using Node.js version 18 or later... | If you use Node.js version 18 or later... |
 | You can do this by rebuilding Prisma Client     | To do this, rebuild Prisma Client         |
+| When designing your schema...                   | When you design your schema...            |
 
 Note that nouns ending in "ing" are fine - for example "Tracing".
 

--- a/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -242,7 +242,6 @@ Ensure that code snippets you include are realistic examples that would work if 
 ### Prisma schema naming conventions
 
 When you create a Prisma schema for an example, follow the [naming conventions](/reference/api-reference/prisma-schema-reference#naming-conventions) we advise for users.
-https://www.prisma.io/docs
 
 ### Lists of shell commands
 

--- a/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -239,6 +239,11 @@ const foo = (...) // Too vague
 
 Ensure that code snippets you include are realistic examples that would work if run in the context presented.
 
+### Prisma schema naming conventions
+
+When you create a Prisma schema for an example, follow the [naming conventions](/reference/api-reference/prisma-schema-reference#naming-conventions) we advise for users.
+https://www.prisma.io/docs
+
 ### Lists of shell commands
 
 When you need to provide a series of CLI commands as instructions to the reader, use a single block. Don't use a list unless you want to provide context for each step:

--- a/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
@@ -20,7 +20,11 @@ We chose the `User` and `Post` models for the following reasons:
 - Consistent models make it easier for the reader when learning about different concepts, because there will be less context switching.
 - Less decision making and cognitive overhead for the docs authors. Using the same models reduces decision fatigue and is one less thing to worry about when trying to explain concepts.
 
-## Naming conventions for tables and columns
+## Naming conventions
+
+See the [naming conventions](/reference/api-reference/prisma-schema-reference#naming-conventions) for Prisma schemas.
+
+In addition:
 
 - Format table names in [PascalCase](https://en.wikipedia.org/wiki/Camel_case).
 - Format column names in [camelCase](https://en.wikipedia.org/wiki/Camel_case).

--- a/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
@@ -24,7 +24,7 @@ We chose the `User` and `Post` models for the following reasons:
 
 See the [naming conventions](/reference/api-reference/prisma-schema-reference#naming-conventions) for Prisma schemas.
 
-In addition:
+Use the following for table and column names:
 
 - Format table names in [PascalCase](https://en.wikipedia.org/wiki/Camel_case).
 - Format column names in [camelCase](https://en.wikipedia.org/wiki/Camel_case).


### PR DESCRIPTION
Docs style guide: added a link to schema naming conventions; various small improvements
