### PR TITLE
Fix dotenv example in migration script

### DIFF
--- a/content/300-guides/125-development-environment/050-environment-variables/200-using-multiple-env-files.mdx
+++ b/content/300-guides/125-development-environment/050-environment-variables/200-using-multiple-env-files.mdx
@@ -60,7 +60,7 @@ The below script uses `dotenv-cli` to pass the `.env.test` environment file (whi
 
 ```json file=package.json
   "scripts": {
-    "migrate:postgres": "dotenv -e .env.test -- npx prisma migrate dev --name postgres-init",
+    "migrate:postgres": "dotenv -e .env.test npx prisma migrate dev --name postgres-init",
   },
 ```
 


### PR DESCRIPTION
## Describe this PR
Fixed documentation example for using dotenv in your NPM scripts.

## Changes

Removed the double hyphen(`--`) as that's no longer the way to do it in `dotenv`.