### PR TITLE
Add warning note for `shadowDatabaseUrl`.

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -98,6 +98,8 @@ datasource db {
 }
 ```
 
+> **Important**: The values for `url` and `shadowDatabaseUrl` should not be the same.
+
 ## Shadow database user permissions
 
 In order to create and delete the shadow database when using development commands such as `migrate dev` and `migrate reset`, Prisma Migrate currently requires that the database user defined in your `datasource` has permission to **create databases**.


### PR DESCRIPTION
## Describe this PR

As a developer I made the mistake to put the same value for both `url` and `shadowDatabaseUrl`. This lead to situation where the Prisma's migration table disappeared several times resulting in an inconsistent app state.

## Changes

- Added a note.

## What issue does this fix?

Can be useful for other devs.

## Any other relevant information

Probably, we could expand and tell concisely what happens when we put the same value.
