### PR TITLE
edited deploying to cloudflare workers page for wrangler 2.x

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -71,7 +71,7 @@ npm install -D prisma typescript wrangler
 
 Wrangler is the official Cloudflare Worker CLI. You will use it to develop and deploy to Cloudflare Workers. This guide uses [Wrangler v2](https://developers.cloudflare.com/workers/wrangler/).
 
-First, initialize wrangler. To do this, run the following command in your terminal:
+First, initialize Wrangler. To do this, run the following command in your terminal:
 
 ```terminal
 npx wrangler init
@@ -83,7 +83,7 @@ This will ask you a few questions.
 Would you like to use git to manage this Worker? (y/n)
 ```
 
-We want to use git, so answer yes.
+We want to use Git, so answer yes.
 
 ```terminal
 Would you like to use TypeScript? (y/n)
@@ -95,7 +95,7 @@ We also want to use TypeScript, so answer yes.
 Would you like to create a Worker at src/index.ts?
 ```
 
-We want to use the `Fetch Handler`.
+Select the `Fetch Handler` option.
 
 Once you're done, this will create a `wrangler.toml` file with some initial configuration.
 

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -79,19 +79,19 @@ npx wrangler init
 
 This will ask you a few questions.
 
-```
+```terminal
 Would you like to use git to manage this Worker? (y/n)
 ```
 
 We want to use git, so answer yes.
 
-```
+```terminal
 Would you like to use TypeScript? (y/n)
 ```
 
 We also want to use TypeScript, so answer yes.
 
-```
+```terminal
 Would you like to create a Worker at src/index.ts?
 ```
 

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -31,7 +31,7 @@ We are continuously testing the Data Proxy with Cloudflare Workers. [Open an iss
 
 After you create a MongoDB Atlas database cluster, you can get its connection string. By default, that connection string does not include a database name.
 
-When you import your project in the Prisma Data Platform at [step 8](#8-import-your-project-into-the-prisma-data-platform), you must provide a connection string that includes a database name.
+When you import your project in the Prisma Data Platform at [step 6](#6-import-your-project-into-the-prisma-data-platform), you must provide a connection string that includes a database name.
 
 However, you do not need to manually create a database in MongoDB Atlas. The project creation workflow in the Prisma Data Platform will create a database with the name you define in the connection string.
 
@@ -52,7 +52,7 @@ However, you do not need to manually create a database in MongoDB Atlas. The pro
    + mongodb+srv://<user>:<password>@cluster.mongodb.net/Log?retryWrites=true&w=majority
    ```
 
-You now have a complete connection string. You will paste the connection string when you create your project in [8. Import your project into the Prisma Data Platform](#8-import-your-project-into-the-prisma-data-platform).
+You now have a complete connection string. You will paste the connection string when you create your project in [6. Import your project into the Prisma Data Platform](#6-import-your-project-into-the-prisma-data-platform).
 
 For security reasons, do not keep the connection string in the text editor or save it in a text file.
 

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -74,7 +74,7 @@ Wrangler is the official Cloudflare Worker CLI. You will use it to develop and d
 ```terminal
 npx wrangler init
  ⛅️ wrangler 2.1.15
---------------------
+ -------------------
 Using npm as package manager, as there is already a package-lock.json file.
 ✨ Created wrangler.toml
 Would you like to use git to manage this Worker? (y/n) y

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -71,24 +71,33 @@ npm install -D prisma typescript wrangler
 
 Wrangler is the official Cloudflare Worker CLI. You will use it to develop and deploy to Cloudflare Workers.
 
+First, initialize wrangler. To do this, run the following command in your terminal:
+
 ```terminal
 npx wrangler init
- ⛅️ wrangler 2.1.15
- -------------------
-Using npm as package manager, as there is already a package-lock.json file.
-✨ Created wrangler.toml
-Would you like to use git to manage this Worker? (y/n) y
-✨ Initialized git repository
-Would you like to use TypeScript? (y/n) y
-✨ Created tsconfig.json
-Would you like to create a Worker at src/index.ts?
-  None
-❯ Fetch handler
-  Scheduled handler
-✨ Created src/index.ts
 ```
 
-This will create a `wrangler.toml` file with some initial configuration.
+This will ask you a few questions.
+
+```
+Would you like to use git to manage this Worker? (y/n)
+```
+
+We want to use git, so answer yes.
+
+```
+Would you like to use TypeScript? (y/n)
+```
+
+We also want to use TypeScript, so answer yes.
+
+```
+Would you like to create a Worker at src/index.ts?
+```
+
+We want to use the `Fetch Handler`.
+
+Once you're done, this will create a `wrangler.toml` file with some initial configuration.
 
 Next, authenticate the Wrangler CLI with your Cloudflare Workers account. To do this, run the following command in your terminal:
 

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -36,13 +36,13 @@ When you import your project in the Prisma Data Platform at [step 8](#8-import-y
 However, you do not need to manually create a database in MongoDB Atlas. The project creation workflow in the Prisma Data Platform will create a database with the name you define in the connection string.
 
 1. [Create a free shared cluster](https://www.mongodb.com/docs/atlas/tutorial/create-new-cluster/) in MongoDB Atlas.
-2. On the _Security Quickstart_ screen, complete the initial security configuration.  
-   1. Add a new database user. 
+2. On the _Security Quickstart_ screen, complete the initial security configuration.
+   1. Add a new database user.
    2. Click **Add My Current IP Address** so that you can connect to the MongoDB shared cluster from your current system.
    3. Click **Finish and Close**.
 3. [Get the database cluster connection string](https://www.mongodb.com/docs/guides/atlas/connection-string/).
 4. Paste the connection string in a text editor and add the collection name `Log`.
-   
+
    The code sample below shows a connection string, that is originally provided by MongoDB Atlas, with the database name now added.
 
    ```diff
@@ -64,7 +64,7 @@ Open your terminal and navigate to a location of your choice. Run the following 
 mkdir prisma-mongodb-cloudflare
 cd prisma-mongodb-cloudflare
 npm init -y
-npm install -D prisma typescript @cloudflare/wrangler webpack
+npm install -D prisma typescript wrangler
 ```
 
 ## 3. Set up Wrangler
@@ -73,6 +73,19 @@ Wrangler is the official Cloudflare Worker CLI. You will use it to develop and d
 
 ```terminal
 npx wrangler init
+ ⛅️ wrangler 2.1.15
+--------------------
+Using npm as package manager, as there is already a package-lock.json file.
+✨ Created wrangler.toml
+Would you like to use git to manage this Worker? (y/n) y
+✨ Initialized git repository
+Would you like to use TypeScript? (y/n) y
+✨ Created tsconfig.json
+Would you like to create a Worker at src/index.ts?
+  None
+❯ Fetch handler
+  Scheduled handler
+✨ Created src/index.ts
 ```
 
 This will create a `wrangler.toml` file with some initial configuration.
@@ -90,91 +103,7 @@ You can now verify that you're logged in by running `npx wrangler whoami`.
 npx wrangler whoami
 ```
 
-## 4. Set up TypeScript
-
-The Cloudflare Worker environment natively supports Javascript, Rust, C, and C++. To get TypeScript working on Cloudflare Workers, you need to compile TypeScript to JavaScript before deploying to a Worker.
-
-To set this up, create a `tsconfig.json` in your project root with the following content:
-
-```json
-{
-  "compilerOptions": {
-    "outDir": "./dist",
-    "module": "commonjs",
-    "target": "esnext",
-    "lib": ["esnext"],
-    "alwaysStrict": true,
-    "strict": true,
-    "preserveConstEnums": true,
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "types": ["@cloudflare/workers-types"]
-  },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
-}
-```
-
-And then install `@cloudflare/workers-types` with npm:
-
-```terminal
-npm install -D @cloudflare/workers-types ts-loader@8.3.0
-```
-
-<Admonition type="info">
-
-You need to pin `ts-loader` to version `@8.3.0` for the Wrangler CLI to work properly.
-
-</Admonition>
-
-## 5. Set up Webpack
-
-Wrangler has built-in webpack support that can be used to compile your code in development and before deploying to Cloudflare.
-
-To configure webpack support, first create a `webpack.config.js` in the project root with the following code:
-
-```js
-const path = require('path')
-
-module.exports = {
-  entry: './src/index.ts',
-  output: {
-    filename: 'worker.js',
-    path: path.join(__dirname, 'dist'),
-  },
-  // Cloudflare Worker environment is similar to a webworker
-  target: 'webworker',
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js'],
-  },
-  mode: 'development',
-  // wrangler doesn't like eval which devtools use in development
-  devtool: 'none',
-  module: {
-    rules: [
-      {
-        // Compile Typescript code
-        test: /\.tsx?$/,
-        loader: 'ts-loader',
-        options: {
-          transpileOnly: true,
-        },
-      },
-    ],
-  },
-}
-```
-
-Next, add the following line to your `wrangler.toml` file to point Wrangler to use this webpack configuration:
-
-```diff
-name = "prisma-mongodb-cloudflare"
-type = "webpack"
-+webpack_config = "webpack.config.js"
-```
-
-## 6. Set up Prisma
+## 4. Set up Prisma
 
 Now you're ready to add Prisma to the project.
 
@@ -186,7 +115,7 @@ This creates a Prisma schema in `prisma/schema.prisma`.
 
 <Admonition>
 
-**Note:**<br /><br /> 
+**Note:**<br /><br />
 
 This process also creates an `.env` file, but this file has no effect when you use Cloudflare Workers.
 
@@ -220,7 +149,7 @@ enum Level {
 
 This data model will be used to store incoming requests from your Worker.
 
-## 7. Create a repository and push to GitHub
+## 5. Create a repository and push to GitHub
 
 To prepare for the steps ahead, let's [create a private repository](https://github.com/new) on GitHub.
 
@@ -229,7 +158,6 @@ To prepare for the steps ahead, let's [create a private repository](https://gith
 Next, initialize your repository, then push your changes up to GitHub.
 
 ```terminal
-git init -b main
 git remote add origin https://github.com/<username>/prisma-mongodb-cloudflare
 git add .
 git commit -m "initial commit"
@@ -238,15 +166,17 @@ git push -u origin main
 
 You're ready to import your project into the Prisma Data Platform.
 
-## 8. Import your Project into the Prisma Data Platform
+## 6. Import your Project into the Prisma Data Platform
 
 With Cloudflare Workers, you can't directly access your database because there is no TCP support. Fortunately, Prisma has your back with the [Data Proxy](/data-platform/data-proxy).
 
 1. To get started, sign up for a free [Prisma Data Platform account](https://cloud.prisma.io/).
+
    <Admonition type="info">
-   
+
    **Note**<br /><br />
    A GitHub account is required to sign up for the Prisma Data Platform.
+
    </Admonition>
 
    ![Signup for Prisma Data Platform](./450-02-signup-pdp.png)
@@ -257,6 +187,7 @@ With Cloudflare Workers, you can't directly access your database because there i
    ![Import a Project](./450-03-import-project.png)
 
 4. Next, you connect the Prisma Data Platform to the MongoDB Atlas database and set up the Data Proxy.
+
    1. Paste the MongoDB Atlas connection string which also includes the database name as described in [1. Get a MongoDB Atlas connection string](#1-get-a-mongodb-atlas-connection-string).
    2. Under **Location**, select a Data Proxy location that is geographically close to your MongoDB database location.
    3. Enable **Static IPs** and copy and paste them in the _Network Access_ screen in MongoDB Atlas.
@@ -268,16 +199,16 @@ With Cloudflare Workers, you can't directly access your database because there i
       <Admonition type="warning">
 
       If you see, "The database needs to be empty to proceed", you can simply use a different database name. Using the screenshot above, that would be renaming `Log` to something else.
+
       </Admonition>
-      
-      If all goes well, you'll be greeted with a new connection string that starts with `prisma://`. 
-      
+
+      If all goes well, you'll be greeted with a new connection string that starts with `prisma://`.
+
    5. Copy the `prisma://` connection string to your clipboard.
 
       ![Data Proxy Page](./450-05-data-proxy.png)
 
-
-## 9. Set the Data Proxy Connection string in your environment
+## 7. Set the Data Proxy Connection string in your environment
 
 1. Add the Data Proxy connection string to your local environment `.env` file.
 
@@ -285,20 +216,21 @@ With Cloudflare Workers, you can't directly access your database because there i
    - DATABASE_URL = "mongodb+srv://<user>:<password>@cluster.mongodb.net/Log?retryWrites=true&w=majority"
    + DATABASE_URL = "prisma://aws-us-east-1.prisma-data.com/?api_key=•••••••••••••••••"
    ```
+
 1. In your code editor, add the connection string in the `wrangler.toml` file.
 
-    ```diff file=wrangler.toml
-      name = "prisma-mongodb-cloudflare"
-      type = "webpack"
-      webpack_config = "webpack.config.js"
+   ```diff file=wrangler.toml
+     name = "prisma-mongodb-cloudflare"
+     type = "webpack"
+     webpack_config = "webpack.config.js"
 
-    + [vars]
-    + DATABASE_URL = "prisma://aws-us-east-1.prisma-data.com/?api_key=•••••••••••••••••"
-    ```
+   + [vars]
+   + DATABASE_URL = "prisma://aws-us-east-1.prisma-data.com/?api_key=•••••••••••••••••"
+   ```
 
 You are now ready to generate a Prisma Client.
 
-## 10. Generate a Prisma Client
+## 8. Generate a Prisma Client
 
 Next, you'll generate a Prisma Client that connects through the [Data Proxy](/data-platform/data-proxy) over HTTP.
 
@@ -327,15 +259,17 @@ async function handleEvent(event: FetchEvent): Promise<Response> {
 
   // waitUntil method is used for sending logs, after response is sent
   event.waitUntil(
-    prisma.log.create({
-      data: {
-        level: 'Info',
-        message: `${request.method} ${request.url}`,
-        meta: {
-          headers: JSON.stringify(request.headers),
+    prisma.log
+      .create({
+        data: {
+          level: 'Info',
+          message: `${request.method} ${request.url}`,
+          meta: {
+            headers: JSON.stringify(request.headers),
+          },
         },
-      },
-    }).then()
+      })
+      .then()
   )
 
   return new Response(`request method: ${request.method}!`)
@@ -360,7 +294,7 @@ Refresh the page a couple times to verify that it's working. Now if you click on
 
 It's working locally!
 
-## 12. Publish to Cloudflare Workers
+## 9. Publish to Cloudflare Workers
 
 You're now ready to deploy to Cloudflare Workers. Run the following command:
 

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -103,7 +103,6 @@ Next, authenticate the Wrangler CLI with your Cloudflare Workers account. To do 
 
 ```terminal
 npx wrangler login
-Allow Wrangler to open a page in your browser? [y/n] y
 ```
 
 You can now verify that you're logged in by running `npx wrangler whoami`.

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -69,7 +69,7 @@ npm install -D prisma typescript wrangler
 
 ## 3. Set up Wrangler
 
-Wrangler is the official Cloudflare Worker CLI. You will use it to develop and deploy to Cloudflare Workers.
+Wrangler is the official Cloudflare Worker CLI. You will use it to develop and deploy to Cloudflare Workers. This guide uses [Wrangler v2](https://developers.cloudflare.com/workers/wrangler/).
 
 First, initialize wrangler. To do this, run the following command in your terminal:
 
@@ -226,12 +226,12 @@ With Cloudflare Workers, you can't directly access your database because there i
    + DATABASE_URL = "prisma://aws-us-east-1.prisma-data.com/?api_key=•••••••••••••••••"
    ```
 
-1. In your code editor, add the connection string in the `wrangler.toml` file.
+2. In your code editor, add the connection string in the `wrangler.toml` file.
 
    ```diff file=wrangler.toml
      name = "prisma-mongodb-cloudflare"
-     type = "webpack"
-     webpack_config = "webpack.config.js"
+     main = "src/main.ts"
+     compatibility_date = "2022-11-07"
 
    + [vars]
    + DATABASE_URL = "prisma://aws-us-east-1.prisma-data.com/?api_key=•••••••••••••••••"

--- a/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/450-deploying-to-cloudflare-workers.mdx
@@ -242,7 +242,7 @@ The generated Client has a smaller bundle size and is optimized for edge environ
 
 The smaller bundle size is due to the fact that the interfaces talking to the database (the [Prisma engines](/concepts/components/prisma-engines)) are no longer bundled with the Client as this logic is now handled by the Data Proxy.
 
-## 11. Develop the Cloudflare Worker function
+## 9. Develop the Cloudflare Worker function
 
 You're now ready to create a Cloudflare Worker. Create a `src/index.ts` file with the following code:
 
@@ -294,7 +294,7 @@ Refresh the page a couple times to verify that it's working. Now if you click on
 
 It's working locally!
 
-## 9. Publish to Cloudflare Workers
+## 10. Publish to Cloudflare Workers
 
 You're now ready to deploy to Cloudflare Workers. Run the following command:
 


### PR DESCRIPTION
Updates the [cloudflare workers deploy page](https://www.prisma.io/docs/guides/deployment/deployment-guides/deploying-to-cloudflare-workers) to use wrangler 2.

Fixes #3188 