### PR TITLE
Update index.mdx

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -465,7 +465,7 @@ The `@relation` attribute is required when:
 
 ## Disambiguating relations
 
-When you define two relations between two the same models, you need to add the `name` argument in the `@relation` attribute to disambiguate them. As an example for why that's needed, consider the following models:
+When you define two relations between the same two models, you need to add the `name` argument in the `@relation` attribute to disambiguate them. As an example for why that's needed, consider the following models:
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>


### PR DESCRIPTION
Correct sentence in Disambiguating relations section, the sentence was written as "When you define two relations between two the same models", instead of "When you define two relations between the same two models"

## Describe this PR

Incorrect sentence in Disambiguating relations section, currently written as "When you define two relations between two the same models", while it should be "When you define two relations between two the same models"

## Changes

Correct sentence in Disambiguating relations section

- When you define two relations between two the same models
- ... --> When you define two relations between the same two models
