### PR TITLE
Harmonize get started page title with topnav (remove the gerund)

### DIFF
--- a/content/100-getting-started/index.mdx
+++ b/content/100-getting-started/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Getting started'
-metaTitle: 'Getting started'
-metaDescription: 'Getting started'
+title: 'Get started'
+metaTitle: 'Get started'
+metaDescription: 'Get started'
 ---
 
 <TopBlock>


### PR DESCRIPTION
Change "getting started" to "get started" so that when visitors click "get started" in the topnav, the page title agrees with what they clicked