### PR TITLE
Docs: Fix invalid snippet for filteredRelationCount

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/055-aggregation-grouping-summarizing.mdx
@@ -491,7 +491,9 @@ For example, the following query returns all user posts with the title "Hello!":
 await prisma.user.findMany({
   select: {
     _count: {
-      posts: { where: { title: 'Hello!' } },
+      select: {
+        posts: { where: { title: 'Hello!' } },
+      },
     },
   },
 })
@@ -505,8 +507,10 @@ The following query finds all user posts with comments from an author named "Ali
 await prisma.user.findMany({
   select: {
     _count: {
-      posts: {
-        where: { comments: { some: { author: { is: { name: 'Alice' } } } } },
+      select: {
+        posts: {
+          where: { comments: { some: { author: { is: { name: 'Alice' } } } } },
+        },
       },
     },
   },


### PR DESCRIPTION
## Describe this PR

The snippet provided for "Filtered Relation Count" is invalid because of a missing **select** inside **_count**.

## Changes

Added an additional `select` inside `_count`

```prisma
await prisma.user.findMany({
  select: {
    _count: {
      // An error is thrown without this select.
      select: { 
        posts: { where: { title: 'Hello!' } },
      },
    },
  },
})
```

## What issue does this fix?

Documentation for filteredRelationCount preview feature

Fixes #3412  -->
