### PR TITLE
Update 300-many-to-many-relations.mdx

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -109,6 +109,7 @@ The following query:
 - Creates a new `Post`
 - Creates a new category assignment, or `CategoriesOnPosts`
 - Connects the category assignment to existing categories (with IDs `9` and `22`)
+- The `Category` connect must match the case of the schema (i.e. `Category` should be capitalized)
 
 ```ts
 const assignCategories = await prisma.post.create({
@@ -119,7 +120,7 @@ const assignCategories = await prisma.post.create({
         {
           assignedBy: 'Bob',
           assignedAt: new Date(),
-          category: {
+          Category: {
             connect: {
               id: 9,
             },
@@ -128,7 +129,7 @@ const assignCategories = await prisma.post.create({
         {
           assignedBy: 'Bob',
           assignedAt: new Date(),
-          category: {
+          Category: {
             connect: {
               id: 22,
             },


### PR DESCRIPTION
The many-to-many `connect` case of assignment of existing `categories` requires that the model being assigned match the schema letter case (i.e. must be capitalized).

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
