### PR TITLE
Add remark about dbgenerated clarifying casts from DB.

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -3171,6 +3171,8 @@ Represents **default values** that cannot be expressed in the Prisma schema (suc
   - [Set default values for `Unsupported` types](#set-default-value-for-unsupported-type)
   - [Override default value behavior for supported types](#override-default-value-behavior-for-supported-types)
 
+- String values in `dbgenerated` may not match what the DB returns as the default value, because values such as strings may be explicitly cast (e.g. `'hello'::STRING`). When a mismatch is present, Prisma Migrate will indicate a migration is still needed. You can use `prisma db pull` to infer the correct value to resolve the discrepancy. ([Related issue](https://github.com/prisma/prisma/issues/14917))
+
 #### Examples
 
 ##### Set default value for `Unsupported` type

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -3171,7 +3171,7 @@ Represents **default values** that cannot be expressed in the Prisma schema (suc
   - [Set default values for `Unsupported` types](#set-default-value-for-unsupported-type)
   - [Override default value behavior for supported types](#override-default-value-behavior-for-supported-types)
 
-- String values in `dbgenerated` may not match what the DB returns as the default value, because values such as strings may be explicitly cast (e.g. `'hello'::STRING`). When a mismatch is present, Prisma Migrate will indicate a migration is still needed. You can use `prisma db pull` to infer the correct value to resolve the discrepancy. ([Related issue](https://github.com/prisma/prisma/issues/14917))
+- String values in `dbgenerated` might not match what the DB returns as the default value, because values such as strings may be explicitly cast (e.g. `'hello'::STRING`). When a mismatch is present, Prisma Migrate indicates a migration is still needed. You can use `prisma db pull` to infer the correct value to resolve the discrepancy. ([Related issue](https://github.com/prisma/prisma/issues/14917))
 
 #### Examples
 


### PR DESCRIPTION
## Describe this PR

Addresses discussion in https://github.com/prisma/prisma/issues/14917#issuecomment-1262914520.

## Changes

Adds remarks about `dbgenerated` to explain how DB values may be explicitly cast.

## What issue does this fix?

Fixes https://github.com/prisma/prisma/issues/14917
