### PR TITLE
fix typo on data validation guide

### DIFF
--- a/content/300-guides/050-database/900-advanced-database-tasks/07-data-validation/01-postgresql.mdx
+++ b/content/300-guides/050-database/900-advanced-database-tasks/07-data-validation/01-postgresql.mdx
@@ -236,7 +236,7 @@ Congratulations, you just created a table called `lastproduct` in the database w
 
 In the previous sections, you created four tables with different check constraints:
 
-- The `product` table has a check constraint that ensures that the value of `price` is never less than `0.01` and enver exactly `1240.00`.
+- The `product` table has a check constraint that ensures that the value of `price` is never less than `0.01` and never exactly `1240.00`.
 - The `anotherproduct` table has a check constraint that ensures that the value of `reducedprice` is never greater than the value of `price`.
 - The `secondtolastproduct` table has two check constraints - one that ensures that the value of `reducedprice` is never greater than the value of `price`, and one that ensures that the `tags` array always contains the value `product`.
 - The `lastproduct` table has a check constraint that ensures that the value of `category` is never `clothing`.


### PR DESCRIPTION
## Describe this PR

Fix typo on `Data validation with CHECK constraints (PostgreSQL)` page

## Changes

Changed `enver` to `never`

- Refactored example to include new database field
- ... -->

## What issue does this fix?

## Any other relevant information

