### PR TITLE
fix: spelling mistake documentation

### DIFF
--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -371,7 +371,7 @@ await prisma.team.deleteMany({
 })
 ```
 
-You an use the [`$transaction` API to perform a cascading delete](#are-cascading-deletes-supported-by-the-prisma-client-nested-writes).
+You can use the [`$transaction` API to perform a cascading delete](#are-cascading-deletes-supported-by-the-prisma-client-nested-writes).
 
 #### Can I use bulk operations with the `$transaction` API?
 


### PR DESCRIPTION
## Describe this PR
There was a spelling mistake in the docs (https://www.prisma.io/docs/guides/performance-and-optimization/prisma-client-transactions-guide).

## Changes
- Fixed a spelling mistake

## What issue does this fix?
Fixes #855 - Spelling / grammar check as part of build process - https://github.com/prisma/docs/issues/855

## Any other relevant information
I would like to be added as a contributor
@all-contributors please add @Aformation for doc
