### PR TITLE
Update Spellcheck Action to use main branch, not master

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,12 +3,12 @@ name: Documentation Checks
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "content/**/*"
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - "content/**/*"
 jobs:


### PR DESCRIPTION
A follow-up to #3859.

CC @tanberry -- the one thing we missed was to check the workflow! It used `master`, not `main`, by accident. Sorry I missed that!