### PR TITLE
Order transaction isolation levels table

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -375,13 +375,13 @@ Prisma Client supports the following isolation levels if they are available in t
 
 The isolation levels available for each database connector are as follows:
 
-| Database    | `ReadCommitted` | `ReadUncommitted` | `RepeatableRead` | `Serializable` | `Snapshot` |
+| Database    | `ReadUncommitted` | `ReadCommitted` | `RepeatableRead` | `Snapshot` | `Serializable` |
 | ----------- | --------------- | ----------------- | ---------------- | -------------- | ---------- |
-| PostgreSQL  | ✔️              | ✔️                | ✔️               | ✔️             | No         |
-| MySQL       | ✔️              | ✔️                | ✔️               | ✔️             | No         |
+| PostgreSQL  | ✔️              | ✔️                | ✔️               | No             | ✔️         |
+| MySQL       | ✔️              | ✔️                | ✔️               | No             | ✔️         |
 | SQL Server  | ✔️              | ✔️                | ✔️               | ✔️             | ✔️         |
-| CockroachDB | No              | No                | No               | ✔️             | No         |
-| SQLite      | No              | No                | No               | ✔️             | No         |
+| CockroachDB | No              | No                | No               | No             | ✔️         |
+| SQLite      | No              | No                | No               | No             | ✔️         |
 
 By default, Prisma Client sets the isolation level to the value currently configured in your database.
 


### PR DESCRIPTION
Order the table of transaction isolation levels by strength, similar to how they are listed in the bullet points above. Each transaction isolation level is now positioned to the left of all stronger transaction isolation levels.