### PR TITLE
Simplify example

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -419,16 +419,12 @@ model CategoriesOnPosts {
   category   Category @relation(fields: [categoryId], references: [id])
   categoryId Int
   assignedAt DateTime @default(now())
-  assignedBy String
 
   @@id([postId, categoryId])
 }
 ```
 
-In this example, the `assignedAt` field stores additional information about the relation between `Post` and `Category`:
-
-- `assignedAt` stores _when_ the post was added to the category
-- `assignedBy` store _who_ added the post to the category
+In this example, the `assignedAt` field adds additional information about the relation between `Post` and `Category`: it specifies when the post was assigned to the category.
 
 Note that the same rules as for [1-n-relations](one-to-many-relations) apply (because `Post`↔ `CategoriesOnPosts` and `Category` ↔ `CategoriesOnPosts` are both in fact 1-n-relations), which means one side of the relation needs to be annotated with the `@relation` attribute.
 


### PR DESCRIPTION
## Describe this PR

Simplify relation table example in the many-to-many docs by removing the `assignedBy` field - the `assignedAt` field is already enough to show that you can add extra meta-information to a relation, and `assignedBy` is a bit odd without a relation to a `User` model, which doesn't exist in this example.

See PR #2358 and #2393 for previous discussion.

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
