### PR TITLE
CLI: add `validate` to CLI ref

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -458,7 +458,7 @@ From Prisma 3.0.0 onwards, the `prisma introspect` command is deprecated and rep
 
 ### <inlinecode>validate</inlinecode>
 
-Validates the Prisma schema file.
+Validates the [Prisma Schema Language](https://www.prisma.io/docs/concepts/components/prisma-schema) of the Prisma schema file.
 
 #### Arguments
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -63,7 +63,8 @@ Commands
               db   Manage your database schema and lifecycle
          migrate   Migrate your database
           studio   Browse your data with Prisma Studio
-          format   Format your schema
+        validate   Validate your Prisma schema
+          format   Format your Prisma schema
 
 Flags
 
@@ -455,6 +456,72 @@ From Prisma 3.0.0 onwards, the `prisma introspect` command is deprecated and rep
 
 </Admonition>
 
+### <inlinecode>validate</inlinecode>
+
+Validates the Prisma schema file.
+
+#### Arguments
+
+| Argument   | Required | Description                                                                                                                                         | Default                                     |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `--schema` | No       | Specifies the path to the desired `schema.prisma` file to be processed instead of the default path. Both absolute and relative paths are supported. | `./schema.prisma`, `./prisma/schema.prisma` |
+
+#### Examples
+
+##### Validate a schema without errors
+
+<CodeWithResult>
+<cmd>
+
+```terminal
+prisma validate
+```
+
+</cmd>
+<cmdResult>
+
+```code no-copy
+Environment variables loaded from prisma/.env
+Prisma schema loaded from prisma/schema.prisma
+The schema at /absolute/path/prisma/schema.prisma is valid 🚀
+```
+
+</cmdResult>
+</CodeWithResult>
+
+##### Validate a schema with validation errors
+
+<CodeWithResult>
+<cmd>
+
+```terminal
+prisma validate
+```
+
+</cmd>
+<cmdResult>
+
+```code no-copy
+Environment variables loaded from prisma/.env
+Prisma schema loaded from prisma/schema.prisma
+Error: Schema validation error - Error (query-engine-node-api library)
+Error code: P1012
+error: The preview feature "unknownFeatureFlag" is not known. Expected one of: [...]
+  -->  schema.prisma:3
+   | 
+ 2 |     provider        = "prisma-client-js"
+ 3 |     previewFeatures = ["unknownFeatureFlag"]
+   | 
+
+Validation Error Count: 1
+[Context: getDmmf]
+
+Prisma CLI Version : 4.5.0
+```
+
+</cmdResult>
+</CodeWithResult>
+
 ### <inlinecode>format</inlinecode>
 
 Formats the Prisma schema file, which includes validating, formatting, and persisting the schema.
@@ -503,15 +570,19 @@ prisma format
 ```code no-copy
 Environment variables loaded from prisma/.env
 Prisma schema loaded from prisma/schema.prisma
-Error: Schema parsing
-error: The preview feature "filterJson" is not known. Expected one of: filterJson
+Error: Schema validation error - Error (query-engine-node-api library)
+Error code: P1012
+error: The preview feature "unknownFeatureFlag" is not known. Expected one of: [...]
   -->  schema.prisma:3
-   |
- 2 |   provider        = "prisma-client-js"
- 3 |   previewFeatures = ["unknownFeature"]
-   |
+   | 
+ 2 |     provider        = "prisma-client-js"
+ 3 |     previewFeatures = ["unknownFeatureFlag"]
+   | 
 
 Validation Error Count: 1
+[Context: getDmmf]
+
+Prisma CLI Version : 4.5.0
 ```
 
 </cmdResult>


### PR DESCRIPTION
It's available since "a long time" (Since 2.0.0-beta.1, 2019! [see commit](https://github.com/prisma/prisma/commit/fac2b79f7d2be28b07404ddfe91454af45b1bf81)) but was never documented 

https://github.com/prisma/prisma/pull/16008 adds it to the help output
