### PR TITLE
Various style guide improvements

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
@@ -5,11 +5,11 @@ metaDescription: 'This section of the style guide provides guidelines on tone of
 tocDepth: 3
 ---
 
-### Audience
+## Audience
 
 We assume that our audience has basic software development knowledge. Our audience know how to use their tools, such as their IDE and a terminal window. Many of our users are familiar with advanced software development concepts and techniques, but we cannot assume this in the docs. We cannot assume that our users have any database knowledge.
 
-### Simplify
+## Simplify
 
 It's a good principle of technical communication to write as simply as possible. This is harder than it sounds, but the extra work is worth it to make clearer, more readable docs. It's particularly important when you write for a global audience, not all of whom are fluent with English.
 
@@ -22,11 +22,11 @@ It's a good principle of technical communication to write as simply as possible.
 - Use tables to set out complex information
 - Use diagrams to make complex workflows or concepts easier to visualize
 
-### Tone of voice.
+## Tone of voice.
 
 Write in a calm, assured tone of voice. Our tone is friendly and direct, but [we don't use slang](#avoid-emojis-slang-and-metaphors).
 
-### Write in US English
+## Write in US English
 
 US English is the most globally recognized form of English. Use US English punctuation, grammar, and spelling. For example:
 
@@ -34,15 +34,15 @@ US English is the most globally recognized form of English. Use US English punct
 - "behavior" over "behaviour"
 - "Prisma plans to" over "Prisma plan to"
 
-### Avoid emojis, slang, and metaphors
+## Avoid emojis, slang, and metaphors
 
 Avoid emojis, idiomatic expressions, slang, and metaphors. Prisma has a global community, and the cultural meaning of these items might be different around the world, and can change over time.
 
-### Avoid using imprecise pronouns like "it" or "that"
+## Avoid using imprecise pronouns like "it" or "that"
 
 Try to be as specific as possible when you refer to a specific noun. Do not refer to the noun as "it" unless you have just defined the proper noun in a previous sentence or clause. Even then, your writing might be clearer for international audiences if you specify the noun again. In particular, avoid starting sentences with "It".
 
-### Write in the second person
+## Write in the second person
 
 The second person ("you") gives a conversational tone and speaks directly to the reader. Avoid the first person ("I", "we", "let's", and "us"). Example:
 
@@ -52,11 +52,11 @@ Exception: Use "we" when you refer to Prisma the organization. For example, here
 
 > "We recommend that you share a single instance of `PrismaClient` across your application".
 
-### Use inclusive language
+## Use inclusive language
 
 When you refer to one or more people in the third person, use inclusive, gender-neutral language. Use "they/them/their" instead of "he/him/his" or "she/her/her". Avoid gender-specific words like "guys".
 
-### Jargon
+## Jargon
 
 > Jargon: (n.) special words or expressions that are used by a particular profession or group and are difficult for others to understand.
 
@@ -78,7 +78,7 @@ When you use jargon, follow these guidelines:
 
 - When you link to an external definition, choose a credible source. Wikipedia is acceptable, and official third-party documentation is better.
 
-### Use active voice.
+## Use active voice.
 
 Use active voice instead of passive voice. It's a more concise and straightforward way to communicate. For example:
 
@@ -98,7 +98,7 @@ Sometimes you can omit the acting component or module altogether:
 
 - “Refer to the generated log file in `/directoryX`.”
 
-### Be assertive
+## Be assertive
 
 Use assertive language.
 
@@ -123,13 +123,13 @@ Avoid:
 
 - Please install dotenv-cli
 
-### Use "that" to clarify sentences
+## Use "that" to clarify sentences
 
 Example: "Ensure that you rebuild your schema.".
 
 See: ["That" as a conjunction for noun clauses](https://academicguides.waldenu.edu/formandstyle/writing/grammarmechanics/that).
 
-### Tense
+## Use the present simple tense
 
 - Write in the [present simple](https://en.wikipedia.org/wiki/Simple_present) tense.
 - Use present simple even when you want to write about something that will happen as the result of a user action: say that the result happens, not that it will happen.
@@ -144,7 +144,7 @@ When you run this command, Prisma writes the following log file.
 When you run this command, Prisma will write the following log file.
 ```
 
-### Indicate when something is optional
+## Indicate when something is optional
 
 When a paragraph or sentence offers an optional path, the beginning of the first sentence should indicate that it’s optional. For example, "if you’d like to learn more about xyz, see our reference guide" is clearer than "Go to the reference guide if you’d like to learn more about xyz."
 
@@ -153,3 +153,15 @@ This method allows people who would not like to learn more about xyz to stop rea
 For optional steps in a procedure, a succinct way to convey this is to precede the step with "Optional:". For example:
 
 5. Optional: In the **Tags** field, specify one or more tags for your file. Separate multiple tags with commas.
+
+## Code examples
+
+Start all query examples with a constant. This gives you a noun to refer to later in the document, and in most cases this clarifies the example.
+
+Example:
+
+```ts
+const aggregations = await prisma.user.aggregate({
+  ...
+})
+```

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -145,6 +145,7 @@ Avoid the following common words in English, because they are ambiguous to many 
 | May (to mean "might")            | Can also mean "is permitted to"                    | "Might"                                                                              |
 | Should (to mean "ought to")      | Can also mean "might happen"                       | "Must": "You must rebuild Prisma Client", or <br></br>Omit: "Rebuild Prisma Client." |
 | Once (to mean "when" or "after") | Can also mean "happens once"                       | "When": "When the build completes..."                                                |
+| Wish (to mean "want"")           | Not always clear internationally                   | "Want"                                                                               |
 
 ## Use clear hyperlinks
 

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -145,7 +145,7 @@ Avoid the following common words in English, because they are ambiguous to many 
 | May (to mean "might")            | Can also mean "is permitted to"                    | "Might"                                                                              |
 | Should (to mean "ought to")      | Can also mean "might happen"                       | "Must": "You must rebuild Prisma Client", or <br></br>Omit: "Rebuild Prisma Client." |
 | Once (to mean "when" or "after") | Can also mean "happens once"                       | "When": "When the build completes..."                                                |
-| Wish (to mean "want"")           | Not always clear internationally                   | "Want"                                                                               |
+| Wish (to mean "want")           | Not always clear internationally                   | "Want"                                                                               |
 
 ## Use clear hyperlinks
 

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -214,3 +214,7 @@ Open a terminal window.
 This can be a noun ("setup") or verb ("set up") and as such can cause confusion. Try to avoid, and use an alternative term. For example, "configure" or "enable".
 
 If you must use it, ensure you use the correct form. Remember to check in code snippets, where it might lurk in the code comments.
+
+### Other terms
+
+We have an [internal terminology page](https://www.notion.so/prismaio/Terminology-Product-Names-and-Usage-WIP-8f763e861d4f4114b17b1210eb3b6d99). When we have agreed on these, we will add them to this page.

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -145,7 +145,7 @@ Avoid the following common words in English, because they are ambiguous to many 
 | May (to mean "might")            | Can also mean "is permitted to"                    | "Might"                                                                              |
 | Should (to mean "ought to")      | Can also mean "might happen"                       | "Must": "You must rebuild Prisma Client", or <br></br>Omit: "Rebuild Prisma Client." |
 | Once (to mean "when" or "after") | Can also mean "happens once"                       | "When": "When the build completes..."                                                |
-| Wish (to mean "want")           | Not always clear internationally                   | "Want"                                                                               |
+| Wish (to mean "want")            | Not always clear internationally                   | "Want"                                                                               |
 
 ## Use clear hyperlinks
 

--- a/content/600-about/200-prisma-docs/30-docs-components/03-frontmatter.mdx
+++ b/content/600-about/200-prisma-docs/30-docs-components/03-frontmatter.mdx
@@ -1,33 +1,52 @@
 ---
-title: Frontmatter
-metaDescription: 'Supported frontmatter variables.'
+title: Front matter
+metaDescription: Supported front matter variables.
 ---
 
 <TopBlock></TopBlock>
 
 ## <inlinecode>title</inlinecode>
 
-The `<h1>` title of the page.
+The `<h1>` title of the page. This title appears at the top of the page, and in the left-hand navigation.
+
+Note:
+
+- You can wrap the `title` text in single quotes, but this is not mandatory.
+- If you wrap the `title` text in single quotes, then you cannot include apostrophes in the text.
 
 ## <inlinecode>metaTitle</inlinecode>
 
-The `<title>` of the page - falls back to `title` (`h1`)
+The `<title>` of the page - falls back to `title` (`h1`).
+
+Note:
+
+- You can wrap the `metaTitle` text in single quotes, but this is not mandatory.
+- If you wrap the `metaTitle` text in single quotes, then you cannot include apostrophes in the text.
 
 ## <inlinecode>navTitle</inlinecode>
 
-Allows you to specify a different, usually shorter title for the left-hand navigation.
+Specifies a different, usually shorter title for the left-hand navigation.
 
 ## <inlinecode>metaDescription</inlinecode>
 
 The `<meta name="description" content="" />` of the page.
 
+Note:
+
+- You can wrap the `metaDescription` text in single quotes, but this is not mandatory.
+- If you wrap the `metaDescription` text in single quotes, then you cannot include apostrophes in the text.
+
 ## <inlinecode>staticLink</inlinecode>
 
-Turns the page into a non-linked heading in the left-hand navigation. For example: https://www.prisma.io/docs/concepts/overview
+Accepts `true` or `false` (defaults to `false`).
 
-> **Note**: The page still exists, but you can only navigate to it via the breadcrumb.
+If `true`, this option turns the page into a heading in the left-hand navigation. This heading cannot be clicked by the docs user. For example: https://www.prisma.io/docs/concepts/overview
+
+> **Note**: The page still exists, but docs users can only navigate to it with the breadcrumb trail. We recommend that you add a [subsections](/about/prisma-docs/docs-components/mdx-examples#subsections) MDX component to the page, so that it contains useful content when a user navigates to it with the breadcrumb trail.
 
 ## <inlinecode>preview</inlinecode>
+
+Accepts `true` or `false` (defaults to `false`).
 
 Adds a `preview` label to a page in the left-hand navigation.
 
@@ -51,11 +70,18 @@ tocDepth: 2
 
 ## <inlinecode>hidePage</inlinecode>
 
-Hides page from all navigation (still visible through search). For example:
+Accepts `true` or `false` (defaults to `false`).
+
+Hides the page from all navigation.
 
 ```
 hidePage: true
 ```
+
+Note:
+
+- A page hidden with `hidePage` is not listed by the [subsections](/about/prisma-docs/docs-components/mdx-examples#subsections) MDX component.
+- A page hidden with `hidePage` is still findable by docs users with a search.
 
 <!--
 


### PR DESCRIPTION
- Added "wish" to "do not use" words list
- Improved the front matter descriptions## Describe this PR
- Fixed heading level in writing style doc
- Added a new code examples section (with the requirement that we use constants in query examples)
- Linked to Prisma's internal terminology page