### PR TITLE
Better name for relation scalar in examples

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -67,9 +67,9 @@ model User {
 }
 
 model Profile {
-  id     Int  @id @default(autoincrement())
-  user   User @relation(fields: [userId], references: [email])
-  userId Int  @unique // relation scalar field (used in the `@relation` attribute above)
+  id        Int  @id @default(autoincrement())
+  user      User @relation(fields: [userEmail], references: [email])
+  userEmail Int  @unique // relation scalar field (used in the `@relation` attribute above)
 }
 ```
 
@@ -84,9 +84,9 @@ model User {
 }
 
 model Profile {
-  id     String @id @default(auto()) @map("_id") @db.ObjectId
-  user   User   @relation(fields: [userId], references: [email])
-  userId String @unique @db.ObjectId // relation scalar field (used in the `@relation` attribute above)
+  id        String @id @default(auto()) @map("_id") @db.ObjectId
+  user      User   @relation(fields: [userEmail], references: [email])
+  userEmail String @unique @db.ObjectId // relation scalar field (used in the `@relation` attribute above)
 }
 ```
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/100-one-to-one-relations.mdx
@@ -67,9 +67,9 @@ model User {
 }
 
 model Profile {
-  id        Int  @id @default(autoincrement())
-  user      User @relation(fields: [userEmail], references: [email])
-  userEmail Int  @unique // relation scalar field (used in the `@relation` attribute above)
+  id        Int    @id @default(autoincrement())
+  user      User   @relation(fields: [userEmail], references: [email])
+  userEmail String @unique // relation scalar field (used in the `@relation` attribute above)
 }
 ```
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -69,9 +69,9 @@ model User {
 }
 
 model Post {
-  id          Int  @id @default(autoincrement())
-  authorEmail Int
-  author      User @relation(fields: [authorEmail], references: [email])
+  id          Int    @id @default(autoincrement())
+  authorEmail String
+  author      User   @relation(fields: [authorEmail], references: [email])
 }
 ```
 
@@ -86,9 +86,9 @@ model User {
 }
 
 model Post {
-  id          Int  @id @default(auto()) @map("_id") @db.ObjectId
-  authorEmail Int
-  author      User @relation(fields: [authorEmail], references: [email])
+  id          Int    @id @default(auto()) @map("_id") @db.ObjectId
+  authorEmail String
+  author      User   @relation(fields: [authorEmail], references: [email])
 }
 ```
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/200-one-to-many-relations.mdx
@@ -69,9 +69,9 @@ model User {
 }
 
 model Post {
-  id       Int  @id @default(autoincrement())
-  authorId Int
-  author   User @relation(fields: [authorId], references: [email])
+  id          Int  @id @default(autoincrement())
+  authorEmail Int
+  author      User @relation(fields: [authorEmail], references: [email])
 }
 ```
 
@@ -86,9 +86,9 @@ model User {
 }
 
 model Post {
-  id       Int  @id @default(auto()) @map("_id") @db.ObjectId
-  authorId Int
-  author   User @relation(fields: [authorId], references: [email])
+  id          Int  @id @default(auto()) @map("_id") @db.ObjectId
+  authorEmail Int
+  author      User @relation(fields: [authorEmail], references: [email])
 }
 ```
 


### PR DESCRIPTION
## Describe this PR

Update examples to use `userEmail` instead of `userId`. See [Slack thread](https://prisma-company.slack.com/archives/C5Z9TH6N9/p1662658762707029).

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
