### PR TITLE
fix: broken navTitle metadata

### DIFF
--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -217,7 +217,6 @@ const TreeNode = ({
   }, [isCollapsed])
 
   React.useEffect(() => {
-    console.log(SpecialPaths)
     if (lastLevel && isCurrent && hasExpandButton && collapsed[label]) setCollapsed(label, true)
   }, [])
 

--- a/src/hooks/useAllArticlesQuery.ts
+++ b/src/hooks/useAllArticlesQuery.ts
@@ -10,6 +10,7 @@ export const useAllArticlesQuery = () => {
             frontmatter {
               title
               duration
+              navTitle
               staticLink
               experimental
               preview


### PR DESCRIPTION
## Describe this PR

The navTitle meta tag appears to have no effect.

## Changes

Added `navTitle` to frontmatter query on `useAllArticlesQuery()` fn.

## What issue does this fix?

Fixed #3984

## Any other relevant information

N/A