### PR TITLE
Fix broken anchor link - Mongoose migration guide

### DIFF
--- a/content/300-guides/400-migrate-to-prisma/03-migrate-from-mongoose.mdx
+++ b/content/300-guides/400-migrate-to-prisma/03-migrate-from-mongoose.mdx
@@ -528,7 +528,7 @@ npm install @prisma/client
 
 ## Step 4. Replace your Mongoose queries with Prisma Client
 
-In this section, we'll show a few sample queries that are being migrated from Mongoose to Prisma Client, based on the example routes from the sample REST API project. For a comprehensive overview of how the Prisma Client API differs from Mongoose, check out the [API comparison](/concepts/more/comparisons/prisma-and-mongoose#api-comparison) page.
+In this section, we'll show a few sample queries that are being migrated from Mongoose to Prisma Client, based on the example routes from the sample REST API project. For a comprehensive overview of how the Prisma Client API differs from Mongoose, check out the [API comparison](/concepts/more/comparisons/prisma-and-mongoose) page.
 
 First, to set up the `PrismaClient` instance that you'll use to send database queries from the various route handlers, create a new file named `prisma.js` in the `src` directory:
 

--- a/content/300-guides/400-migrate-to-prisma/03-migrate-from-mongoose.mdx
+++ b/content/300-guides/400-migrate-to-prisma/03-migrate-from-mongoose.mdx
@@ -528,7 +528,7 @@ npm install @prisma/client
 
 ## Step 4. Replace your Mongoose queries with Prisma Client
 
-In this section, we'll show a few sample queries that are being migrated from Mongoose to Prisma Client, based on the example routes from the sample REST API project. For a comprehensive overview of how the Prisma Client API differs from Mongoose, check out the [API comparison](/concepts/more/comparisons/prisma-and-mongoose) page.
+In this section, we'll show a few sample queries that are being migrated from Mongoose to Prisma Client, based on the example routes from the sample REST API project. For a comprehensive overview of how the Prisma Client API differs from Mongoose, check out the [Mongoose and Prisma API comparison](/concepts/more/comparisons/prisma-and-mongoose) page.
 
 First, to set up the `PrismaClient` instance that you'll use to send database queries from the various route handlers, create a new file named `prisma.js` in the `src` directory:
 


### PR DESCRIPTION
## Describe this PR

In this case just removing the anchor and linking to the page itself looks fine, as the whole page is about API operations. I think this got broken when this page was rearranged for the MongoDB GA.

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Fixes #4096 

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
