### PR TITLE
fix NOT client API links in filtering-and-sorting and null-and-undefined docs

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
@@ -85,7 +85,7 @@ Refer to the Prisma Client reference documentation for [a full list of operators
 
 #### Combining operators
 
-You can use operators (such as [`NOT`](/reference/api-reference/prisma-client-reference#not) <span class="api"></span> and [`OR`](/reference/api-reference/prisma-client-reference#or) <span class="api"></span>) to filter by a combination of conditions. The following query returns all users with an `email` that ends in `"prisma.io"` or `"gmail.com"`, but not `"hotmail.com"`:
+You can use operators (such as [`NOT`](/reference/api-reference/prisma-client-reference#not-1) <span class="api"></span> and [`OR`](/reference/api-reference/prisma-client-reference#or) <span class="api"></span>) to filter by a combination of conditions. The following query returns all users with an `email` that ends in `"prisma.io"` or `"gmail.com"`, but not `"hotmail.com"`:
 
 <CodeWithResult>
 <cmd>

--- a/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/080-null-and-undefined.mdx
@@ -176,7 +176,7 @@ const users = await prisma.user.findMany({
 
 The query receives filters from a formData object, which includes an optional email property. In this instance, the value of the email property is `undefined`. When this query is run no data is returned.
 
-This is in contrast to the [`AND`](/reference/api-reference/prisma-client-reference#and) <span class="api"></span> and [`NOT`](/reference/api-reference/prisma-client-reference#not) <span class="api"></span> operators, which will both return all the users
+This is in contrast to the [`AND`](/reference/api-reference/prisma-client-reference#and) <span class="api"></span> and [`NOT`](/reference/api-reference/prisma-client-reference#not-1) <span class="api"></span> operators, which will both return all the users
 if you pass in an `undefined` value.
 
 > This is because passing an `undefined` value to an `AND` or `NOT` operator is the same


### PR DESCRIPTION
## Describe this PR

The links to the `NOT` client API are incorrect on pages https://www.prisma.io/docs/concepts/components/prisma-client/filtering-and-sorting and https://www.prisma.io/docs/concepts/components/prisma-client/null-and-undefined. 
## Changes

Link have been updated to the correct `...#not-1`.

## What issue does this fix?

I assume these are part of the incorrect links mentioned in https://github.com/prisma/docs/issues/3813