### PR TITLE
Update 070-case-sensitivity.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/070-case-sensitivity.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/070-case-sensitivity.mdx
@@ -121,7 +121,7 @@ const users = await prisma.user.findMany({
   where: {
     email: {
       endsWith: 'prisma.io',
-      mode: 'insensitive', // Default value: default
+      mode: 'insensitive', // Default value: default, use Prisma.QueryMode.insensitive from @prisma/client  when using TypeScript
     },
   },
 })


### PR DESCRIPTION
When using NestJS with TypeScript, directly putting mode: 'insensitive' throws an error because 'mode' should be of type Prisma.QueryMode, so one needs to put Prisma.QueryMode.insensitive or Prisma.QueryMode.default instead of putting the string.

## Describe this PR

I was getting an error on a NestJS project using the 'mode' option on queries. Reviewing the doc on how to add the mode: insensitive it's not correct if we are using TypeScript you should put mode: Prisma.QueryMode.insensitive

## Changes

Only add a small comment in the same line where  the example of mode: insensitive is presented

## What issue does this fix?

No issues reported, just a clarification for improving the documentation

## Any other relevant information

