### PR TITLE
Style guide: add notes from SEO briefing to the Front matter page

### DIFF
--- a/content/600-about/200-prisma-docs/30-docs-components/03-frontmatter.mdx
+++ b/content/600-about/200-prisma-docs/30-docs-components/03-frontmatter.mdx
@@ -9,6 +9,8 @@ metaDescription: Supported front matter variables.
 
 The `<h1>` title of the page. This title appears at the top of the page, and in the left-hand navigation.
 
+You do not need to add this text as a `<h1>` because Gatsby generates this heading from the `title` tag.
+
 Note:
 
 - You can wrap the `title` text in single quotes, but this is not mandatory.
@@ -17,6 +19,10 @@ Note:
 ## <inlinecode>metaTitle</inlinecode>
 
 The `<title>` of the page - falls back to `title` (`h1`).
+
+This tag is important for Google SEO. If we wish, we can make the `metaTitle` more descriptive than the `title`.
+
+For good SEO, spell out abbreviations in this tag, unless they are industry standard. For example, spell out "Prisma Data Platform", but it is fine to use the abbreviation "ORM".
 
 Note:
 

--- a/content/600-about/200-prisma-docs/30-docs-components/03-frontmatter.mdx
+++ b/content/600-about/200-prisma-docs/30-docs-components/03-frontmatter.mdx
@@ -9,7 +9,7 @@ metaDescription: Supported front matter variables.
 
 The `<h1>` title of the page. This title appears at the top of the page, and in the left-hand navigation.
 
-You do not need to add this text as a `<h1>` because Gatsby generates this heading from the `title` tag.
+You do not need to add this text as an `<h1>` because Gatsby generates this heading from the `title` tag.
 
 Note:
 


### PR DESCRIPTION
Style guide: add notes from SEO briefing to the Front matter page