### PR TITLE
workaround when using pnpm/pnpx

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -107,7 +107,7 @@ Congratulations, you now have your database and tables ready. Let's go and learn
 
 ### Note on the usage with pnpm
 
-if you use pnpm/pnpx instead of npm/npx, you need to install @prisma/client before running prisma migrate.
+If you use pnpm/pnpx instead of npm/npx, you need to install @prisma/client before running prisma migrate.
 ```terminal
 pnpm i @prima/client
 ```

--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -105,6 +105,13 @@ Because the SQLite database file didn't exist before, the command also created i
 
 Congratulations, you now have your database and tables ready. Let's go and learn how you can send some queries to read and write data!
 
+### Note on the usage with pnpm
+
+if you use pnpm/pnpx instead of npm/npx, you need to install @prisma/client before running prisma migrate.
+```terminal
+pnpm i @prima/client
+```
+
 ## 4. Explore how to send queries to your database with Prisma Client
 
 To send queries to the database, you will need a TypeScript file to execute your Prisma Client queries. Create a new file called `script.ts` for this purpose:


### PR DESCRIPTION
## Describe this PR

When working with pnpm/pnpx there is a problem while prisma generate is run. 

```
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
npm ERR! Cannot read properties of null (reading 'matches')
```
workaround is to do a pnpm i  @prisma/client before running migrate (generate)


## Changes

Adds a little side note into the quickstart 

## What issue does this fix?
See PR description
## Any other relevant information

don't know if that is the right place to add this information - but it certainly would help others running into this problem