### PR TITLE
Fix typo

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/260-client-extensions/120-query.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/260-client-extensions/120-query.mdx
@@ -158,7 +158,7 @@ const xprisma = prisma.$extends({
   query: {
     user: {
       async findFirst({ args, query, operation }) {
-        const [result] = await prisma.$transaction(query(args))
+        const [result] = await prisma.$transaction([query(args)])
         return result
       },
     },


### PR DESCRIPTION
Typescript was complaining about the example due to missing array, so I added it.