### PR TITLE
update binaryTargets: add darwin-arm64 for macOS ARM64

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
@@ -51,7 +51,7 @@ As an example, for a PostgreSQL database hosted on Heroku, the [connection URL](
 DATABASE_URL="postgresql://opnmyfngbknppm:XXX@ec2-46-137-91-216.eu-west-1.compute.amazonaws.com:5432/d50rgmkqi2ipus?schema=hello-prisma"
 ```
 
-When running PostgreSQL locally on Mac OS, your user and password as well as the database name _typically_ correspond to the current _user_ of your OS, e.g. assuming the user is called `janedoe`:
+When running PostgreSQL locally on macOS, your user and password as well as the database name _typically_ correspond to the current _user_ of your OS, e.g. assuming the user is called `janedoe`:
 
 ```bash file=.env
 DATABASE_URL="postgresql://janedoe:janedoe@localhost:5432/janedoe?schema=hello-prisma"

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
@@ -44,7 +44,7 @@ As an example, for a PostgreSQL database hosted on Heroku, the connection URL mi
 DATABASE_URL="postgresql://opnmyfngbknppm:XXX@ec2-46-137-91-216.eu-west-1.compute.amazonaws.com:5432/d50rgmkqi2ipus?schema=hello-prisma"
 ```
 
-When running PostgreSQL locally on Mac OS, your user and password as well as the database name _typically_ correspond to the current _user_ of your OS, e.g. assuming the user is called `janedoe`:
+When running PostgreSQL locally on macOS, your user and password as well as the database name _typically_ correspond to the current _user_ of your OS, e.g. assuming the user is called `janedoe`:
 
 ```bash file=.env
 DATABASE_URL="postgresql://janedoe:janedoe@localhost:5432/janedoe?schema=hello-prisma"

--- a/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
@@ -54,7 +54,7 @@ generator client {
 ```
 
 In that case, Prisma detects your operating system and finds the right binary file for it based on the [list of supported operating systems](/reference/api-reference/prisma-schema-reference#binarytargets-options) <span class="api"></span>.
-If you're running macOS Intel x86 (`darwin`), the binary file that was compiled for `darwin` will be selected.
+If you use macOS Intel x86 (`darwin`), then the binary file that was compiled for `darwin` will be selected.
 If you're running macOS ARM64 (`darwin-arm64`), the binary file that was compiled for `darwin-arm64` will be selected.
 
 > **Note**: The `native` binary target is the default. You can set it explicitly if you wish to [include additional binary targets for deployment to different environments](/guides/deployment/deployment-guides/deploying-to-aws-lambda#binary-targets-in-schemaprisma).

--- a/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
@@ -44,7 +44,7 @@ The correct file is particularly important when [deploying](/guides/deployment/d
 
 The `native` binary target is special. It doesn't map to a concrete operating system. Instead, when `native` is specified in `binaryTargets`, Prisma detects the _current_ operating system and automatically specifies the correct binary target for it.
 
-As an example, assume you're running **Mac OS** and you specify the following generator:
+As an example, assume you're running **macOS** and you specify the following generator:
 
 ```prisma
 generator client {
@@ -53,7 +53,9 @@ generator client {
 }
 ```
 
-In that case, Prisma detects your operating system and finds the right binary file for it based on the [list of supported operating systems](/reference/api-reference/prisma-schema-reference#binarytargets-options) <span class="api"></span>. As you're running Mac OS (`darwin`), the binary file that was compiled for `darwin` will be selected.
+In that case, Prisma detects your operating system and finds the right binary file for it based on the [list of supported operating systems](/reference/api-reference/prisma-schema-reference#binarytargets-options) <span class="api"></span>.
+If you're running macOS Intel x86 (`darwin`), the binary file that was compiled for `darwin` will be selected.
+If you're running macOS ARM64 (`darwin-arm64`), the binary file that was compiled for `darwin-arm64` will be selected.
 
 > **Note**: The `native` binary target is the default. You can set it explicitly if you wish to [include additional binary targets for deployment to different environments](/guides/deployment/deployment-guides/deploying-to-aws-lambda#binary-targets-in-schemaprisma).
 

--- a/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
@@ -55,7 +55,7 @@ generator client {
 
 In that case, Prisma detects your operating system and finds the right binary file for it based on the [list of supported operating systems](/reference/api-reference/prisma-schema-reference#binarytargets-options) <span class="api"></span>.
 If you use macOS Intel x86 (`darwin`), then the binary file that was compiled for `darwin` will be selected.
-If you're running macOS ARM64 (`darwin-arm64`), the binary file that was compiled for `darwin-arm64` will be selected.
+If you use macOS ARM64 (`darwin-arm64`), then the binary file that was compiled for `darwin-arm64` will be selected.
 
 > **Note**: The `native` binary target is the default. You can set it explicitly if you wish to [include additional binary targets for deployment to different environments](/guides/deployment/deployment-guides/deploying-to-aws-lambda#binary-targets-in-schemaprisma).
 

--- a/content/200-concepts/100-components/08-prisma-engines/200-query-engine.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/200-query-engine.mdx
@@ -20,7 +20,7 @@ This page covers relevant technical details about the query engine.
 
 ## The query engine file
 
-The **query engine file** is different for each operating system. It is named `query-engine-PLATFORM` or `libquery_engine-PLATFORM` where `PLATFORM` corresponds to the name of a compile target. Query engine file extensions depend on the platform as well. As an example, if the query engine must run on a [Darwin](<https://en.wikipedia.org/wiki/Darwin_(operating_system)>) operating system such as macOS, it is called `libquery_engine-darwin.dylib.node` or `query-engine-darwin`. You can find an overview of all supported platforms [here](/reference/api-reference/prisma-schema-reference#binarytargets-options).
+The **query engine file** is different for each operating system. It is named `query-engine-PLATFORM` or `libquery_engine-PLATFORM` where `PLATFORM` corresponds to the name of a compile target. Query engine file extensions depend on the platform as well. As an example, if the query engine must run on a [Darwin](<https://en.wikipedia.org/wiki/Darwin_(operating_system)>) operating system such as macOS Intel, it is called `libquery_engine-darwin.dylib.node` or `query-engine-darwin`. You can find an overview of all supported platforms [here](/reference/api-reference/prisma-schema-reference#binarytargets-options).
 
 The query engine file is downloaded into the `runtime` directory of the generated Prisma Client when `prisma generate` is called.
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -175,11 +175,12 @@ A `generator` block accepts the following fields:
 
 The following tables list all supported operating systems with the name of platform to specify in [`binaryTargets`](/concepts/components/prisma-schema/generators#binary-targets).
 
-##### Mac OS
+##### macOS
 
-| Build OS | Prisma engine build name |
-| :------- | :----------------------- |
-| Mac OS   | `darwin`                 |
+| Build OS        | Prisma engine build name |
+| :-------        | :----------------------- |
+| macOS Intel x86 | `darwin`                 |
+| macOS ARM64     | `darwin-arm64`           |
 
 ##### Windows
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -200,10 +200,10 @@ PRISMA_FMT_BINARY=custom/my-custom-format-engine-unix
 
 `PRISMA_CLI_BINARY_TARGETS` can be used to specify one or more binary targets that Prisma CLI will download during installation (so it must be provided during `npm install` of Prisma CLI and does not affect runtime of Prisma CLI or Prisma Client).
 
-Use `PRISMA_CLI_BINARY_TARGETS` if you 1) deploy to a specific platform via an upload of a local project that includes dependencies, and 2) your local environment is different from the target (e.g. AWS Lambda is `rhel-openssl-1.0.x`, and your local environment might be macOS `darwin`). Using the `PRISMA_CLI_BINARY_TARGETS` environment variable ensures that the target engine files are also downloaded.
+Use `PRISMA_CLI_BINARY_TARGETS` if you 1) deploy to a specific platform via an upload of a local project that includes dependencies, and 2) your local environment is different from the target (e.g. AWS Lambda is `rhel-openssl-1.0.x`, and your local environment might be macOS arm64 `darwin-arm64`). Using the `PRISMA_CLI_BINARY_TARGETS` environment variable ensures that the target engine files are also downloaded.
 
 ```terminal
-PRISMA_CLI_BINARY_TARGETS=darwin,rhel-openssl-1.0.x npm install
+PRISMA_CLI_BINARY_TARGETS=darwin-arm64,rhel-openssl-1.0.x npm install
 ```
 
 This is the Prisma CLI equivalent for the [`binaryTargets` property of the `generator` block](/concepts/components/prisma-schema/generators#binary-targets), which enables you to define the same setting for Prisma Client.


### PR DESCRIPTION
Found about this missing in the docs in the following reproduction https://github.com/prisma/prisma/issues/15981
