### PR TITLE
Fixing updateMany link

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -706,7 +706,7 @@ const updateUser = await prisma.user.update({
 
 ### Update multiple records
 
-The following query uses [`updateMany`](/reference/api-reference/prisma-client-reference#updateMany) <span class="api"></span> to update all `User` records that contain `prisma.io`:
+The following query uses [`updateMany`](/reference/api-reference/prisma-client-reference#updatemany) <span class="api"></span> to update all `User` records that contain `prisma.io`:
 
 <CodeWithResult>
 <cmd>


### PR DESCRIPTION
Should point to #updatemany, not #updateMany

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
