### PR TITLE
Docs Typo: adds0 -> adds

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -2882,7 +2882,7 @@ Add `@@ignore` to a model that you want to exclude from the Prisma Client (for e
 
 #### Remarks
 
-- In [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later, Prisma adds `@@ignore` to an invalid model. (It also adds0 [`@ignore`](#ignore) to relations pointing to such a model)
+- In [2.17.0](https://github.com/prisma/prisma/releases/tag/2.17.0) and later, Prisma adds `@@ignore` to an invalid model. (It also adds [`@ignore`](#ignore) to relations pointing to such a model)
 
 #### Examples
 


### PR DESCRIPTION
## Describe this PR

Fixes small typo on https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference

## Changes

Change "adds0" to "adds" in docs
