### PR TITLE
Add SQL Server 2022 to supported databases

### DIFF
--- a/content/400-reference/300-database-reference/03-supported-databases.mdx
+++ b/content/400-reference/300-database-reference/03-supported-databases.mdx
@@ -23,6 +23,7 @@ Prisma currently supports the following databases:
 | SQLite                       | \*      |
 | AWS Aurora                   | \*      |
 | AWS Aurora Serverless &sup1; | \*      |
+| Microsoft SQL Server         | 2022    |
 | Microsoft SQL Server         | 2019    |
 | Microsoft SQL Server         | 2017    |
 | Azure SQL                    | \*      |


### PR DESCRIPTION
## Describe this PR

SQL Server 2022 should be added as a supported database. We test it in our CI and all tests pass without any modifications to our code.