### PR TITLE
Fixes to make style guide obey its own guidelines

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -137,7 +137,7 @@ Prisma automatically converts JavaScript objects (for example, `{ extendedPetsDa
 
 ## Make lists clear with the Oxford Comma
 
-Use the Oxford Comma except in titles. It is a comma used after the penultimate item in a list of three or more items, before "and" or "or" e.g. an Italian painter, sculptor, and architect. It makes things clearer.
+Use the Oxford Comma except in titles. It is a comma used after the penultimate item in a list of three or more items, before "and" or "or". It makes things clearer. Example: "... an Italian inventor, painter, sculptor, and architect".
 
 [Confusion can happen when you don’t use the Oxford comma.](https://img.buzzfeed.com/buzzfeed-static/static/2015-02/22/18/enhanced/webdr11/enhanced-buzz-32156-1424646300-12.jpg?downsize=715:*&output-format=auto&output-quality=auto)
 

--- a/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -137,7 +137,7 @@ Prisma automatically converts JavaScript objects (for example, `{ extendedPetsDa
 
 ## Make lists clear with the Oxford Comma
 
-Use the Oxford Comma except in titles. It is a comma used after the penultimate item in a list of three or more items, before "and" or "or". It makes things clearer. Example: "... an Italian inventor, painter, sculptor, and architect".
+Use the Oxford Comma except in titles. It is a comma used after the penultimate item in a list of three or more items, before "and" or "or". It makes things clearer. Example: "... an Italian painter, sculptor, and architect".
 
 [Confusion can happen when you don’t use the Oxford comma.](https://img.buzzfeed.com/buzzfeed-static/static/2015-02/22/18/enhanced/webdr11/enhanced-buzz-32156-1424646300-12.jpg?downsize=715:*&output-format=auto&output-quality=auto)
 


### PR DESCRIPTION
- Replaced Latin term with English equivalent
- Split out a multi-clause sentence into separate sentences