### PR TITLE
feat: add "Special cases for referential actions" subsection

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -168,7 +168,7 @@ Although referential actions are an ANSI SQL feature, some relational databases 
 ### Special cases for referential actions
 
 - † On MySQL (using the InnoDB storage engine), `SetDefault` is not supported, with differences depending on the database version. 
-  - On MySQL 8+, `SetDefault` is considered an alias for `NoAction`. One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.
+  - On MySQL 8+, `SetDefault` effectively acts as an alias for `NoAction`. One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.
   - On MySQL 5.6+, however, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error. 
   - MariaDB also lacks proper support for `SetDefault`.
   - For this reason, when setting `mysql` as the database provider, Prisma warns users to replace `SetDefault` referential actions appearing in the Prisma schema with another action, to avoid undesired surprises at runtime.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -163,7 +163,7 @@ The following table shows which referential action each database supports.
 
 Although referential actions are an ANSI SQL feature, some relational databases diverged from the standard, giving rise to a few special cases.
 
-<Admonition />
+</ Admonition>
 
 ### Special cases for referential actions
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -153,7 +153,7 @@ The following table shows which referential action each database supports.
 | Database    | Cascade | Restrict | NoAction | SetNull | SetDefault |
 | :---------- | :------ | :------- | :------- | :------ | :--------- |
 | PostgreSQL  | **✔️**  | **✔️**   | **✔️**   | **✔️**⌘ | **✔️**     |
-| MySQL       | **✔️**  | **✔️**   | **✔️**   | **✔️**  | ❌ (✔️†)    |
+| MySQL       | **✔️**  | **✔️**   | **✔️**   | **✔️**  | ❌ (✔️†)   |
 | SQLite      | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |
 | SQL Server  | **✔️**  | **❌**‡  | **✔️**   | **✔️**  | **✔️**     |
 | CockroachDB | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |
@@ -161,22 +161,17 @@ The following table shows which referential action each database supports.
 
 ### Special cases for referential actions
 
-<Admonition type="warning">
+Referential actions are part of the ANSI SQL standard. However, there are special cases where some relational databases diverge from the standard:
 
-Although referential actions are an ANSI SQL feature, some relational databases diverged from the standard, giving rise to a few special cases.
-
-</Admonition>
-
-- † On MySQL (using the InnoDB storage engine), `SetDefault` is not supported, with differences depending on the database version. 
-  - On MySQL 8+, `SetDefault` effectively acts as an alias for `NoAction`. One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.
-  - On MySQL 5.6+, however, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error. 
-  - MariaDB also lacks proper support for `SetDefault`. MariaDB 10.5+ behaves like like MySQL 8+, accepting `SET DEFAULT` declarations but failing at runtime when those actions are triggered. MariaDB 10.4 and previous versions, instead, act like MySQL 5.6+, rejecting `SET DEFAULT` declarations as syntax errors.
-  - For this reason, when setting `mysql` as the database provider, Prisma warns users to replace `SetDefault` referential actions appearing in the Prisma schema with another action, to avoid undesired surprises at runtime.
-- ⌘ Postgres is the only database supported by Prisma that allows defining a `SetNull` referential action referring to a non-nullable field. However, once that action is triggered at runtime, a foreign key constraint error is raised.
-  - For this reason, when setting `postgres` as the database provider in `foreignKeys` relation mode, Prisma warns users to mark fields included in a `@relation` attribute with a `SetNull` referential action as optional.
+- † MySQL (and the InnoDB storage engine) does not support `SetDefault`. The exact behavior depends on the database version:
+  - In MySQL versions 8 and later, and MariaDB versions 10.5 and later, `SetDefault` effectively acts as an alias for `NoAction`. You can define tables using the `SET DEFAULT` referential action, but a foreign key constraint error is triggered at runtime.
+  - In MySQL versions 5.6 and later, and MariaDB versions before 10.5, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error.
+  - For this reason, when you set `mysql` as the database provider, Prisma warns users to replace `SetDefault` referential actions in the Prisma schema with another action.
+- ⌘ PostgreSQL is the only database supported by Prisma that allows you to define a `SetNull` referential action referring to a non-nullable field. However, this raises a foreign key constraint error when the action is triggered at runtime.
+  - For this reason, when you set `postgres` as the database provider in the `foreignKeys` relation mode, Prisma warns users to mark as optional any fields that are included in a `@relation` attribute with a `SetNull` referential action.
   - For all other database providers, Prisma rejects the schema with an explanatory validation error.
 - ‡ [`NoAction`](#noaction) can be used in place of [`Restrict`](#restrict) when working with an SQL Server database.
-- †† Referential Actions for MongoDB are available from version 3.7.0 and later.
+- †† Referential actions for MongoDB are available from version 3.7.0 and later.
 
 ### <inlinecode>Cascade</inlinecode>
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -168,7 +168,7 @@ Referential actions are part of the ANSI SQL standard. However, there are specia
   - In MySQL versions 5.6 and later, and MariaDB versions before 10.5, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error.
   - For this reason, when you set `mysql` as the database provider, Prisma warns users to replace `SetDefault` referential actions in the Prisma schema with another action.
 - ⌘ PostgreSQL is the only database supported by Prisma that allows you to define a `SetNull` referential action referring to a non-nullable field. However, this raises a foreign key constraint error when the action is triggered at runtime.
-  - For this reason, when you set `postgres` as the database provider in the `foreignKeys` relation mode, Prisma warns users to mark as optional any fields that are included in a `@relation` attribute with a `SetNull` referential action.
+  - For this reason, when you set `postgres` as the database provider in the (default) `foreignKeys` relation mode, Prisma warns users to mark as optional any fields that are included in a `@relation` attribute with a `SetNull` referential action.
   - For all other database providers, Prisma rejects the schema with an explanatory validation error.
 - ‡ [`NoAction`](#noaction) can be used in place of [`Restrict`](#restrict) when working with an SQL Server database.
 - †† Referential actions for MongoDB are available from version 3.7.0 and later.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -163,7 +163,7 @@ The following table shows which referential action each database supports.
 
 Although referential actions are an ANSI SQL feature, some relational databases diverged from the standard, giving rise to a few special cases.
 
-</ Admonition>
+</Admonition>
 
 ### Special cases for referential actions
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -159,13 +159,13 @@ The following table shows which referential action each database supports.
 | CockroachDB | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |
 | MongoDB††   | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **❌**     |
 
+### Special cases for referential actions
+
 <Admonition type="warning">
 
 Although referential actions are an ANSI SQL feature, some relational databases diverged from the standard, giving rise to a few special cases.
 
 </Admonition>
-
-### Special cases for referential actions
 
 - † On MySQL (using the InnoDB storage engine), `SetDefault` is not supported, with differences depending on the database version. 
   - On MySQL 8+, `SetDefault` effectively acts as an alias for `NoAction`. One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -153,7 +153,7 @@ The following table shows which referential action each database supports.
 | Database    | Cascade | Restrict | NoAction | SetNull | SetDefault |
 | :---------- | :------ | :------- | :------- | :------ | :--------- |
 | PostgreSQL  | **✔️**  | **✔️**   | **✔️**   | **✔️**⌘ | **✔️**     |
-| MySQL       | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**†    |
+| MySQL       | **✔️**  | **✔️**   | **✔️**   | **✔️**  | ❌ (✔️†)    |
 | SQLite      | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |
 | SQL Server  | **✔️**  | **❌**‡  | **✔️**   | **✔️**  | **✔️**     |
 | CockroachDB | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -167,14 +167,14 @@ Although referential actions are an ANSI SQL feature, some relational databases 
 
 ### Special cases for referential actions
 
-- † On MySQL (using the InnoDB storage engine), `SetDefault` is not supported, with differences depending on the database version. On MySQL 8+, `SetDefault` is considered an alias for `NoAction`.
-  One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.
-  On MySQL 5.6+, however, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error.
-  MariaDB also lacks proper support for `SetDefault`.
-  For this reason, when setting `mysql` as the database provider, `prisma` warns users to replace `SetDefault` referential actions appearing in the Prisma schema with another action, to avoid undesired surprises at runtime.
+- † On MySQL (using the InnoDB storage engine), `SetDefault` is not supported, with differences depending on the database version. 
+  - On MySQL 8+, `SetDefault` is considered an alias for `NoAction`. One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.
+  - On MySQL 5.6+, however, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error. 
+  - MariaDB also lacks proper support for `SetDefault`.
+  - For this reason, when setting `mysql` as the database provider, Prisma warns users to replace `SetDefault` referential actions appearing in the Prisma schema with another action, to avoid undesired surprises at runtime.
 - ⌘ Postgres is the only database supported by Prisma that allows defining a `SetNull` referential action referring to a non-nullable field. However, once that action is triggered at runtime, a foreign key constraint error is raised.
-  For this reason, when setting `postgres` as the database provider in `foreignKeys` relation mode, `prisma` warns users to mark fields included in a `@relation` attribute with a `SetNull` referential action as optional.
-  For all other database providers, `prisma` would reject the schema with an explanatory validation error.
+  - For this reason, when setting `postgres` as the database provider in `foreignKeys` relation mode, Prisma warns users to mark fields included in a `@relation` attribute with a `SetNull` referential action as optional.
+  - For all other database providers, Prisma rejects the schema with an explanatory validation error.
 - ‡ [`NoAction`](#noaction) can be used in place of [`Restrict`](#restrict) when working with an SQL Server database.
 - †† Referential Actions for MongoDB are available from version 3.7.0 and later.
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -170,7 +170,7 @@ Although referential actions are an ANSI SQL feature, some relational databases 
 - † On MySQL (using the InnoDB storage engine), `SetDefault` is not supported, with differences depending on the database version. 
   - On MySQL 8+, `SetDefault` effectively acts as an alias for `NoAction`. One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.
   - On MySQL 5.6+, however, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error. 
-  - MariaDB also lacks proper support for `SetDefault`.
+  - MariaDB also lacks proper support for `SetDefault`. MariaDB 10.5+ behaves like like MySQL 8+, accepting `SET DEFAULT` declarations but failing at runtime when those actions are triggered. MariaDB 10.4 and previous versions, instead, act like MySQL 5.6+, rejecting `SET DEFAULT` declarations as syntax errors.
   - For this reason, when setting `mysql` as the database provider, Prisma warns users to replace `SetDefault` referential actions appearing in the Prisma schema with another action, to avoid undesired surprises at runtime.
 - ⌘ Postgres is the only database supported by Prisma that allows defining a `SetNull` referential action referring to a non-nullable field. However, once that action is triggered at runtime, a foreign key constraint error is raised.
   - For this reason, when setting `postgres` as the database provider in `foreignKeys` relation mode, Prisma warns users to mark fields included in a `@relation` attribute with a `SetNull` referential action as optional.

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/410-referential-actions/index.mdx
@@ -152,14 +152,29 @@ The following table shows which referential action each database supports.
 
 | Database    | Cascade | Restrict | NoAction | SetNull | SetDefault |
 | :---------- | :------ | :------- | :------- | :------ | :--------- |
-| PostgreSQL  | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |
+| PostgreSQL  | **✔️**  | **✔️**   | **✔️**   | **✔️**⌘ | **✔️**     |
 | MySQL       | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**†    |
 | SQLite      | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |
 | SQL Server  | **✔️**  | **❌**‡  | **✔️**   | **✔️**  | **✔️**     |
 | CockroachDB | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **✔️**     |
 | MongoDB††   | **✔️**  | **✔️**   | **✔️**   | **✔️**  | **❌**     |
 
-- † On MySQL, `SetDefault` is ignored and is silently replaced with `NoAction` instead.
+<Admonition type="warning">
+
+Although referential actions are an ANSI SQL feature, some relational databases diverged from the standard, giving rise to a few special cases.
+
+<Admonition />
+
+### Special cases for referential actions
+
+- † On MySQL (using the InnoDB storage engine), `SetDefault` is not supported, with differences depending on the database version. On MySQL 8+, `SetDefault` is considered an alias for `NoAction`.
+  One can define tables using the `SET DEFAULT` referential action, but once that action is triggered at runtime, a foreign key constraint error is raised.
+  On MySQL 5.6+, however, attempting to create one such table definition with the `SET DEFAULT` referential action fails with a syntax error.
+  MariaDB also lacks proper support for `SetDefault`.
+  For this reason, when setting `mysql` as the database provider, `prisma` warns users to replace `SetDefault` referential actions appearing in the Prisma schema with another action, to avoid undesired surprises at runtime.
+- ⌘ Postgres is the only database supported by Prisma that allows defining a `SetNull` referential action referring to a non-nullable field. However, once that action is triggered at runtime, a foreign key constraint error is raised.
+  For this reason, when setting `postgres` as the database provider in `foreignKeys` relation mode, `prisma` warns users to mark fields included in a `@relation` attribute with a `SetNull` referential action as optional.
+  For all other database providers, `prisma` would reject the schema with an explanatory validation error.
 - ‡ [`NoAction`](#noaction) can be used in place of [`Restrict`](#restrict) when working with an SQL Server database.
 - †† Referential Actions for MongoDB are available from version 3.7.0 and later.
 


### PR DESCRIPTION
## Describe this PR

- Add "Special cases for referential actions" subsection in the "Referential Actions" page
- Describe warnings for `mysql` when using `SetDefault`
- Describe warnings for `postgres` when using `SetNull` in `relationMode = "prisma"` 

## What issue does this fix?

Fixes https://github.com/prisma/docs/issues/3885

## Any other relevant information

https://pris.ly/d/mysql-set-default and https://pris.ly/d/postgres-set-null redirects to this new subsection.
