### PR TITLE
feat: add instructions for AWS lambdas with arm64 architectures

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -346,10 +346,9 @@ But, if you are using `serverless-webpack`, you cannot use that method.
 
 ### Lambdas with arm64 architectures
 
-Lambda functions that use [arm64 architectures (AWS Graviton2 processor)](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html#foundation-arch-adv) should use
-an `arm64` precompiled binary.
+Lambda functions that use [arm64 architectures (AWS Graviton2 processor)](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html#foundation-arch-adv) should use an `arm64` precompiled binary.
 
-Set the binary target in the Prisma schema:
+Set in the Prisma schema the following in the generator block:
 
 ```
 binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -348,7 +348,7 @@ But, if you are using `serverless-webpack`, you cannot use that method.
 
 Lambda functions that use [arm64 architectures (AWS Graviton2 processor)](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html#foundation-arch-adv) should use an `arm64` precompiled binary.
 
-Set in the Prisma schema the following in the generator block:
+In the `generator` block of your `schema.prisma` file, add the following:
 
 ```
 binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -354,7 +354,7 @@ In the `generator` block of your `schema.prisma` file, add the following:
 binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]
 ```
 
-Update the Serverless configuration file to ensure the `arm64` binary is packaged:
+Update the Serverless configuration file to package the `arm64` binary:
 
 ```
 package:

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -344,6 +344,28 @@ This ensures the packaged archive is as small as possible.
 
 But, if you are using `serverless-webpack`, you cannot use that method.
 
+### Lambdas with arm64 architectures
+
+Lambda functions that use [arm64 architectures (AWS Graviton2 processor)](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html#foundation-arch-adv) should use
+an `arm64` precompiled binary.
+
+Set the binary target in the Prisma schema:
+
+```
+binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]
+```
+
+Update the Serverless configuration file to ensure the `arm64` binary is packaged:
+
+```
+package:
+  patterns:
+    - '!node_modules/.prisma/client/libquery_engine-*'
+    - 'node_modules/.prisma/client/libquery_engine-linux-arm64-*'
+    - '!node_modules/prisma/libquery_engine-*'
+    - '!node_modules/@prisma/engines/**'
+```
+
 ### Deployment using `serverless-webpack`
 
 If you are using `serverless-webpack`, you can use the [serverless-webpack-prisma](https://github.com/danieluhm2004/serverless-webpack-prisma) plugin without any additional configuration. `serverless-webpack-prisma` does the following:

--- a/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/400-deploying-to-aws-lambda.mdx
@@ -346,7 +346,7 @@ But, if you are using `serverless-webpack`, you cannot use that method.
 
 ### Lambdas with arm64 architectures
 
-Lambda functions that use [arm64 architectures (AWS Graviton2 processor)](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html#foundation-arch-adv) should use an `arm64` precompiled binary.
+Lambda functions that use [arm64 architectures (AWS Graviton2 processor)](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html#foundation-arch-adv) must use an `arm64` precompiled binary.
 
 In the `generator` block of your `schema.prisma` file, add the following:
 


### PR DESCRIPTION
## Describe this PR

This PR updates the Prisma deployment docs with instructions for packaging and deploying Prisma binaries to AWS Lambda functions with `arm64` architectures (Gravtion2 Processor).

## Changes

Updated [Deploying to AWS Lambda](https://www.prisma.io/docs/guides/deployment/deployment-guides/deploying-to-aws-lambda) section of Prisma docs to add instructions for Lambdas with `arm64` architectures.

## What issue does this fix?

Fixes #3940 