### PR TITLE
'Emulate referential integrity' -> 'Emulate relations'

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-relation-mode.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-relation-mode.mdx
@@ -125,7 +125,7 @@ If you switch between relation modes, Prisma will add or remove foreign keys to 
 
 The `foreignKeys` relation mode handles relations in your relational database using foreign keys. This is the default option when you use a relational database connector (PostgreSQL, MySQL, SQLite, SQL Server, CockroachDB).
 
-The `foreignKeys` relation mode is not available when you use the MongoDB connector. Some relational databases, [such as PlanetScale](/guides/database/using-prisma-with-planetscale#how-to-emulate-referential-integrity-in-prisma-client), also forbid the use of foreign keys. In these cases, you should instead [emulate relations in Prisma with the `prisma` relation mode](#emulate-relations-in-prisma-with-the-prisma-relation-mode).
+The `foreignKeys` relation mode is not available when you use the MongoDB connector. Some relational databases, [such as PlanetScale](/guides/database/using-prisma-with-planetscale#how-to-emulate-relations-in-prisma-client), also forbid the use of foreign keys. In these cases, you should instead [emulate relations in Prisma with the `prisma` relation mode](#emulate-relations-in-prisma-with-the-prisma-relation-mode).
 
 ### Referential integrity
 

--- a/content/300-guides/050-database/850-using-prisma-with-planetscale.mdx
+++ b/content/300-guides/050-database/850-using-prisma-with-planetscale.mdx
@@ -41,9 +41,9 @@ PlanetScale's branching model and design for scalability means that there are al
 - **Branching and deploy requests.** PlanetScale provides two types of database branches: _development branches_, which allow you to test out schema changes, and _production branches_, which are protected from direct schema changes. Instead, changes must be first created on a development branch and then deployed to production using a deploy request. Production branches are highly available and include automated daily backups. To learn more, see [How to use branches and deploy requests](#how-to-use-branches-and-deploy-requests).
 
 - **Referential actions and integrity.** To support scaling across multiple database servers, PlanetScale [does not allow the use of foreign key constraints](https://docs.planetscale.com/learn/operating-without-foreign-key-constraints), which are normally used in relational databases to enforce relationships between data in different tables, and asks users to handle this manually in their applications.  
-  With Prisma you can maintain these relationships in your data and allow the use of [referential actions](/concepts/components/prisma-schema/relations/referential-actions) by using Prisma's ability to [emulate referential integrity in Prisma Client](/concepts/components/prisma-schema/relations/relation-mode#handling-the-referential-integrity-in-prisma). For more information, see [How to emulate referential integrity in Prisma Client](#how-to-emulate-referential-integrity-in-prisma-client).
+  With Prisma you can maintain these relationships in your data and allow the use of [referential actions](/concepts/components/prisma-schema/relations/referential-actions) by using Prisma's ability to [emulate relations in Prisma Client](/concepts/components/prisma-schema/relations/relation-mode#emulate-relations-in-prisma-with-the-prisma-relation-mode) with the `prisma` relation mode. For more information, see [How to emulate relations in Prisma Client](#how-to-emulate-relations-in-prisma-client).
 
-- **Creating indexes on foreign keys.** When emulating referential integrity in Prisma, you will need to create indexes on foreign keys. In a standard MySQL database, if a table has a column with a foreign key constraint, an index is automatically created on that column. Because PlanetScale does not support foreign keys, these indexes are [currently](https://github.com/prisma/prisma/issues/10611) not created when emulating referential integrity, which can lead to issues with queries not being well optimised. To avoid this, you can create indexes in Prisma. For more information, see [How to create indexes on foreign keys](#how-to-create-indexes-on-foreign-keys).
+- **Creating indexes on foreign keys.** When emulating relations in Prisma, you will need to create indexes on foreign keys. In a standard MySQL database, if a table has a column with a foreign key constraint, an index is automatically created on that column. Because PlanetScale does not support foreign keys, these indexes are [currently](https://github.com/prisma/prisma/issues/10611) not created when Prisma Client emulates relations, which can lead to issues with queries not being well optimised. To avoid this, you can create indexes in Prisma. For more information, see [How to create indexes on foreign keys](#how-to-create-indexes-on-foreign-keys).
 
 - **Making schema changes with `db push`.** When you merge a development branch into your production branch, PlanetScale will automatically compare the two schemas and generate its own schema diff. This means that Prisma's [`prisma migrate`](/concepts/components/prisma-migrate) workflow, which generates its own history of migration files, is not a natural fit when working with PlanetScale. These migration files may not reflect the actual schema changes run by PlanetScale when the branch is merged.
 
@@ -55,7 +55,7 @@ PlanetScale's branching model and design for scalability means that there are al
 
   For an example of how this works, see [How to make schema changes with `db push`](#how-to-make-schema-changes-with-db-push)
 
-- **Introspection**. When you introspect on an existing database, you will get a schema with no relations, as they are usually defined based on foreign keys that connect tables. Because PlanetScale does not support foreign keys, and you use Prisma to emulate referential integrity, you will need to add the missing relations in manually. For more information, see [How to add in missing relations after Introspection](#how-to-add-in-missing-relations-after-introspection).
+- **Introspection**. When you introspect on an existing database, you will get a schema with no relations, as they are usually defined based on foreign keys that connect tables. Because PlanetScale does not support foreign keys, and you use Prisma to emulate relations, you will need to add the missing relations in manually. For more information, see [How to add in missing relations after Introspection](#how-to-add-in-missing-relations-after-introspection).
 
 ## How to use branches and deploy requests
 
@@ -65,11 +65,11 @@ Every PlanetScale database is created with a branch called `main`, which is init
 
 If you try to push to a production branch, you will get the [error message](/reference/api-reference/error-reference#p3022) `Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database.`
 
-## How to emulate referential integrity in Prisma Client
+## How to emulate relations in Prisma Client
 
-PlanetScale does not allow foreign keys in its database schema. By default, Prisma uses foreign keys in the underlying database to enforce relations between fields in your Prisma schema. In Prisma versions 3.1.1 and later, you can emulate referential integrity in the Prisma Client, which avoids the need for foreign keys in the database.
+PlanetScale does not allow foreign keys in its database schema. By default, Prisma uses foreign keys in the underlying database to enforce relations between fields in your Prisma schema. In Prisma versions 3.1.1 and later, you can [emulate relations in Prisma Client with the `prisma` relation mode](/concepts/components/prisma-schema/relations/relation-mode#emulate-relations-in-prisma-with-the-prisma-relation-mode), which avoids the need for foreign keys in the database.
 
-Referential integrity is currently a [preview feature](/concepts/components/preview-features). To enable this, add it to the `previewFeatures` list in the `generator` block of `schema.prisma`, and then set the `relationMode` field to `"prisma"` in the `datasource` block:
+The ability to set the relation mode is currently a [preview feature](/concepts/components/preview-features). To enable this, add it to the `previewFeatures` list in the `generator` block of `schema.prisma`, and then set the `relationMode` field to `"prisma"` in the `datasource` block:
 
 ```prisma file=schema.prisma
 datasource db {
@@ -95,7 +95,7 @@ If you use relations in your Prisma schema with the default `"foreignKeys"` opti
 
 ## How to create indexes on foreign keys
 
-When [emulating referential integrity in Prisma](#how-to-emulate-referential-integrity-in-prisma-client), you will need to create your own indexes. As an example of a situation where you would want to add an index, take this schema for a blog with posts and comments:
+When [you emulate relations in Prisma Client](#how-to-emulate-relations-in-prisma-client), you need to create your own indexes. As an example of a situation where you would want to add an index, take this schema for a blog with posts and comments:
 
 ```prisma file=schema.prisma
 model Post {
@@ -147,7 +147,7 @@ One issue to be aware of is that [implicit many-to-many relations](/concepts/com
 
 ## How to make schema changes with `db push`
 
-To use `db push` with PlanetScale, you will first need to [enable emulation of referential integrity in Prisma](#how-to-emulate-referential-integrity-in-prisma-client). Pushing to your branch without referential emulation enabled will give the [error message](/reference/api-reference/error-reference#p3021) `Foreign keys cannot be created on this database.`
+To use `db push` with PlanetScale, you will first need to [enable emulation of relations in Prisma Client](#how-to-emulate-relations-in-prisma-client). Pushing to your branch without referential emulation enabled will give the [error message](/reference/api-reference/error-reference#p3021) `Foreign keys cannot be created on this database.`
 
 As an example, let's say you decide to decide to add a new `excerpt` field to the blog post schema above. You will first need to [create a new development branch and connect to it](#how-to-use-branches-and-deploy-requests).
 


### PR DESCRIPTION
## Describe this PR

Update PlanetScale guide and links to refer to emulating relations rather than emulating referential integrity.

This will also fix the broken link issue #4098.

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #4098 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
