### PR TITLE
fix(errors): add missing prop for validation errors

### DIFF
--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -72,9 +72,10 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 - Missing field - for example, an empty `data: {}` property when creating a new record
 - Incorrect field type provided (for example, setting a `Boolean` field to `"Hello, I like cheese and gold!"`)
 
-| **Property** | **Description** |
-| :----------- | :-------------- |
-| `message`    | Error message.  |
+| **Property**    | **Description**                                  |
+| :-------------- | :----------------------------------------------- |
+| `message`       | Error message.                                   |
+| `clientVersion` | Version of Prisma Client (for example, `2.19.0`) |         |
 
 ## Error codes
 

--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -75,7 +75,7 @@ Prisma Client throws a `PrismaClientValidationError` exception if validation fai
 | **Property**    | **Description**                                  |
 | :-------------- | :----------------------------------------------- |
 | `message`       | Error message.                                   |
-| `clientVersion` | Version of Prisma Client (for example, `2.19.0`) |         |
+| `clientVersion` | Version of Prisma Client (for example, `2.19.0`) |
 
 ## Error codes
 


### PR DESCRIPTION
As a user [pointed out](https://github.com/prisma/prisma/issues/11385#issuecomment-1036507250), there is a missing property in the documentation of `PrismaClientValidationErrors`.