### PR TITLE
Fix broken link

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
@@ -1134,7 +1134,7 @@ const users = await prisma.user.findMany({
 
 ### Filter on "-to-one" relations
 
-Prisma Client provides the [`is`](/reference/api-reference/prisma-client-reference#is) and [`isNot`](/reference/api-reference/prisma-client-reference#isNot) options to filter records by the properties of related records on the "-to-one" side of the relation. For example, filtering posts based on properties of their author.
+Prisma Client provides the [`is`](/reference/api-reference/prisma-client-reference#is) and [`isNot`](/reference/api-reference/prisma-client-reference#isnot) options to filter records by the properties of related records on the "-to-one" side of the relation. For example, filtering posts based on properties of their author.
 
 For example, the following query returns `Post` records that meet the following criteria:
 


### PR DESCRIPTION
Fix broken link to `isnot` heading in the Client API reference