### PR TITLE
Prisma 4.4.0: document isolation levels for sequential transactions

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -141,7 +141,7 @@ const [findRawData, aggregateRawData, commandRawData] =
 
 </TabbedContent>
 
-Instead of immediately awaiting the result of each operation when it's performed, the operation itself is stored in a variable first which later is submitted to the database with a method called `$transaction`. Prisma Client will ensure that either all three `create`-operations succeed or none of them succeed.
+Instead of immediately awaiting the result of each operation when it's performed, the operation itself is stored in a variable first which later is submitted to the database with a method called `$transaction`. Prisma Client will ensure that either all three `create` operations succeed or none of them succeed.
 
 > **Note**: Operations are executed according to the order they are placed in the transaction. Using a query in a transaction does not influence the order of operations in the query itself.
 >

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -340,7 +340,7 @@ For sequential operations:
 ```ts
 await prisma.$transaction(
   [
-    // Code running in a transaction...
+    // Prisma Client operations running in a transaction...
   ],
   {
     isolationLevel: Prisma.TransactionIsolationLevel.Serializable, // optional, default defined by database configuration

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -147,7 +147,7 @@ Instead of immediately awaiting the result of each operation when it's performed
 >
 > Refer to the 📖 [transactions guide](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api) for more examples.
 
-The sequential transaction API has a second parameter with the following optional configuration option:
+From version 4.4.0, the sequential transaction API has a second parameter with the following optional configuration option:
 
 - `isolationLevel`: Sets the [transaction isolation level](#transaction-isolation-level). By default this is set to the value currently configured in your database.
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -147,7 +147,7 @@ Instead of immediately awaiting the result of each operation when it's performed
 >
 > Refer to the 📖 [transactions guide](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api) for more examples.
 
-From version 4.4.0, the sequential operation API has a second parameter with the following optional configuration option:
+From version 4.4.0, the transaction API has a second parameter. For sequential operations, you can use the following optional configuration option in this parameter:
 
 - `isolationLevel`: Sets the [transaction isolation level](#transaction-isolation-level). By default this is set to the value currently configured in your database.
 
@@ -272,7 +272,7 @@ try {
 }
 ```
 
-The interactive transaction API has a second parameter with the following optional configuration options:
+The transaction API has a second parameter. For interactive transactions, you can use the following optional configuration options in this parameter:
 
 - `maxWait`: The maximum amount of time the Prisma Client will wait to acquire a transaction from the database. The default value is 2 seconds.
 - `timeout`: The maximum amount of time the interactive transaction can run before being canceled and rolled back. The default value is 5 seconds.
@@ -313,12 +313,12 @@ This feature is not available on MongoDB, because MongoDB does not support isola
 You can set the transaction [isolation level](https://www.prisma.io/dataguide/intro/database-glossary#isolation-levels) for transactions in the following Prisma versions:
 
 - For interactive transactions: from version 4.2.0
-- For sequential Prisma Client operations: from version 4.4.0
+- For sequential operations: from version 4.4.0
 
 <Admonition type="info">
 
 **In earlier versions**<br /><br />
-In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential Prisma Client operations), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
+In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential operations), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
 
 - [Default transaction isolation level in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
 - [Default transaction isolation level in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
@@ -331,7 +331,24 @@ In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequentia
 
 </Admonition>
 
-To set the transaction isolation level, use the `isolationLevel` option in the second parameter of the API. For example, for an interactive transaction:
+#### Set the isolation level
+
+To set the transaction isolation level, use the `isolationLevel` option in the second parameter of the API.
+
+For sequential operations:
+
+```ts
+await prisma.$transaction(
+  [
+    // Code running in a transaction...
+  ],
+  {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable, // optional, default defined by database configuration
+  }
+)
+```
+
+For an interactive transaction:
 
 ```jsx
 await prisma.$transaction(

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -147,7 +147,7 @@ Instead of immediately awaiting the result of each operation when it's performed
 >
 > Refer to the 📖 [transactions guide](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api) for more examples.
 
-From version 4.4.0, the transaction API has a second parameter. For sequential operations, you can use the following optional configuration option in this parameter:
+From version 4.4.0, the sequential operations transaction API has a second parameter. You can use the following optional configuration option in this parameter:
 
 - `isolationLevel`: Sets the [transaction isolation level](#transaction-isolation-level). By default this is set to the value currently configured in your database.
 

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -147,7 +147,7 @@ Instead of immediately awaiting the result of each operation when it's performed
 >
 > Refer to the 📖 [transactions guide](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api) for more examples.
 
-From version 4.4.0, the sequential transaction API has a second parameter with the following optional configuration option:
+From version 4.4.0, the sequential operation API has a second parameter with the following optional configuration option:
 
 - `isolationLevel`: Sets the [transaction isolation level](#transaction-isolation-level). By default this is set to the value currently configured in your database.
 
@@ -313,12 +313,12 @@ This feature is not available on MongoDB, because MongoDB does not support isola
 You can set the transaction [isolation level](https://www.prisma.io/dataguide/intro/database-glossary#isolation-levels) for transactions in the following Prisma versions:
 
 - For interactive transactions: from version 4.2.0
-- For sequential transactions: from version 4.4.0
+- For sequential Prisma Client operations: from version 4.4.0
 
 <Admonition type="info">
 
 **In earlier versions**<br /><br />
-In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential transactions), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
+In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential Prisma Client operations), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
 
 - [Default transaction isolation level in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
 - [Default transaction isolation level in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -19,7 +19,7 @@ A database transaction refers to a sequence of read/write operations that are _g
 Prisma provides the following options for using transactions:
 
 - [Nested writes](#nested-writes): use the Prisma Client API to process multiple operations on one or more related records inside the same transaction.
-- [Batch / bulk transactions](#batchbulk-operations): process one or more operations in bulk via `updateMany`, `deleteMany`, and `createMany`.
+- [Batch / bulk transactions](#batchbulk-operations): process one or more operations in bulk with `updateMany`, `deleteMany`, and `createMany`.
 - The Prisma Client `$transaction` API:
   - [Sequential operations](#sequential-prisma-client-operations): pass an array of Prisma Client queries to be executed sequentially inside a transaction, using `$transaction<R>(queries: PrismaPromise<R>[]): Promise<R[]>`.
   - [Interactive transactions](#interactive-transactions-in-preview) (in Preview): pass a function that can contain user code including Prisma Client queries, non-Prisma code and other control flow to be executed in a transaction, using `$transaction<R>(fn: (prisma: PrismaClient) => R, options?: object): R`
@@ -141,11 +141,29 @@ const [findRawData, aggregateRawData, commandRawData] =
 
 </TabbedContent>
 
-Instead of immediately awaiting the result of each operation when it's performed, the operation itself is stored in a variable first which later is submitted to the database via a method called `$transaction`. Prisma Client will ensure that either all three `create`-operations succeed or none of them succeed.
+Instead of immediately awaiting the result of each operation when it's performed, the operation itself is stored in a variable first which later is submitted to the database with a method called `$transaction`. Prisma Client will ensure that either all three `create`-operations succeed or none of them succeed.
 
 > **Note**: Operations are executed according to the order they are placed in the transaction. Using a query in a transaction does not influence the order of operations in the query itself.
 >
 > Refer to the 📖 [transactions guide](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api) for more examples.
+
+The sequential transaction API has a second parameter with the following optional configuration option:
+
+- `isolationLevel`: Sets the [transaction isolation level](#transaction-isolation-level). By default this is set to the value currently configured in your database.
+
+For example:
+
+```ts
+await prisma.$transaction(
+  [
+    prisma.resource.deleteMany({ where: { name: 'name' } }),
+    prisma.resource.createMany({ data }),
+  ],
+  {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable, // optional, default defined by database configuration
+  }
+)
+```
 
 ### Interactive transactions (in Preview)
 
@@ -162,9 +180,9 @@ generator client {
 }
 ```
 
-Then you can pass an async function into [`$transaction`](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api). 
+Then you can pass an async function into [`$transaction`](/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api).
 
-The first argument passed into this async function is an instance of Prisma Client. Below, we will call this instance `tx`. Any Prisma call invoked on this `tx` instance is encapsulated into the transaction. 
+The first argument passed into this async function is an instance of Prisma Client. Below, we will call this instance `tx`. Any Prisma call invoked on this `tx` instance is encapsulated into the transaction.
 
 Let's look at an example:
 
@@ -284,20 +302,23 @@ transaction functions. We recommend you get in and out as quick as possible!
 
 </Admonition>
 
-#### Transaction isolation level
+### Transaction isolation level
 
 <Admonition type="info">
 
-This feature is not available on MongoDB, as MongoDB does not support isolation levels.
+This feature is not available on MongoDB, because MongoDB does not support isolation levels.
 
 </Admonition>
 
-From version 4.2.0, you can set the transaction [isolation level](https://www.prisma.io/dataguide/intro/database-glossary#isolation-levels).
+You can set the transaction [isolation level](https://www.prisma.io/dataguide/intro/database-glossary#isolation-levels) for transactions in the following Prisma versions:
+
+- For interactive transactions: from version 4.2.0
+- For sequential transactions: from version 4.4.0
 
 <Admonition type="info">
 
-**Before version 4.2.0**<br /><br />
-In version 4.1.0 and earlier, you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
+**In earlier versions**<br /><br />
+In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential transactions), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
 
 - [Default transaction isolation level in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
 - [Default transaction isolation level in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
@@ -310,7 +331,7 @@ In version 4.1.0 and earlier, you cannot configure the transaction isolation lev
 
 </Admonition>
 
-To set the transaction isolation level, use the `isolationLevel` option in the second parameter of the API. For example:
+To set the transaction isolation level, use the `isolationLevel` option in the second parameter of the API. For example, for an interactive transaction:
 
 ```jsx
 await prisma.$transaction(
@@ -325,6 +346,8 @@ await prisma.$transaction(
 )
 ```
 
+#### Supported isolation levels
+
 Prisma Client supports the following isolation levels if they are available in the underlying database:
 
 - `ReadUncommitted`
@@ -332,8 +355,6 @@ Prisma Client supports the following isolation levels if they are available in t
 - `RepeatableRead`
 - `Snapshot`
 - `Serializable`
-
-##### Isolation levels by database
 
 The isolation levels available for each database connector are as follows:
 
@@ -345,9 +366,9 @@ The isolation levels available for each database connector are as follows:
 | CockroachDB | No              | No                | No               | ✔️             | No         |
 | SQLite      | No              | No                | No               | ✔️             | No         |
 
-By default Prisma Client will set the isolation level to the value currently configured in your database.
+By default, Prisma Client sets the isolation level to the value currently configured in your database.
 
-The isolation levels configured by default in each database are:
+The isolation levels configured by default in each database are as follows:
 
 | Database    | Default          |
 | ----------- | ---------------- |
@@ -357,7 +378,7 @@ The isolation levels configured by default in each database are:
 | CockroachDB | `Serializable`   |
 | SQLite      | `Serializable`   |
 
-For more database-specific information on isolation levels, see the following resources:
+For database-specific information on isolation levels, see the following resources:
 
 - [Transaction isolation levels in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
 - [Transaction isolation levels in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)


### PR DESCRIPTION
Modified the isolation levels material so that it applies to sequential transactions, in addition to interactive transactions (as already documented).
