### PR TITLE
docs: fix wording for proper written notation

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/03-generators.mdx
@@ -15,13 +15,13 @@ generator client {
 }
 ```
 
-A generator determines which assets are created when you run the `prisma generate` command. The main property `provider` defines which **Prisma Client (language specific)** is created - currently, only `prisma-client-js` is available. Alternatively you can define any Npm package that follows our generator specification. Additionally and optionally you can define a custom output folder for the generated assets with `output`.
+A generator determines which assets are created when you run the `prisma generate` command. The main property `provider` defines which **Prisma Client (language specific)** is created - currently, only `prisma-client-js` is available. Alternatively you can define any npm package that follows our generator specification. Additionally and optionally you can define a custom output folder for the generated assets with `output`.
 
 </TopBlock>
 
 ## Prisma Client: `prisma-client-js`
 
-The generator for Prisma's Javascript Client accepts multiple additional properties:
+The generator for Prisma's JavaScript Client accepts multiple additional properties:
 
 - `previewFeatures`: [Preview features](/concepts/components/preview-features) to include
 - `binaryTargets`: Engine binary targets for `prisma-client-js` (for example, `debian-openssl-1.1.x` if you are deploying to Ubuntu 18+, or `native` if you are working locally)


### PR DESCRIPTION
## Describe this PR

Fixed the following non-compliant written form of terms in docs:
- `Npm` is incorrect
- `Javascript` is incorrect

## Changes

Wording changes.
