### PR TITLE
Relations index page fixes

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -289,7 +289,7 @@ For MongoDB, Prisma uses a [normalized data model design](https://docs.mongodb.c
 
 Many-to-many relations in relational databases can be [explicit](/concepts/components/prisma-schema/relations/many-to-many-relations#explicit-many-to-many-relations), where the relation table is represented as an explicit model in your Prisma schema, or [implicit](/concepts/components/prisma-schema/relations/many-to-many-relations#implicit-many-to-many-relations), where Prisma manages the relation table and it does not appear in the Prisma schema.
 
-Implicit many-to-many relations require both models to have a single `@id`. Be aware that:
+Implicit many-to-many relations require both models to have a single `@id`. Be aware of the following:
 
 - You cannot use a [multi-field ID](/reference/api-reference/prisma-schema-reference#id-1)
 - You cannot use a `@unique` in place of an `@id`

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -267,25 +267,16 @@ model Category {
 
 <Admonition type="info">
 
-Implicit many-to-many relations require both models to have a single `@id`. Be aware that:
 This schema is the same as the [example data model](/concepts/components/prisma-schema/data-model) but has all [scalar fields](/concepts/components/prisma-schema/data-model#scalar-fields) removed (except for the required [relation scalars](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields)) so you can focus on the [relation fields](#relation-fields).
 
-- You cannot use a [multi-field ID](/reference/api-reference/prisma-schema-reference#id-1)
-- You cannot use a `@unique` in place of an `@id`
   </Admonition>
-
-To use either of these features, you must set up an explicit many-to-many instead.
 
 <Admonition type="info">
 
-The implicit m-n-relation still manifests in a relation table in the underlying database. However, this relation table is managed by Prisma.
 This example uses [implicit many-to-many relations](/concepts/components/prisma-schema/relations/many-to-many-relations#implicit-many-to-many-relations). These relations do not require the `@relation` attribute unless you need to [disambiguate relations](#disambiguating-relations).
-
-Using an implicit instead of an explicit m-n relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (since you e.g. have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
 
 </Admonition>
 
-If you're not using Prisma Migrate but obtain your data model from [introspection](/concepts/components/introspection), you can still make use of implicit many-to-many relations by following Prisma's [conventions for relation tables](many-to-many-relations#conventions-for-relation-tables-in-implicit-m-n-relations).
 Notice that the syntax is slightly different between relational databases and MongoDB - particularly for [many-to-many relations](many-to-many-relations).
 
 For relational databases, the following entity relationship diagram represents the database that corresponds to the sample Prisma schema:
@@ -294,9 +285,30 @@ For relational databases, the following entity relationship diagram represents t
 
 For MongoDB, Prisma uses a [normalized data model design](https://docs.mongodb.com/manual/core/data-model-design/), which means that documents reference each other by ID in a similar way to relational databases. See [the MongoDB section](#mongodb) for more details.
 
+### Implicit and explicit many-to-many relations
+
+Many-to-many relations in relational databases can be [explicit](/concepts/components/prisma-schema/relations/many-to-many-relations#explicit-many-to-many-relations), where the relation table is represented as an explicit model in your Prisma schema, or [implicit](/concepts/components/prisma-schema/relations/many-to-many-relations#implicit-many-to-many-relations), where Prisma manages the relation table and it does not appear in the Prisma schema.
+
+Implicit many-to-many relations require both models to have a single `@id`. Be aware that:
+
+- You cannot use a [multi-field ID](/reference/api-reference/prisma-schema-reference#id-1)
+- You cannot use a `@unique` in place of an `@id`
+
+To use either of these features, you must set up an explicit many-to-many instead.
+
+The implicit many-to-many relation still manifests in a relation table in the underlying database. However, this relation table is managed by Prisma.
+
+Using an implicit instead of an explicit many-to-many relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (since you e.g. have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
 Consider these two models:
+If you're not using Prisma Migrate but obtain your data model from [introspection](/concepts/components/introspection), you can still make use of implicit many-to-many relations by following Prisma's [conventions for relation tables](many-to-many-relations#conventions-for-relation-tables-in-implicit-m-n-relations).
+
+## Relation fields
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
+Relation [fields](/concepts/components/prisma-schema/data-model#defining-fields) are fields on a Prisma [model](/concepts/components/prisma-schema/data-model#defining-models) that do _not_ have a [scalar type](/concepts/components/prisma-schema/data-model#scalar-fields). Instead, their type is another model.
+
+Every relation must have exactly two relation fields, one on each model. In the case of one-to-one and one-to-many relations, an additional _relation scalar field_ is required which gets linked by one of the two relation fields in the `@relation` attribute. This relation scalar is the direct representation of the _foreign key_ in the underlying database.
+
 <tab>
 
 ```prisma
@@ -376,7 +388,7 @@ Also note that the annotated relation field `author` needs to link the relation 
 
 The other relation field called `posts` is defined purely on a Prisma-level, it doesn't manifest in the database.
 
-### Annotated relation fields and relation scalar fields
+### Annotated relation fields
 
 Relations that require one side of the relation to be _annotated_ with the `@relation` attribute are referred to as _annotated relation fields_. This includes:
 
@@ -406,6 +418,8 @@ authorId   String  @db.ObjectId
 </TabbedContent>
 
 A scalar field _becomes_ a relation scalar field when it's used in the `fields` of a `@relation` attribute.
+
+### Relation scalar fields
 
 <Admonition type="info">
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -301,7 +301,8 @@ To use either of these features, you must set up an explicit many-to-many instea
 
 The implicit many-to-many relation still manifests in a relation table in the underlying database. However, Prisma manages this relation table.
 
-Using an implicit instead of an explicit many-to-many relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (because, for example, you have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
+If you use an implicit many-to-many relation instead of an explicit one, it makes the [Prisma Client API](/concepts/components/prisma-client) simpler (because, for example, you have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
+
 If you're not using Prisma Migrate but obtain your data model from [introspection](/concepts/components/introspection), you can still make use of implicit many-to-many relations by following Prisma's [conventions for relation tables](many-to-many-relations#conventions-for-relation-tables-in-implicit-m-n-relations).
 
 ## Relation fields

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -302,7 +302,6 @@ To use either of these features, you must set up an explicit many-to-many instea
 The implicit many-to-many relation still manifests in a relation table in the underlying database. However, Prisma manages this relation table.
 
 Using an implicit instead of an explicit many-to-many relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (because, for example, you have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
-Consider these two models:
 If you're not using Prisma Migrate but obtain your data model from [introspection](/concepts/components/introspection), you can still make use of implicit many-to-many relations by following Prisma's [conventions for relation tables](many-to-many-relations#conventions-for-relation-tables-in-implicit-m-n-relations).
 
 ## Relation fields

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -296,7 +296,7 @@ Implicit many-to-many relations require both models to have a single `@id`. Be a
 
 To use either of these features, you must set up an explicit many-to-many instead.
 
-The implicit many-to-many relation still manifests in a relation table in the underlying database. However, this relation table is managed by Prisma.
+The implicit many-to-many relation still manifests in a relation table in the underlying database. However, Prisma manages this relation table.
 
 Using an implicit instead of an explicit many-to-many relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (because, for example, you have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
 Consider these two models:

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -298,7 +298,7 @@ To use either of these features, you must set up an explicit many-to-many instea
 
 The implicit many-to-many relation still manifests in a relation table in the underlying database. However, this relation table is managed by Prisma.
 
-Using an implicit instead of an explicit many-to-many relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (since you e.g. have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
+Using an implicit instead of an explicit many-to-many relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (because, for example, you have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
 Consider these two models:
 If you're not using Prisma Migrate but obtain your data model from [introspection](/concepts/components/introspection), you can still make use of implicit many-to-many relations by following Prisma's [conventions for relation tables](many-to-many-relations#conventions-for-relation-tables-in-implicit-m-n-relations).
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -287,7 +287,10 @@ For MongoDB, Prisma uses a [normalized data model design](https://docs.mongodb.c
 
 ### Implicit and explicit many-to-many relations
 
-Many-to-many relations in relational databases can be [explicit](/concepts/components/prisma-schema/relations/many-to-many-relations#explicit-many-to-many-relations), where the relation table is represented as an explicit model in your Prisma schema, or [implicit](/concepts/components/prisma-schema/relations/many-to-many-relations#implicit-many-to-many-relations), where Prisma manages the relation table and it does not appear in the Prisma schema.
+Many-to-many relations in relational databases can be modelled in two ways:
+
+- [explicit many-to-many relations](/concepts/components/prisma-schema/relations/many-to-many-relations#explicit-many-to-many-relations), where the relation table is represented as an explicit model in your Prisma schema
+- [implicit many-to-many relations](/concepts/components/prisma-schema/relations/many-to-many-relations#implicit-many-to-many-relations), where Prisma manages the relation table and it does not appear in the Prisma schema.
 
 Implicit many-to-many relations require both models to have a single `@id`. Be aware of the following:
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Relations'
 metaTitle: 'Relations (Reference)'
-metaDescription: 'A relation is a connection between two models in the Prisma schema. This page explains how you can define 1-1, 1-n and m-n relations in Prisma.'
+metaDescription: 'A relation is a connection between two models in the Prisma schema. This page explains how you can define one-to-one, one-to-many and many-to-many relations in Prisma.'
 tocDepth: 2
 ---
 
@@ -61,7 +61,7 @@ At a Prisma level, a connection between two models is **always** represented by 
 
 The following entity relationship diagram defines the same one-to-many relation between the `User` and `Post` tables in a **relational database**:
 
-![A 1-n relationship between a user and posts table.](./one-to-many.png)
+![A one-to-many relationship between a user and posts table.](./one-to-many.png)
 
 In SQL, you use a _foreign key_ to create a relation between two tables. Foreign keys are stored on **one side** of the relation. Our example is made up of:
 
@@ -103,7 +103,7 @@ The following list of `Post` documents (in the `Post` collection) each have a `u
 ]
 ```
 
-This data structure represents a 1-n relation because multiple `Post` documents refer to the same `User` document.
+This data structure represents a one-to-many relation because multiple `Post` documents refer to the same `User` document.
 
 #### `@db.ObjectId` on IDs and relation scalar fields
 
@@ -192,15 +192,11 @@ In this query, the current value of `authorID` does not matter. The query change
 
 There are three different types (or [cardinalities](<https://en.wikipedia.org/wiki/Cardinality_(data_modeling)>)) of relations in Prisma:
 
-- [One-to-one](one-to-one-relations) (also called 1-1-relation)
-- [One-to-many](one-to-many-relations) (also called 1-n-relation)
-- [Many-to-many](many-to-many-relations) (also called m-n-relation)
+- [One-to-one](one-to-one-relations) (also called 1-1 relations)
+- [One-to-many](one-to-many-relations) (also called 1-n relations)
+- [Many-to-many](many-to-many-relations) (also called m-n relations)
 
 The following Prisma schema includes every type of relation:
-
-- 1-1: `User` ↔ `Profile`
-- 1-n: `User` ↔ `Post`
-- m-n: `Post` ↔ `Category`
 
 Notice that the syntax is slightly different between relational databases and MongoDB - particularly for [many-to-many relations](many-to-many-relations).
 
@@ -217,6 +213,10 @@ Relation [fields](/concepts/components/prisma-schema/data-model#defining-fields)
 Every relation must have exactly two relation fields, one on each model. In case of 1-1 and 1-n relations, an additional _relation scalar field_ is required which gets linked by one of the two relation fields in the `@relation` attribute. This relation scalar is the direct representation of the _foreign key_ in the underlying database.
 
 Consider these two models:
+
+- one-to-one: `User` ↔ `Profile`
+- one-to-many: `User` ↔ `Post`
+- many-to-many: `Post` ↔ `Category`
 
 <TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>, <FileWithIcon text="MongoDB" icon="database"/>]}>
 <tab>
@@ -412,9 +412,9 @@ The other relation field called `posts` is defined purely on a Prisma-level, it 
 
 Relations that require one side of the relation to be _annotated_ with the `@relation` attribute are referred to as _annotated relation fields_. This includes:
 
-- 1-1
-- 1-n
-- m-n for MongoDB only
+- one-to-one relations
+- one-to-many relations
+- many-to-many relations for MongoDB only
 
 The side of the relation which is annotated with the `@relation` attribute represents the side that **stores the foreign key in the underlying database**. The "actual" field that represents the foreign key is required on that side of the relation as well, it's called _relation scalar field_, and is referenced inside `@relation` attribute:
 
@@ -458,13 +458,13 @@ The [`@relation`](/reference/api-reference/prisma-schema-reference#relation) <sp
 
 The `@relation` attribute is required when:
 
-- you define a 1-1 or 1-n relation, it is required on _one side_ of the relation (with the corresponding relation scalar field)
+- you define a one-to-one or one-to-many relation, it is required on _one side_ of the relation (with the corresponding relation scalar field)
 - you need to disambiguate a relation (that's e.g. the case when you have two relations between the same models)
 - you define a [self-relation](self-relations)
-- you define [an m-n for MongoDB](many-to-many-relations#mongodb)
+- you define [a many-to-many relation for MongoDB](many-to-many-relations#mongodb)
 - you need to control how the relation table is represented in the underlying database (e.g. use a specific name for a relation table)
 
-> **Note**: [Implicit m-n relations](many-to-many-relations#implicit-many-to-many-relations) in relational databases do not require the `@relation` attribute.
+> **Note**: [Implicit many-to-many relations](many-to-many-relations#implicit-many-to-many-relations) in relational databases do not require the `@relation` attribute.
 
 ## Disambiguating relations
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -286,35 +286,13 @@ Using an implicit instead of an explicit m-n relations makes the [Prisma Client 
 </Admonition>
 
 If you're not using Prisma Migrate but obtain your data model from [introspection](/concepts/components/introspection), you can still make use of implicit many-to-many relations by following Prisma's [conventions for relation tables](many-to-many-relations#conventions-for-relation-tables-in-implicit-m-n-relations).
+Notice that the syntax is slightly different between relational databases and MongoDB - particularly for [many-to-many relations](many-to-many-relations).
 
-For **relational databases**, the following entity relationship diagram represents the database that corresponds to the sample Prisma schema:
+For relational databases, the following entity relationship diagram represents the database that corresponds to the sample Prisma schema:
 
 ![The sample schema as an entity relationship diagram](sample-schema.png)
 
-For **MongoDB**, Prisma uses a [normalized data model design](https://docs.mongodb.com/manual/core/data-model-design/), which means that documents reference each other by ID in a similar way to relational databases:
-
-For example, the following MongoDB document represents a `User`:
-
-```json
-{ "_id": { "$oid": "60d5922d00581b8f0062e3a8" }, "name": "Ella" }
-```
-
-The following list of `Post` documents each have a `userId` field which reference the same user:
-
-```json
-[
-  {
-    "_id": { "$oid": "60d5922e00581b8f0062e3a9" },
-    "title": "How to make sushi",
-    "authorId": { "$oid": "60d5922d00581b8f0062e3a8" }
-  },
-  {
-    "_id": { "$oid": "60d5922e00581b8f0062e3aa" },
-    "title": "How to re-install Windows",
-    "authorId": { "$oid": "60d5922d00581b8f0062e3a8" }
-  }
-]
-```
+For MongoDB, Prisma uses a [normalized data model design](https://docs.mongodb.com/manual/core/data-model-design/), which means that documents reference each other by ID in a similar way to relational databases. See [the MongoDB section](#mongodb) for more details.
 
 Consider these two models:
 

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -198,22 +198,6 @@ There are three different types (or [cardinalities](<https://en.wikipedia.org/wi
 
 The following Prisma schema includes every type of relation:
 
-Notice that the syntax is slightly different between relational databases and MongoDB - particularly for [many-to-many relations](many-to-many-relations).
-
-> **Note**: This schema is the same as the [example data model](/concepts/components/prisma-schema/data-model) but has all [scalar fields](/concepts/components/prisma-schema/data-model#scalar-fields) removed (except for the required [relation scalars](#annotated-relation-fields-and-relation-scalar-fields)) so you can focus on the [relation fields](#relation-fields).
-
-The following entity relationship diagram represents the database that corresponds to the sample Prisma schema:
-
-![The sample schema as an entity relationship diagram](sample-schema.png)
-
-## Relation fields
-
-Relation [fields](/concepts/components/prisma-schema/data-model#defining-fields) are fields on a Prisma [model](/concepts/components/prisma-schema/data-model#defining-models) that do _not_ have a [scalar type](/concepts/components/prisma-schema/data-model#scalar-fields). Instead, their type is another model.
-
-Every relation must have exactly two relation fields, one on each model. In case of 1-1 and 1-n relations, an additional _relation scalar field_ is required which gets linked by one of the two relation fields in the `@relation` attribute. This relation scalar is the direct representation of the _foreign key_ in the underlying database.
-
-Consider these two models:
-
 - one-to-one: `User` ↔ `Profile`
 - one-to-many: `User` ↔ `Post`
 - many-to-many: `Post` ↔ `Category`

--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -281,19 +281,25 @@ model Category {
 </tab>
 </TabbedContent>
 
-> **Note**: This schema is the same as the [example data model](/concepts/components/prisma-schema/data-model) but has all [scalar fields](/concepts/components/prisma-schema/data-model#scalar-fields) removed (except for the required [relation scalars](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields)) so you can focus on the [relation fields](#relation-fields).
-> **Note**: Implicit many-to-many relations do **not** require the `@relation` attribute unless you need to [disambiguate relations](#disambiguating-relations).
+<Admonition type="info">
 
 Implicit many-to-many relations require both models to have a single `@id`. Be aware that:
+This schema is the same as the [example data model](/concepts/components/prisma-schema/data-model) but has all [scalar fields](/concepts/components/prisma-schema/data-model#scalar-fields) removed (except for the required [relation scalars](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields)) so you can focus on the [relation fields](#relation-fields).
 
 - You cannot use a [multi-field ID](/reference/api-reference/prisma-schema-reference#id-1)
 - You cannot use a `@unique` in place of an `@id`
+  </Admonition>
 
 To use either of these features, you must set up an explicit many-to-many instead.
 
+<Admonition type="info">
+
 The implicit m-n-relation still manifests in a relation table in the underlying database. However, this relation table is managed by Prisma.
+This example uses [implicit many-to-many relations](/concepts/components/prisma-schema/relations/many-to-many-relations#implicit-many-to-many-relations). These relations do not require the `@relation` attribute unless you need to [disambiguate relations](#disambiguating-relations).
 
 Using an implicit instead of an explicit m-n relations makes the [Prisma Client API](/concepts/components/prisma-client) for many-to-many relations a bit simpler (since you e.g. have one fewer level of nesting inside of [nested writes](/concepts/components/prisma-client/relation-queries#nested-writes)).
+
+</Admonition>
 
 If you're not using Prisma Migrate but obtain your data model from [introspection](/concepts/components/introspection), you can still make use of implicit many-to-many relations by following Prisma's [conventions for relation tables](many-to-many-relations#conventions-for-relation-tables-in-implicit-m-n-relations).
 


### PR DESCRIPTION
## Describe this PR

- Fix duplicate/mangled content in the [Relations index page](https://www.prisma.io/docs/concepts/components/prisma-schema/relations).
- Style guide terminology fixes: 1-1 to 'one-to-one', etc

## Changes

Fixes #4192 

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
