### PR TITLE
Fix typos on Reading JSON field docs

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -70,11 +70,11 @@ const user = await prisma.user.findFirst({
   },
 })
 
-// Example extendedProfile data:
+// Example extendedPetsData data:
 // [{ name: 'Bob the dog' }, { name: 'Claudine the cat' }]
 
-if (user?.pets && typeof user?.pets === 'object' && Array.isArray(user?.pets)) {
-  const petsObject = user?.pets as Prisma.JsonArray
+if (user?.extendedPetsData && typeof user?.extendedPetsData === 'object' && Array.isArray(user?.extendedPetsData)) {
+  const petsObject = user?.extendedPetsData as Prisma.JsonArray
 
   const firstPet = petsObject[0]
 }


### PR DESCRIPTION
## Describe this PR

Fixes wrong names on [Reading JSON field docs](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields)

## Any other relevant information

The beginning of this doc page proposes a `User` model with an `extendedPetsData` field. However later on it was using `extendedProfile` and `pets` to reference that same field.
