### PR TITLE
Docs: excluding fields section, code typo

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/063-excluding-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/063-excluding-fields.mdx
@@ -24,7 +24,7 @@ The following is a type-safe `exclude` function returns a user without the `pass
 // Exclude keys from user
 function exclude<User, Key extends keyof User>(
   user: User,
-  ...keys: Key[]
+  keys: Key[]
 ): Omit<User, Key> {
   for (let key of keys) {
     delete user[key]
@@ -34,7 +34,7 @@ function exclude<User, Key extends keyof User>(
 
 function main() {
   const user = await prisma.user.findUnique({ where: 1 })
-  const userWithoutPassword = exclude(user, 'password')
+  const userWithoutPassword = exclude(user, ['password'])
 }
 ```
 
@@ -44,7 +44,7 @@ function main() {
 
 ```js
 // Exclude keys from user
-function exclude(user, ...keys) {
+function exclude(user, keys) {
   for (let key of keys) {
     delete user[key]
   }
@@ -53,7 +53,7 @@ function exclude(user, ...keys) {
 
 function main() {
   const user = await prisma.user.findUnique({ where: 1 })
-  const userWithoutPassword = exclude(user, 'password')
+  const userWithoutPassword = exclude(user, ['password'])
 }
 ```
 


### PR DESCRIPTION


## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->
The keys parameter should be an array but a string is passed and it's possible cause it's being used with the spread operator it shouldn't cause in this case you are only able to delete 1 key and the loop is redundant, correct me if I am wrong but in my project, it didn't work deleting multiple values
## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->
- Refactored parameters and function use example

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->
Unable to exclude multiple keys 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
