### PR TITLE
Update treenode collapse fn

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -75,7 +75,6 @@ const siteConfig = {
         },
       ],
     },
-
     GeneralLinkData: [
       {
         categoryName: 'Overview',
@@ -416,6 +415,7 @@ const siteConfig = {
         width: '1200',
       },
     },
+    SpecialPaths: ['prisma-cli', 'deployment', 'sql-views'],
   },
   feedback: {
     sentimentUrl: '/docs/api/sentiment',

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -213,10 +213,14 @@ const TreeNode = ({
     }
   }, [isCollapsed])
 
+  React.useEffect(() => {
+    if (lastLevel && isCurrent && hasExpandButton) collapse()
+  }, [])
+
   const isCurrent =
     location &&
     slug &&
-    (location.pathname + '/').includes(urlGenerator(slug).replace(/\/index$/, '') + '/')
+    (location.pathname + '/').includes(urlGenerator(slug).replace(/\/index$/, ''))
 
   return url === '/' ? null : (
     <ListItem className={calculatedClassName}>

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -223,13 +223,13 @@ const TreeNode = ({
 
   const specialCases =
     slug &&
-    SpecialPaths.find((e: string) =>
+    (SpecialPaths.find((e: string) =>
       urlGenerator(slug)
         .replace(/\/index$/, '')
         .endsWith(e)
     )
       ? '/'
-      : ''
+      : '')
 
   const isCurrent =
     location &&

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -218,7 +218,10 @@ const TreeNode = ({
   }, [])
 
   const specialCases =
-    slug && (urlGenerator(slug).includes('prisma-cli') || urlGenerator(slug).includes('deployment'))
+    slug &&
+    (urlGenerator(slug).includes('prisma-cli') ||
+      urlGenerator(slug).includes('deployment') ||
+      urlGenerator(slug).includes('sql-views'))
       ? '/'
       : ''
 

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -5,7 +5,8 @@ import ArrowDown from '../../icons/ArrowDown'
 import Link from '../link'
 import { urlGenerator } from '../../utils/urlGenerator'
 import { useLocation } from '@reach/router'
-import { withPrefix } from 'gatsby'
+import { graphql, useStaticQuery, withPrefix } from 'gatsby'
+import config from '../../../config'
 
 const List = styled.ul`
   list-style: none;
@@ -157,6 +158,8 @@ const TreeNode = ({
   codeStyle,
   parents,
 }: any) => {
+  const SpecialPaths = config.siteMetadata.SpecialPaths
+
   let isCollapsed = collapsed[label]
   const hasChildren = items.length !== 0
 
@@ -214,20 +217,17 @@ const TreeNode = ({
   }, [isCollapsed])
 
   React.useEffect(() => {
-    if (lastLevel && isCurrent && hasExpandButton) collapse()
+    console.log(SpecialPaths)
+    if (lastLevel && isCurrent && hasExpandButton && collapsed[label]) setCollapsed(label, true)
   }, [])
 
   const specialCases =
     slug &&
-    (urlGenerator(slug)
-      .replace(/\/index$/, '')
-      .endsWith('prisma-cli') ||
+    SpecialPaths.find((e: string) =>
       urlGenerator(slug)
         .replace(/\/index$/, '')
-        .endsWith('deployment') ||
-      urlGenerator(slug)
-        .replace(/\/index$/, '')
-        .endsWith('sql-views'))
+        .endsWith(e)
+    )
       ? '/'
       : ''
 

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -217,10 +217,15 @@ const TreeNode = ({
     if (lastLevel && isCurrent && hasExpandButton) collapse()
   }, [])
 
+  const specialCases =
+    slug && (urlGenerator(slug).includes('prisma-cli') || urlGenerator(slug).includes('deployment'))
+      ? '/'
+      : ''
+
   const isCurrent =
     location &&
     slug &&
-    (location.pathname + '/').includes(urlGenerator(slug).replace(/\/index$/, ''))
+    location.pathname.includes(urlGenerator(slug).replace(/\/index$/, '') + specialCases)
 
   return url === '/' ? null : (
     <ListItem className={calculatedClassName}>

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -219,9 +219,15 @@ const TreeNode = ({
 
   const specialCases =
     slug &&
-    (urlGenerator(slug).includes('prisma-cli') ||
-      urlGenerator(slug).includes('deployment') ||
-      urlGenerator(slug).includes('sql-views'))
+    (urlGenerator(slug)
+      .replace(/\/index$/, '')
+      .endsWith('prisma-cli') ||
+      urlGenerator(slug)
+        .replace(/\/index$/, '')
+        .endsWith('deployment') ||
+      urlGenerator(slug)
+        .replace(/\/index$/, '')
+        .endsWith('sql-views'))
       ? '/'
       : ''
 


### PR DESCRIPTION
## Describe this PR

When changing the techs on the switcher the highlight on the menu disappears.

## Changes

Update `treeNode.tsx` to collapse if current page is active, if it is last level, and has an expand button.

## What issue does this fix?

[Fixes #3823](https://github.com/prisma/docs/issues/3823)

## Any other relevant information

N/A
