### PR TITLE
fix: dotenv-expand only works for the .env file

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -200,7 +200,7 @@ You can use the `env()` function in the following places:
 - A datasource url
 - Generator binary targets
 
-In version 2.7.0 and later, you can expand any variables stored in the `.env` file. Use the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). This is useful when dealing with PaaS or similar products such as Heroku):
+In version 2.7.0 and later, you can expand any variables stored in the `.env` file. Use the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). (This is useful when dealing with PaaS or similar products such as Heroku):
 
 ```
 # .env

--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -195,18 +195,18 @@ datasource db {
 }
 ```
 
-In version 2.7.0 and later, you can expand variables using the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). This is useful when dealing with PaaS or similar products. such as Heroku):
+The `env()` function can be used in the following places:
+
+- A datasource url
+- Generator binary targets
+
+In version 2.7.0 and later, variables stored in the `.env` file can be expanded using the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). This is useful when dealing with PaaS or similar products. such as Heroku):
 
 ```
 # .env
 DATABASE_URL=postgresql://test:test@localhost:5432/test
 DATABASE_URL_WITH_SCHEMA=${DATABASE_URL}?schema=public
 ```
-
-The `env()` function can be used in the following places:
-
-- A datasource url
-- Generator binary targets
 
 See [Environment variables](/guides/development-environment/environment-variables) from more information.
 

--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -195,12 +195,12 @@ datasource db {
 }
 ```
 
-The `env()` function can be used in the following places:
+You can use the `env()` function in the following places:
 
 - A datasource url
 - Generator binary targets
 
-In version 2.7.0 and later, variables stored in the `.env` file can be expanded using the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). This is useful when dealing with PaaS or similar products. such as Heroku):
+In version 2.7.0 and later, you can expand any variables stored in the `.env` file. Use the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). This is useful when dealing with PaaS or similar products such as Heroku):
 
 ```
 # .env

--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -200,15 +200,7 @@ You can use the `env()` function in the following places:
 - A datasource url
 - Generator binary targets
 
-In version 2.7.0 and later, you can expand any variables stored in the `.env` file. Use the format specified by [dotenv-expand](https://github.com/motdotla/dotenv-expand). (This is useful when dealing with PaaS or similar products such as Heroku):
-
-```
-# .env
-DATABASE_URL=postgresql://test:test@localhost:5432/test
-DATABASE_URL_WITH_SCHEMA=${DATABASE_URL}?schema=public
-```
-
-See [Environment variables](/guides/development-environment/environment-variables) from more information.
+See [Environment variables](/guides/development-environment/environment-variables) for more information about how to use a `.env` file during development.
 
 ## Comments
 

--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -200,7 +200,7 @@ You can use the `env()` function in the following places:
 - A datasource url
 - Generator binary targets
 
-See [Environment variables](/guides/development-environment/environment-variables) for more information about how to use a `.env` file during development.
+See [Environment variables](/guides/development-environment/environment-variables) for more information about how to use an `.env` file during development.
 
 ## Comments
 


### PR DESCRIPTION
See tracking issue https://github.com/prisma/docs/issues/2835
