### PR TITLE
#3962 quickstart page schema

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -78,6 +78,27 @@ This creates a new `prisma` directory with your Prisma schema file and configure
 The Prisma schema provides an intuitive way to model data. Add the following models to your `schema.prisma` file:
 
 ```prisma file=prisma/schema.prisma
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+  posts Post[]
+}
+
+model Post {
+  id        Int     @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean @default(false)
+  author    User    @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
 model User {
   id    Int     @id @default(autoincrement())
   email String  @unique

--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -99,21 +99,6 @@ model Post {
   author    User    @relation(fields: [authorId], references: [id])
   authorId  Int
 }
-model User {
-  id    Int     @id @default(autoincrement())
-  email String  @unique
-  name  String?
-  posts Post[]
-}
-
-model Post {
-  id        Int     @id @default(autoincrement())
-  title     String
-  content   String?
-  published Boolean @default(false)
-  author    User    @relation(fields: [authorId], references: [id])
-  authorId  Int
-}
 ```
 
 Models in the Prisma schema have two main purposes:


### PR DESCRIPTION
## Describe this PR

Fix sample `schema.prisma` at the quickstart doc page. Added `datasource`, because without it the migration step would give the error:
`Couldn't find a datasource in the schema.prisma file`

## Changes

- Refactored example `schema.prisma` to include the `datasource db`

## What issue does this fix?

Fixes #3962 

## Any other relevant information

Prisma version: `4.5.0`
Node version: `16.15.1`
