### PR TITLE
docs: clarify interactiveTransactions

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -164,7 +164,7 @@ generator client {
 
 Then you can pass an async function into [`$transaction`](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api). 
 
-The first argument passed into this async function is an instance of Prisma Client. Below we will call this instance `tx` and any Prisma call invoked on this `tx` instance will be encapsulated into the transaction. 
+The first argument passed into this async function is an instance of Prisma Client. Below, we will call this instance `tx`. Any Prisma call invoked on this `tx` instance is encapsulated into the transaction. 
 
 Let's look at an example:
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -162,7 +162,9 @@ generator client {
 }
 ```
 
-Then you can pass an async function into [`$transaction`](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
+Then you can pass an async function into [`$transaction`](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api). 
+
+The first argument passed into this async function is an instance of Prisma Client. Below we will call this instance `tx` and any Prisma call invoked on this `tx` instance will be encapsulated into the transaction. 
 
 Let's look at an example:
 
@@ -184,9 +186,9 @@ import { PrismaClient } from '@prisma/client'
 const prisma = new PrismaClient()
 
 async function transfer(from: string, to: string, amount: number) {
-  return await prisma.$transaction(async (prisma) => {
+  return await prisma.$transaction(async (tx) => {
     // 1. Decrement amount from the sender.
-    const sender = await prisma.account.update({
+    const sender = await tx.account.update({
       data: {
         balance: {
           decrement: amount,
@@ -196,12 +198,14 @@ async function transfer(from: string, to: string, amount: number) {
         email: from,
       },
     })
+
     // 2. Verify that the sender's balance didn't go below zero.
     if (sender.balance < 0) {
       throw new Error(`${from} doesn't have enough to send ${amount}`)
     }
+
     // 3. Increment the recipient's balance by amount
-    const recipient = await prisma.account.update({
+    const recipient = await tx.account.update({
       data: {
         balance: {
           increment: amount,
@@ -211,6 +215,7 @@ async function transfer(from: string, to: string, amount: number) {
         email: to,
       },
     })
+
     return recipient
   })
 }
@@ -241,7 +246,7 @@ To catch the exception, you can wrap `$transaction` in a try-catch block:
 
 ```js
 try {
-  await prisma.$transaction(async (prisma) => {
+  await prisma.$transaction(async (tx) => {
     // Code running in a transaction...
   })
 } catch (err) {
@@ -259,7 +264,7 @@ For example:
 
 ```jsx
 await prisma.$transaction(
-  async (prisma) => {
+  async (tx) => {
     // Code running in a transaction...
   },
   {

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -842,7 +842,7 @@ generator client {
 
 Then you can pass an async function into [$transaction](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
 
-The first argument passed into this async function is an instance of Prisma Client. Below we will call this instance `tx` and any Prisma call invoked on this `tx` instance will be encapsulated into the transaction. 
+The first argument passed into this async function is an instance of Prisma Client. Below, we will call this instance `tx`. Any Prisma call invoked on this `tx` instance is encapsulated into the transaction. 
 
 In the example below, Alice and Bob each have $100 in their account. If they try to send more money than they have, the transfer is rejected.
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -842,6 +842,8 @@ generator client {
 
 Then you can pass an async function into [$transaction](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
 
+The first argument passed into this async function is an instance of Prisma Client. Below we will call this instance `tx` and any Prisma call invoked on this `tx` instance will be encapsulated into the transaction. 
+
 In the example below, Alice and Bob each have $100 in their account. If they try to send more money than they have, the transfer is rejected.
 
 The expected outcome would be for Alice to make 1 transfer for $100 and the other transfer would be rejected. This would result in Alice having $0 and Bob having $200.
@@ -851,9 +853,9 @@ import { PrismaClient } from '@prisma/client'
 const prisma = new PrismaClient()
 
 async function transfer(from: string, to: string, amount: number) {
-  return await prisma.$transaction(async (prisma) => {
+  return await prisma.$transaction(async (tx) => {
     // 1. Decrement amount from the sender.
-    const sender = await prisma.account.update({
+    const sender = await tx.account.update({
       data: {
         balance: {
           decrement: amount,
@@ -863,12 +865,14 @@ async function transfer(from: string, to: string, amount: number) {
         email: from,
       },
     })
+
     // 2. Verify that the sender's balance didn't go below zero.
     if (sender.balance < 0) {
       throw new Error(`${from} doesn't have enough to send ${amount}`)
     }
+
     // 3. Increment the recipient's balance by amount
-    const recipient = prisma.account.update({
+    const recipient = tx.account.update({
       data: {
         balance: {
           increment: amount,
@@ -878,6 +882,7 @@ async function transfer(from: string, to: string, amount: number) {
         email: to,
       },
     })
+    
     return recipient
   })
 }

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -703,12 +703,12 @@ We introduced `findFirstOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`]
 - Its return type is non-nullable. For example, `post.findFirst()` can return `post` or `null`, but `post.findFirstOrThrow` always returns `post`.
 - It is not compatible with sequential operations in the [`$transaction` API](/concepts/components/prisma-client/transactions#the-transaction-api). If the query returns `NotFoundError`, then the API will not roll back any operations in the array of calls. As a workaround, you can use interactive transactions with the `$transaction` API, as follows:
 
-  ```ts
-   $transaction(async (prisma) => {
-     await prisma.model.create({ data: { ... });
-     await prisma.model.findFirstOrThrow();
-   })
-  ```
+```ts
+prisma.$transaction(async (tx) => {
+  await tx.model.create({ data: { ... });
+  await tx.model.findFirstOrThrow();
+})
+```
 
 ### <inlinecode>findMany</inlinecode>
 


### PR DESCRIPTION
I found it confusing that we were overriding the `prisma` variable in the scope of the transaction callback. This PR introduces the usage of `tx` to help showcase the difference between a user's 'top level' `prisma` variable and the 'special' transaction variable that's inside the scope of the callback. 