### PR TITLE
Created info for percent encoding

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
@@ -42,6 +42,7 @@ Here's a short explanation of each component:
 - `PORT`: The port where your database server is running (typically `5432` for PostgreSQL)
 - `DATABASE`: The name of the [database](https://www.postgresql.org/docs/12/manage-ag-overview.html)
 - `SCHEMA`: The name of the [schema](https://www.postgresql.org/docs/12/ddl-schemas.html) inside the database
+> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 If you're unsure what to provide for the `schema` parameter for a PostgreSQL connection URL, you can probably omit it. In that case, the default schema name `public` will be used.
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database.mdx
@@ -39,6 +39,7 @@ Here's a short explanation of each component:
 - `HOST`: The host where a [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/#mongodb-binary-bin.mongod) (or [`mongos`](https://docs.mongodb.com/manual/reference/program/mongos/#mongodb-binary-bin.mongos)) instance is running
 - `PORT`: The port where your database server is running (typically `27017` for MongoDB)
 - `DATABASE`: The name of the database
+> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 As an example, for a MongoDB database hosted on [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), the [connection URL](/reference/database-reference/connection-urls) might look similar to this:
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
@@ -90,6 +90,7 @@ Here's a short explanation of each component:
 - `PASSWORD`: The password for your database user
 - `PORT`: The port where your database server is running (typically `3306` for MySQL)
 - `DATABASE`: The name of the [database](https://dev.mysql.com/doc/refman/8.0/en/creating-database.html)
+> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 As an example, for a MySQL database hosted on AWS RDS, the [connection URL](/reference/database-reference/connection-urls) might look similar to this:
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database.mdx
@@ -39,6 +39,7 @@ Here's a short explanation of each component:
 - `HOST`: The host where a [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/#mongodb-binary-bin.mongod) (or [`mongos`](https://docs.mongodb.com/manual/reference/program/mongos/#mongodb-binary-bin.mongos)) instance is running
 - `PORT`: The port where your database server is running (typically `27017` for MongoDB)
 - `DATABASE`: The name of the database
+> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 As an example, for a MongoDB database hosted on [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), the [connection URL](/reference/database-reference/connection-urls) might look similar to this:
 


### PR DESCRIPTION
## Describe this PR

It's not mentioned in the docs how, when, why someone would need to percent encode characters in their database uri

## Changes

I added a small indent to describe why and when someone would need to percent encode characters in their connection url and provided a link to explain how.

## What issue does this fix?

I ran into this issue myself and noticed other people were having this problem and posting it on the repos discussions and creating issues. Assuming they read the docs properly people wont need to encounter the issue.

## Any other relevant information

undefined
