### PR TITLE
Indexes sort configuration

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2230,7 +2230,7 @@ The `length` and `sort` arguments are added to the relevant field names:
 
 ```prisma no-lines
 @@unique(fields: [title(length:10), author])
-@@unique([title(sort:"Desc"), author(sort:"Asc")])
+@@unique([title(sort: Desc), author(sort: Asc)])
 ```
 
 #### Signature
@@ -2476,7 +2476,7 @@ The `length` and `sort` arguments are added to the relevant field names:
 
 ```prisma no-lines
 @@index(fields: [title(length:10), author])
-@@index([title(sort:"Asc"), author(sort:"Desc")])
+@@index([title(sort: Asc), author(sort: Desc)])
 ```
 
 #### Signature


### PR DESCRIPTION
Indexes sorting specification  (`Asc`, `Desc`) is incosistent. On the one hand, on page [reference/api-reference/prisma-schema-reference#index](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#index), `Asc` and `Desc` are in double quotes: 
```
@@index(fields: [title(length:10), author])
@@index([title(sort:"Asc"), author(sort:"Desc")])
```
On the other hand, on page [concepts/components/prisma-schema/indexes](https://www.prisma.io/docs/concepts/components/prisma-schema/indexes), they don't have double quotes:

```
model Post {
  title      String   @db.VarChar(300)
  abstract   String   @db.VarChar(3000)
  slug       String   @unique(sort: Desc, length: 42) @db.VarChar(3000)
  author     String
  created_at DateTime

  @@id([title(length: 100, sort: Desc), abstract(length: 10)])
  @@index([author, created_at(sort: Desc)])
}
```
 
However, for the changes to be correctly applied to the migration, `Asc` and `Desc` have to be written without double quotes. This patch fixes the typo.