### PR TITLE
Style guide: removed broken Oxford Comma link

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -140,7 +140,7 @@ Prisma automatically converts JavaScript objects (for example, `{ extendedPetsDa
 
 Use the Oxford Comma except in titles. It is a comma used after the penultimate item in a list of three or more items, before "and" or "or". It makes things clearer. Example: "... an Italian painter, sculptor, and architect".
 
-[Confusion can happen when you don’t use the Oxford comma.](https://img.buzzfeed.com/buzzfeed-static/static/2015-02/22/18/enhanced/webdr11/enhanced-buzz-32156-1424646300-12.jpg?downsize=715:*&output-format=auto&output-quality=auto)
+In rare cases, the Oxford Comma can make a list less clear. In this situation, re-order the list where possible to make the meaning clear.
 
 ## Code snippets
 


### PR DESCRIPTION
Removed a broken link to an external comedy example of the Oxford Comma. For maintenance reasons, I don't think we need to link out to an external example, no matter how amusing it is. I've added a caveat about being too dogmatic about this guideline.