### PR TITLE
fix(environment-variables-reference): fix code block type

### DIFF
--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -36,11 +36,13 @@ See [Formatting via environment variables](/concepts/components/prisma-client/wo
 
 ### <inlinecode>BROWSER</inlinecode>
 
-`BROWSER` is for Prisma Studio to force which browser it should be open in, if not set it will open in the default browser. It's also used as a flag when starting the studio from the CLI.
+`BROWSER` is for Prisma Studio to force which browser it should be open in, if not set it will open in the default browser.
 
-```js
+```terminal
 BROWSER=firefox prisma studio --port 5555
 ```
+
+Alternatively you can set this when starting Studio from the CLI as well:
 
 ```terminal
 prisma studio --browser firefox
@@ -74,7 +76,7 @@ The Prisma CLI supports custom HTTP(S) proxies to download the Prisma engines. T
 
 `NO_PROXY` is a comma-separated list of hostnames or IP addresses that do not require a proxy.
 
-```terminal
+```env
 NO_PROXY=myhostname.com,10.11.12.0/16,172.30.0.0/16
 ```
 
@@ -82,7 +84,7 @@ NO_PROXY=myhostname.com,10.11.12.0/16,172.30.0.0/16
 
 `HTTP_PROXY` is set with the hostname or IP address of a proxy server.
 
-```terminal
+```env
 HTTP_PROXY=http://proxy.example.com
 ```
 
@@ -90,7 +92,7 @@ HTTP_PROXY=http://proxy.example.com
 
 `HTTPS_PROXY` is set with the hostname or IP address of a proxy server.
 
-```terminal
+```env
 HTTPS_PROXY=https://proxy.example.com
 ```
 
@@ -124,7 +126,7 @@ It is the environment variable equivalent for the [`engineType` property of the 
 
 `PRISMA_ENGINES_MIRROR` can be used to specify a custom CDN (or server) endpoint to download the engines files for the CLI/Client. The default value is `https://binaries.prisma.sh`, where Prisma hosts the engine files.
 
-```terminal
+```env
 PRISMA_ENGINES_MIRROR=https://example.org/custom-engines/
 ```
 
@@ -140,7 +142,7 @@ By default, all engine files are downloaded when you install Prisma CLI, copied 
 
 `PRISMA_QUERY_ENGINE_BINARY` is used to set a custom location for your own query engine binary.
 
-```terminal
+```env
 PRISMA_QUERY_ENGINE_BINARY=custom/my-query-engine-unix
 ```
 
@@ -153,7 +155,7 @@ Note: This can only have an effect if the engine type of CLI or Client are set t
 
 `PRISMA_QUERY_ENGINE_LIBRARY` is used to set a custom location for your own query engine library.
 
-```terminal
+```env
 PRISMA_QUERY_ENGINE_LIBRARY=custom/my-query-engine-unix
 ```
 
@@ -166,7 +168,7 @@ Note: This can only have an effect if the engine type of CLI or Client are set t
 
 `PRISMA_MIGRATION_ENGINE_BINARY` is used to set a custom location for your own migration engine binary.
 
-```terminal
+```env
 PRISMA_MIGRATION_ENGINE_BINARY=custom/my-migration-engine-unix
 ```
 
@@ -174,7 +176,7 @@ PRISMA_MIGRATION_ENGINE_BINARY=custom/my-migration-engine-unix
 
 `PRISMA_INTROSPECTION_ENGINE_BINARY` is used to set a custom location for your own introspection engine binary.
 
-```terminal
+```env
 PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
 ```
 
@@ -182,7 +184,7 @@ PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
 
 `PRISMA_FMT_BINARY` is used to set a custom location for your own format engine binary.
 
-```terminal
+```env
 PRISMA_FMT_BINARY=custom/my-custom-format-engine-unix
 ```
 


### PR DESCRIPTION
`terminal` only for commands, `env` for env var definitions
