### PR TITLE
Update 060-full-text-search.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -170,19 +170,7 @@ For the full range of supported operations, see the [MySQL full text search docu
 
 ### PostgreSQL
 
-To speed up your full-text queries, you should add an index to your database. Prisma schema and Prisma Migrate currently don't support defining and creating PostgreSQL search indices, but you can add one yourself. The following example adds a `GIN` index to the table `posts` on the field `body`:
-
-```sql
-CREATE EXTENSION pg_trgm;
-CREATE EXTENSION btree_gin;
-CREATE INDEX post_body_index 
-   ON posts USING GIN (to_tsvector('english', body));
-```
-To know more about adding indexes using SQL, check the [Unique constraints and indexes (PostgreSQL)](/guides/general-guides/database-workflows/unique-constraints-and-indexes/postgresql#1-create-a-new-database-and-project-directory) guide.
-
-For further information, see the [PostgreSQL documentation on indexes](https://www.postgresql.org/docs/12/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX).
-
-You can continue using Prisma Migrate as you were before, it will ignore indexes that it doesn't know about.
+The Prisma Client does not currently support using indexes to speed up full text search. There is an existing [GitHub Issue](https://github.com/prisma/prisma/issues/8950) for this.
 
 ### MySQL
 


### PR DESCRIPTION
resolves #4002.

The docs currently state that adding a full-text search index in Postgres will improve performance, but those indexes aren't actually used, so any effort creating them is wasted right now. Probably we should just remove that section from the docs.

Docs link: https://www.prisma.io/docs/concepts/components/prisma-client/full-text-search#postgresql-1
Github issue showing that indexes are not being used: https://github.com/prisma/prisma/issues/8950#issue-980473627
Slack conversation about this: https://prisma.slack.com/archives/CA491RJH0/p1666896107795639