### PR TITLE
Add a remark about upsert’s race conditions

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -954,6 +954,7 @@ const user = await prisma.user.update({
 #### Remarks
 
 - To perform arithmetic operations on update (add, subtract, multiply, divide), use [atomic updates](#atomic-number-operations) to prevent race conditions.
+- Prisma performs the upsert first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. Since it does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, [two simultaneous upserts on the same record can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
 
 #### Reference
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -954,7 +954,7 @@ const user = await prisma.user.update({
 #### Remarks
 
 - To perform arithmetic operations on update (add, subtract, multiply, divide), use [atomic updates](#atomic-number-operations) to prevent race conditions.
-- Prisma performs the upsert by first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. Since it does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, [two simultaneous upserts with the same `UNIQUE` key can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
+- Prisma performs the upsert by first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. It does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, so [two simultaneous upserts with the same `UNIQUE` key can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
 
 #### Reference
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -954,7 +954,7 @@ const user = await prisma.user.update({
 #### Remarks
 
 - To perform arithmetic operations on update (add, subtract, multiply, divide), use [atomic updates](#atomic-number-operations) to prevent race conditions.
-- Prisma performs the upsert by first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. It does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, so [two simultaneous upserts with the same `UNIQUE` key can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
+- Prisma performs the upsert by first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. It [currently](https://github.com/prisma/prisma/issues/9972) does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, so [two simultaneous upserts with the same `UNIQUE` key can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
 
 #### Reference
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -954,7 +954,7 @@ const user = await prisma.user.update({
 #### Remarks
 
 - To perform arithmetic operations on update (add, subtract, multiply, divide), use [atomic updates](#atomic-number-operations) to prevent race conditions.
-- Prisma performs the upsert first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. Since it does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, [two simultaneous upserts on the same record can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
+- Prisma performs the upsert first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. Since it does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, [two simultaneous upserts with the same `UNIQUE` key can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
 
 #### Reference
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -954,7 +954,7 @@ const user = await prisma.user.update({
 #### Remarks
 
 - To perform arithmetic operations on update (add, subtract, multiply, divide), use [atomic updates](#atomic-number-operations) to prevent race conditions.
-- Prisma performs the upsert first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. Since it does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, [two simultaneous upserts with the same `UNIQUE` key can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
+- Prisma performs the upsert by first executing a `SELECT` query to check if the record exists, followed by an `INSERT` or `UPDATE` query depending on the result of the `SELECT` query. Since it does not use the `ON CONFLICT` or the `ON DUPLICATE KEY` clause, [two simultaneous upserts with the same `UNIQUE` key can result in a “Unique constraint failed” error](https://github.com/prisma/prisma/issues/3242). It is your application’s responsibility to handle the [P2002](error-reference#p2002) error and retry the upsert.
 
 #### Reference
 


### PR DESCRIPTION
## Describe this PR

I have been bitten hard by this issue:

- https://github.com/prisma/prisma/issues/3242

This is because I have assumed that Prisma’s upsert behavior would be equivalent to [MongoDB’s behavior](https://www.mongodb.com/docs/manual/reference/method/db.collection.update/#upsert-with-unique-index).

- MongoDB’s upsert behavior is similar to using a `ON DUPLICATE KEY` or `ON CONFLICT` clause, so the database makes sure that 2 simulataneous `upsert`’s on the same document with same unique key are treated sequentially — one `upsert` results in an `insert`, and the other results in an `update`.
- Prisma’s upsert behavior first does a `SELECT` followed by `INSERT`/`UPDATE`. If 2 simultaneous upserts are taking place, it could lead to a race condition where both upserts does not see an existing record and both attempts to insert, resulting in a P2002 error.

## Changes

Document this behavior. This is the remark I wish I saw when I decided to use this method.

## What issue does this fix?

https://github.com/prisma/prisma/issues/3242

## Any other relevant information

N/A