### PR TITLE
Update 020-use-custom-model-and-field-names.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
@@ -285,7 +285,7 @@ model User {
 }
 ```
 
-Since the names of the virtual relation fields `Post_Post_authorToUser` and `Post_Post_favoritedByToUser` are based on the generated relation names, they don't look very friendly in the Prisma Client API. In that case, you can rename the relation fields to anything you like, e.g.:
+Since the names of the virtual relation fields `Post_Post_authorToUser` and `Post_Post_favoritedByToUser` are based on the generated relation names, they don't look very friendly in the Prisma Client API. In that case, you can rename the relation fields to anything you like, for example:
 
 ```prisma highlight=11-12;edit
 model Post {

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
@@ -285,7 +285,7 @@ model User {
 }
 ```
 
-Since the names of the virtual relation fields `Post_Post_authorToUser` and `Post_Post_favoritedByToUser` are based on the generated relation names, they don't look very friendly in the Prisma Client API. In that case, you can rename the relation fields to anything you like, for example:
+Because the names of the virtual relation fields `Post_Post_authorToUser` and `Post_Post_favoritedByToUser` are based on the generated relation names, they don't look very friendly in the Prisma Client API. In that case, you can rename the relation fields. For example:
 
 ```prisma highlight=11-12;edit
 model Post {

--- a/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/000-working-with-prismaclient/020-use-custom-model-and-field-names.mdx
@@ -287,7 +287,7 @@ model User {
 
 Since the names of the virtual relation fields `Post_Post_authorToUser` and `Post_Post_favoritedByToUser` are based on the generated relation names, they don't look very friendly in the Prisma Client API. In that case, you can rename the relation fields to anything you like, e.g.:
 
-```prisma
+```prisma highlight=11-12;edit
 model Post {
   id                          Int   @id @default(autoincrement())
   author                      Int


### PR DESCRIPTION
- Clarified the section on renaming relation fields with some code highlighting to make it instantly obvious what has changed.
- I also made a quick drive-by fix to replace a Latin abbreviation in this section with its English equivalent, as per the style guide.