### PR TITLE
3878 transactions docs investigate why we only cover some database types at the end

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -312,13 +312,22 @@ This feature is not available on MongoDB, because MongoDB does not support isola
 
 You can set the transaction [isolation level](https://www.prisma.io/dataguide/intro/database-glossary#isolation-levels) for transactions in the following Prisma versions:
 
-- For interactive transactions from version 4.2.0
-- For sequential operations from version 4.4.0
+- For interactive transactions: from version 4.2.0
+- For sequential operations: from version 4.4.0
 
 <Admonition type="info">
 
 **In earlier versions**<br /><br />
-In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential operations), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the [isolation level configured in your database](#database-specific-information-on-isolation-levels) is used.
+In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential operations), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
+
+- [Default transaction isolation level in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
+- [Default transaction isolation level in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
+- [Default transaction isolation level in MySQL](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
+  <br />
+  <br />
+  CockroachDB and SQLite always use the <inlinecode>
+    Serializable
+  </inlinecode> isolation level.
 
 </Admonition>
 
@@ -386,9 +395,7 @@ The isolation levels configured by default in each database are as follows:
 | CockroachDB | `Serializable`   |
 | SQLite      | `Serializable`   |
 
-#### Database-specific information on isolation levels
-
-See the following resources:
+For database-specific information on isolation levels, see the following resources:
 
 - [Transaction isolation levels in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
 - [Transaction isolation levels in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)

--- a/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/058-transactions.mdx
@@ -312,22 +312,13 @@ This feature is not available on MongoDB, because MongoDB does not support isola
 
 You can set the transaction [isolation level](https://www.prisma.io/dataguide/intro/database-glossary#isolation-levels) for transactions in the following Prisma versions:
 
-- For interactive transactions: from version 4.2.0
-- For sequential operations: from version 4.4.0
+- For interactive transactions from version 4.2.0
+- For sequential operations from version 4.4.0
 
 <Admonition type="info">
 
 **In earlier versions**<br /><br />
-In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential operations), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the isolation level configured in your database is used. For database-specific information on isolation levels, including database defaults, see the following resources:<br /><br />
-
-- [Default transaction isolation level in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
-- [Default transaction isolation level in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)
-- [Default transaction isolation level in MySQL](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
-  <br />
-  <br />
-  CockroachDB and SQLite always use the <inlinecode>
-    Serializable
-  </inlinecode> isolation level.
+In versions before 4.2.0 (for interactive transactions), or 4.4.0 (for sequential operations), you cannot configure the transaction isolation level at a Prisma level. The isolation level is not explicitly set by Prisma, so the [isolation level configured in your database](#database-specific-information-on-isolation-levels) is used.
 
 </Admonition>
 
@@ -395,7 +386,9 @@ The isolation levels configured by default in each database are as follows:
 | CockroachDB | `Serializable`   |
 | SQLite      | `Serializable`   |
 
-For database-specific information on isolation levels, see the following resources:
+#### Database-specific information on isolation levels
+
+See the following resources:
 
 - [Transaction isolation levels in PostgreSQL](https://www.postgresql.org/docs/9.3/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION)
 - [Transaction isolation levels in Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15)

--- a/src/gatsby-types.d.ts
+++ b/src/gatsby-types.d.ts
@@ -655,7 +655,6 @@ declare namespace Queries {
     | 'childMdx.frontmatter.hiddenPage'
     | 'childMdx.frontmatter.hidePage'
     | 'childMdx.frontmatter.langSwitcher'
-    | 'childMdx.frontmatter.metaDecription'
     | 'childMdx.frontmatter.metaDescription'
     | 'childMdx.frontmatter.metaDescriptions'
     | 'childMdx.frontmatter.metaTitle'
@@ -816,7 +815,6 @@ declare namespace Queries {
     | 'childrenMdx.frontmatter.hiddenPage'
     | 'childrenMdx.frontmatter.hidePage'
     | 'childrenMdx.frontmatter.langSwitcher'
-    | 'childrenMdx.frontmatter.metaDecription'
     | 'childrenMdx.frontmatter.metaDescription'
     | 'childrenMdx.frontmatter.metaDescriptions'
     | 'childrenMdx.frontmatter.metaTitle'
@@ -1948,7 +1946,6 @@ declare namespace Queries {
     | 'frontmatter.hiddenPage'
     | 'frontmatter.hidePage'
     | 'frontmatter.langSwitcher'
-    | 'frontmatter.metaDecription'
     | 'frontmatter.metaDescription'
     | 'frontmatter.metaDescriptions'
     | 'frontmatter.metaTitle'
@@ -2069,7 +2066,6 @@ declare namespace Queries {
     readonly hiddenPage: Maybe<Scalars['Boolean']>
     readonly hidePage: Maybe<Scalars['Boolean']>
     readonly langSwitcher: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>
-    readonly metaDecription: Maybe<Scalars['String']>
     readonly metaDescription: Maybe<Scalars['String']>
     readonly metaDescriptions: Maybe<Scalars['String']>
     readonly metaTitle: Maybe<Scalars['String']>
@@ -2094,7 +2090,6 @@ declare namespace Queries {
     readonly hiddenPage: InputMaybe<BooleanQueryOperatorInput>
     readonly hidePage: InputMaybe<BooleanQueryOperatorInput>
     readonly langSwitcher: InputMaybe<StringQueryOperatorInput>
-    readonly metaDecription: InputMaybe<StringQueryOperatorInput>
     readonly metaDescription: InputMaybe<StringQueryOperatorInput>
     readonly metaDescriptions: InputMaybe<StringQueryOperatorInput>
     readonly metaTitle: InputMaybe<StringQueryOperatorInput>

--- a/src/gatsby-types.d.ts
+++ b/src/gatsby-types.d.ts
@@ -655,6 +655,7 @@ declare namespace Queries {
     | 'childMdx.frontmatter.hiddenPage'
     | 'childMdx.frontmatter.hidePage'
     | 'childMdx.frontmatter.langSwitcher'
+    | 'childMdx.frontmatter.metaDecription'
     | 'childMdx.frontmatter.metaDescription'
     | 'childMdx.frontmatter.metaDescriptions'
     | 'childMdx.frontmatter.metaTitle'
@@ -815,6 +816,7 @@ declare namespace Queries {
     | 'childrenMdx.frontmatter.hiddenPage'
     | 'childrenMdx.frontmatter.hidePage'
     | 'childrenMdx.frontmatter.langSwitcher'
+    | 'childrenMdx.frontmatter.metaDecription'
     | 'childrenMdx.frontmatter.metaDescription'
     | 'childrenMdx.frontmatter.metaDescriptions'
     | 'childrenMdx.frontmatter.metaTitle'
@@ -1946,6 +1948,7 @@ declare namespace Queries {
     | 'frontmatter.hiddenPage'
     | 'frontmatter.hidePage'
     | 'frontmatter.langSwitcher'
+    | 'frontmatter.metaDecription'
     | 'frontmatter.metaDescription'
     | 'frontmatter.metaDescriptions'
     | 'frontmatter.metaTitle'
@@ -2066,6 +2069,7 @@ declare namespace Queries {
     readonly hiddenPage: Maybe<Scalars['Boolean']>
     readonly hidePage: Maybe<Scalars['Boolean']>
     readonly langSwitcher: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>
+    readonly metaDecription: Maybe<Scalars['String']>
     readonly metaDescription: Maybe<Scalars['String']>
     readonly metaDescriptions: Maybe<Scalars['String']>
     readonly metaTitle: Maybe<Scalars['String']>
@@ -2090,6 +2094,7 @@ declare namespace Queries {
     readonly hiddenPage: InputMaybe<BooleanQueryOperatorInput>
     readonly hidePage: InputMaybe<BooleanQueryOperatorInput>
     readonly langSwitcher: InputMaybe<StringQueryOperatorInput>
+    readonly metaDecription: InputMaybe<StringQueryOperatorInput>
     readonly metaDescription: InputMaybe<StringQueryOperatorInput>
     readonly metaDescriptions: InputMaybe<StringQueryOperatorInput>
     readonly metaTitle: InputMaybe<StringQueryOperatorInput>


### PR DESCRIPTION
We cover all the main database types now, so I've made only some minor changes:
- Fixed some punctuation
- Removed some duplicate content, and linked to it from the admonition