### PR TITLE
fix: wrong version number mentioned in “soft deletes without middleware”

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/053-middleware/100-soft-delete-middleware.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-middleware/100-soft-delete-middleware.mdx
@@ -9,7 +9,7 @@ tocDepth: 3
 
 <Admonition type="info">
 
-From version 3.5.0, you can perform soft deletes without middleware. [Learn more](/reference/api-reference/prisma-client-reference/#filter-on-non-unique-fields-with-userwhereuniqueinput).
+From version 4.5.0, you can perform soft deletes without middleware. [Learn more](/reference/api-reference/prisma-client-reference/#filter-on-non-unique-fields-with-userwhereuniqueinput).
 
 </Admonition>
 


### PR DESCRIPTION
## Describe this PR

The note about soft deletes without middleware mentions a wrong version number. It is off by one major version.

## Changes

Change "3.5.0" to "4.5.0"

## What issue does this fix?

N/A

## Any other relevant information

N/A