### PR TITLE
Add GA version for `migrate diff` and `db execute` in the CLI reference

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -720,7 +720,7 @@ prisma db seed
 
 <Admonition type="info">
 
-The `db execute` command is generally available in versions 3.13.0 and later. It was available in preview in versions 3.9.0 and later.
+The `db execute` command is generally available in versions 3.13.0 and later. It is available in preview in versions 3.9.0 and later using the `--preview-feature` CLI flag.
 
 </Admonition>
 
@@ -1000,7 +1000,7 @@ prisma migrate status
 
 <Admonition type="info">
 
-The `migrate diff` command is generally available in versions 3.13.0 and later. It was available in preview in versions 3.9.0 and later.
+The `migrate diff` command is generally available in versions 3.13.0 and later. It is available in preview in versions 3.9.0 and later using the `--preview-feature` CLI flag.
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -720,7 +720,7 @@ prisma db seed
 
 <Admonition type="info">
 
-This command is available in Preview in versions 3.9.0 and later.
+The `db execute` command is generally available in versions 3.13.0 and later. It was available in preview in versions 3.9.0 and later.
 
 </Admonition>
 
@@ -1000,7 +1000,7 @@ prisma migrate status
 
 <Admonition type="info">
 
-This command is available in Preview in versions 3.9.0 and later.
+The `migrate diff` command is generally available in versions 3.13.0 and later. It was available in preview in versions 3.9.0 and later.
 
 </Admonition>
 


### PR DESCRIPTION
## Describe this PR

Add GA version for `migrate diff` and `db execute` in the CLI reference

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
