### PR TITLE
docs: update binary target location usage

### DIFF
--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -141,7 +141,8 @@ By default, all engine files are downloaded when you install Prisma CLI, copied 
 `PRISMA_QUERY_ENGINE_BINARY` is used to set a custom location for your own query engine binary.
 
 ```terminal
-PRISMA_QUERY_ENGINE_BINARY=custom/my-query-engine-unix
+PRISMA_QUERY_ENGINE_BINARY=path/to/my/query-engine-<target>
+# Example: ./prisma/binaries/query-engine-linux-arm64-openssl-1.0.x
 ```
 
 For Prisma CLI it allows you to define the query engine file to be used.  
@@ -154,7 +155,8 @@ Note: This can only have an effect if the engine type of CLI or Client are set t
 `PRISMA_QUERY_ENGINE_LIBRARY` is used to set a custom location for your own query engine library.
 
 ```terminal
-PRISMA_QUERY_ENGINE_LIBRARY=custom/my-query-engine-unix
+PRISMA_QUERY_ENGINE_LIBRARY=path/to/my/libquery_engine-<target>.so.node
+# Example: ./prisma/binaries/libquery_engine-linux-arm64-openssl-1.0.x.so.node
 ```
 
 For Prisma CLI it allows you to define the query engine file to be used.  

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -141,7 +141,7 @@ By default, all engine files are downloaded when you install Prisma CLI, copied 
 `PRISMA_QUERY_ENGINE_BINARY` is used to set a custom location for your own query engine binary.
 
 ```terminal
-PRISMA_QUERY_ENGINE_BINARY=path/to/my/query-engine-<target>
+PRISMA_QUERY_ENGINE_BINARY=custom/query-engine-<target>
 # Example: ./prisma/binaries/query-engine-linux-arm64-openssl-1.0.x
 ```
 
@@ -155,7 +155,7 @@ Note: This can only have an effect if the engine type of CLI or Client are set t
 `PRISMA_QUERY_ENGINE_LIBRARY` is used to set a custom location for your own query engine library.
 
 ```terminal
-PRISMA_QUERY_ENGINE_LIBRARY=path/to/my/libquery_engine-<target>.so.node
+PRISMA_QUERY_ENGINE_LIBRARY=custom/libquery_engine-<target>.so.node
 # Example: ./prisma/binaries/libquery_engine-linux-arm64-openssl-1.0.x.so.node
 ```
 


### PR DESCRIPTION
## Describe this PR

Current documentation for usage of environment variables causes some confusion (see [#15029](https://github.com/prisma/prisma/issues/15029))

## Changes

- Add clearer usage of `PRISMA_QUERY_ENGINE_LIBRARY` and `PRISMA_QUERY_ENGINE_LIBRARY`
- Add examples for both of the above

## What issue does this fix?

Fixes: [#15029](https://github.com/prisma/prisma/issues/15029)
