### PR TITLE
Update the postgres truncation strategy

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -930,7 +930,7 @@ await prisma.$transaction([deleteProfile, deletePosts, deleteUsers])
 
 If you are comfortable working with raw SQL you can perform a `TRUNCATE` on a table by utilizing [`$executeRawUnsafe`](/concepts/components/prisma-client/raw-database-access#executerawunsafe).
 
-In the following examples, the first tab shows how to perform a `TRUNCATE` on a Postgres database by using a `$queryRaw` look up that maps over the table and `TRUNCATES` each table.
+In the following examples, the first tab shows how to perform a `TRUNCATE` on a Postgres database by using a `$queryRaw` look up that maps over the table and `TRUNCATES` all tables in a single query.
 
 The second tab shows performing the same function but with a MySQL database. In this instance the constraints must be removed before the `TRUNCATE` can be executed, before being reinstated once finished. The whole process is run as a `$transaction`
 
@@ -941,18 +941,18 @@ The second tab shows performing the same function but with a MySQL database. In 
 ```ts
 const tablenames = await prisma.$queryRaw<
   Array<{ tablename: string }>
->`SELECT tablename FROM pg_tables WHERE schemaname='public'`
+>`SELECT tablename FROM pg_tables WHERE schemaname='public'`;
 
-for (const { tablename } of tablenames) {
-  if (tablename !== '_prisma_migrations') {
-    try {
-      await prisma.$executeRawUnsafe(
-        `TRUNCATE TABLE "public"."${tablename}" CASCADE;`
-      )
-    } catch (error) {
-      console.log({ error })
-    }
-  }
+const tables = tablenames
+  .map(({ tablename }) => tablename)
+  .filter((name) => name !== '_prisma_migrations')
+  .map((name) => `"public"."${name}"`)
+  .join(', ');
+
+try {
+  await prisma.$executeRawUnsafe(`TRUNCATE TABLE ${tables} CASCADE;`);
+} catch (error) {
+  console.log({ error });
 }
 ```
 


### PR DESCRIPTION
Update the example of the truncation strategy with a single query that runs faster.

## Describe this PR

The truncation strategy from the docs does multiple queries in a loop. It's possible to do it one query instead, which is faster and can e.g. help make test suites run faster.

## Changes

Changing the postgres example of multiple truncation queries to a single truncation query.

## Any other relevant information

It might be possible to do the same with the MySQL example below.
