### PR TITLE
update pascalcase link to go to pascalcase

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
@@ -26,5 +26,5 @@ See the [naming conventions](/reference/api-reference/prisma-schema-reference#na
 
 Use the following for table and column names:
 
-- Format table names in [PascalCase](https://en.wikipedia.org/wiki/Camel_case).
+- Format table names in [PascalCase](https://en.wikipedia.org/wiki/PascalCase).
 - Format column names in [camelCase](https://en.wikipedia.org/wiki/Camel_case).


### PR DESCRIPTION
Updated the Wikipedia link for pascal case to go to the pascal case page. This currently redirects to camel case anyway, however it seemed more appropriate to use the pascal case link instead.