### PR TITLE
Fix typo in Client page

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/index.mdx
@@ -108,7 +108,7 @@ const users = await prisma.user.findMany()
 
 <Admonition type="info">
 
-- Note that queries will only run if used with `await` or chained with `.then()`. When using [`$transaction`](transactions)'s this makes it possible for the client to pass all the queries on to the [query engine](/concepts/components/prisma-engines/query-engine) as a transaction.
+- Note that queries will only run if used with `await` or chained with `.then()`. When using [`$transaction`](transactions)s, this makes it possible for the client to pass all the queries on to the [query engine](/concepts/components/prisma-engines/query-engine) as a transaction.
 - The client methods are ["thenable"](https://masteringjs.io/tutorials/fundamentals/thenable), they return a PrismaPromise which is implemented like a JavaScript Promise, except for the query to be executed they need to be awaited or chained with `.then()`.
 
 </Admonition>


### PR DESCRIPTION
Removed a stray apostrophe, and added a comma for clarity while I was there.