### PR TITLE
Improve discoverability of Prisma.DbNull/Prisma.JsonNull

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -863,7 +863,7 @@ There are two types of `null` values possible for a `JSON` field in an SQL datab
 - Database `NULL`: The value in the database is a `NULL`.
 - JSON `null`: The value in the database contains a JSON value that is `null`.
 
-To differentiate between these possibilities, we've introduced three _null enums_ you can use to filter on:
+To differentiate between these possibilities, we've introduced three _null enums_ you can use:
 
 - `JsonNull`: Represents the `null` value in JSON.
 - `DbNull`: Represents the `NULL` value in the database.
@@ -911,6 +911,8 @@ prisma.log.create({
 ```
 
 ### Filtering by <inlinecode>null</inlinecode> Values
+
+To filter by a JsonNull or a DbNull, you would write:
 
 ```ts highlight=6;normal
 import { Prisma } from '@prisma/client'

--- a/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/051-working-with-fields/100-working-with-json-fields.mdx
@@ -73,7 +73,11 @@ const user = await prisma.user.findFirst({
 // Example extendedPetsData data:
 // [{ name: 'Bob the dog' }, { name: 'Claudine the cat' }]
 
-if (user?.extendedPetsData && typeof user?.extendedPetsData === 'object' && Array.isArray(user?.extendedPetsData)) {
+if (
+  user?.extendedPetsData &&
+  typeof user?.extendedPetsData === 'object' &&
+  Array.isArray(user?.extendedPetsData)
+) {
   const petsObject = user?.extendedPetsData as Prisma.JsonArray
 
   const firstPet = petsObject[0]
@@ -852,7 +856,7 @@ console.log(checkJson.length)
 </tab>
 </TabbedContent>
 
-## Filtering by <inlinecode>null</inlinecode> Values
+## Using <inlinecode>null</inlinecode> Values
 
 There are two types of `null` values possible for a `JSON` field in an SQL database.
 
@@ -861,9 +865,9 @@ There are two types of `null` values possible for a `JSON` field in an SQL datab
 
 To differentiate between these possibilities, we've introduced three _null enums_ you can use to filter on:
 
-- `JsonNull`: Selects the `null` value in JSON.
-- `DbNull`: Selects the `NULL` value in the database.
-- `AnyNull`: Selects both `null` JSON values and `NULL` database values.
+- `JsonNull`: Represents the `null` value in JSON.
+- `DbNull`: Represents the `NULL` value in the database.
+- `AnyNull`: Represents both `null` JSON values and `NULL` database values. (Only when filtering)
 
 <Admonition type="info">
 
@@ -880,20 +884,9 @@ model Log {
 }
 ```
 
-```ts highlight=6;normal
-import { Prisma } from '@prisma/client'
+### Inserting <inlinecode>null</inlinecode> Values
 
-prisma.log.findMany({
-  where: {
-     meta: {
-       equals: Prisma.AnyNull,
-     },
-  },
-})
-```
-
-This also applies to `create`, `update` and `upsert`. To insert a `null` value
-into a `Json` field, you would write:
+To insert a `null` value into a `Json` field, you would write:
 
 ```ts highlight=5;normal
 import { Prisma } from '@prisma/client'
@@ -913,6 +906,20 @@ import { Prisma } from '@prisma/client'
 prisma.log.create({
   data: {
     meta: Prisma.DbNull,
+  },
+})
+```
+
+### Filtering by <inlinecode>null</inlinecode> Values
+
+```ts highlight=6;normal
+import { Prisma } from '@prisma/client'
+
+prisma.log.findMany({
+  where: {
+    meta: {
+      equals: Prisma.AnyNull,
+    },
   },
 })
 ```


### PR DESCRIPTION
Makes the [documentation about Prisma.DbNull and Prisma.JsonNull](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values) more discoverable and clearer about its contents.

Fixes #3800
