### PR TITLE
Update 02-graphql.md

### DIFF
--- a/content/200-concepts/050-overview/300-prisma-in-your-stack/02-graphql.md
+++ b/content/200-concepts/050-overview/300-prisma-in-your-stack/02-graphql.md
@@ -28,7 +28,7 @@ The GraphQL schema and HTTP server are typically handled by separate libraries. 
 | `graphql`             | GraphQL schema (code-first) | Yes                    | No                                                                       |
 | `graphql-tools`       | GraphQL schema (SDL-first)  | Yes                    | No                                                                       |
 | `type-graphql`        | GraphQL schema (code-first) | Yes                    | [`typegraphql-prisma`](https://www.npmjs.com/package/typegraphql-prisma) |
-| `nexus`               | GraphQL schema (code-first) | Yes                    | [`nexus-prisma`](https://nexus.prisma.io/) _Early Preview_               |
+| `nexus`               | GraphQL schema (code-first) | Yes                    | [`nexus-prisma`](https://graphql-nexus.github.io/nexus-prisma) _Early Preview_               |
 | `apollo-server`       | HTTP server                 | Yes                    | n/a                                                                      |
 | `express-graphql`     | HTTP server                 | Yes                    | n/a                                                                      |
 | `fastify-gql`         | HTTP server                 | Yes                    | n/a                                                                      |


### PR DESCRIPTION
Fix link to nexus-prisma as site linked is not loading.

## Describe this PR

Minor change to docs to fix the URL for nexus-prisma.

## Changes

Changed URL to:

https://graphql-nexus.github.io/nexus-prisma

## What issue does this fix?

Current URL does not load.