### PR TITLE
Proposed wording change

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -186,7 +186,7 @@ In the underlying database, this query uses a [nested `connect` query](/referenc
 - The query first looks for the user with an `id` of `20`.
 - The query then sets the `authorID` foreign key to `20`. This links the post with an `id` of `4` to the user with an `id` of `20`.
 
-In this query, the current value of `authorID` does not matter. The query changes it to `20`, no matter its current value.
+In this query, the current value of `authorID` does not matter. The query changes `authorID` to `20`, no matter its current value.
 
 ## Types of relations
 


### PR DESCRIPTION
Proposed wording change (disambiguation)