### PR TITLE
Add explanation about the nested connect query in the example

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -181,9 +181,12 @@ const updateAuthor = await prisma.user.update({
 })
 ```
 
-In the underlying database, this query:
+In the underlying database, this query sets the `authorId` to `20` on the `Post` record where the `id` is `4`.
 
-1. Sets the `authorId` to `20` on the `Post` record where the `id` is `4`
+- The query uses a [nested `connect` query](/reference/api-reference/prisma-client-reference#connect) to link post `4` with user `20`.
+- The query first looks for user `20`.
+- The query then sets the `authorID` foreign key to to `20`. This links post `4` to user `20`.
+- In this query, the current value of `authorID` does not matter. The query changes it to `20`, no matter its current value.
 
 ## Types of relations
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -181,12 +181,13 @@ const updateAuthor = await prisma.user.update({
 })
 ```
 
-In the underlying database, this query sets the `authorId` to `20` on the `Post` record where the `id` is `4`.
+In the underlying database, this query uses a [nested `connect` query](/reference/api-reference/prisma-client-reference#connect) to link the `Post` record with an `authorId` of `4` with the `User` record with an `id` of `20`. The query does this with the following steps:
 
-- The query uses a [nested `connect` query](/reference/api-reference/prisma-client-reference#connect) to link post `4` with user `20`.
 - The query first looks for user `20`.
-- The query then sets the `authorID` foreign key to to `20`. This links post `4` to user `20`.
-- In this query, the current value of `authorID` does not matter. The query changes it to `20`, no matter its current value.
+- It then sets the `authorID` foreign key to to `20`. This sets the `authorID` to `20` on the `Post` record with an `id` of `4`.
+- Note that the current value in `authorID` does not matter. The query changes the value to `20`, no matter what the current value is.
+
+the `authorId` to `20` on the `Post` record where the `id` is `4`.
 
 ## Types of relations
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -181,13 +181,12 @@ const updateAuthor = await prisma.user.update({
 })
 ```
 
-In the underlying database, this query uses a [nested `connect` query](/reference/api-reference/prisma-client-reference#connect) to link the `Post` record with an `authorId` of `4` with the `User` record with an `id` of `20`. The query does this with the following steps:
+In the underlying database, this query uses a [nested `connect` query](/reference/api-reference/prisma-client-reference#connect) to link the post with an `id` of 4 to the user with an `id` of 20. The query does this with the following steps:
 
-- The query first looks for user `20`.
-- It then sets the `authorID` foreign key to to `20`. This sets the `authorID` to `20` on the `Post` record with an `id` of `4`.
-- Note that the current value in `authorID` does not matter. The query changes the value to `20`, no matter what the current value is.
+- The query first looks for the user with an `id` of `20`.
+- The query then sets the `authorID` foreign key to `20`. This links the post with an `id` of `4` to the user with an `id` of `20`.
 
-the `authorId` to `20` on the `Post` record where the `id` is `4`.
+In this query, the current value of `authorID` does not matter. The query changes it to `20`, no matter its current value.
 
 ## Types of relations
 


### PR DESCRIPTION
Added a contextual explanation to an example that uses `connect`, and a link to the relevant part of the API reference