### PR TITLE
Update 03-supported-databases.mdx

### DIFF
--- a/content/400-reference/300-database-reference/03-supported-databases.mdx
+++ b/content/400-reference/300-database-reference/03-supported-databases.mdx
@@ -10,7 +10,7 @@ Prisma currently supports the following databases:
 
 | Database                     | Version |
 | ---------------------------- | ------- |
-| PostgreSQL                   | 9.4+    |
+| PostgreSQL                   | 9.6     |
 | PostgreSQL                   | 10      |
 | PostgreSQL                   | 11      |
 | PostgreSQL                   | 12      |


### PR DESCRIPTION
Bump postgresql to 9.6 since 9.4 and 9.5 are not passing tests


See
https://github.com/prisma/prisma/issues/15320
https://github.com/prisma/prisma-engines/pull/3345

Note that 9.6 is not supported anymore by The PostgreSQL Global Development Group
https://www.postgresql.org/support/versioning/