### PR TITLE
Remove explicit password encoding warning and add link to URL format …

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
@@ -28,7 +28,7 @@ DATABASE_URL="postgresql://johndoe:randompassword@localhost:5432/mydb?schema=pub
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database depends on the database you use. For PostgreSQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database depends on the database you use. For PostgreSQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=SCHEMA
@@ -42,7 +42,6 @@ Here's a short explanation of each component:
 - `PORT`: The port where your database server is running (typically `5432` for PostgreSQL)
 - `DATABASE`: The name of the [database](https://www.postgresql.org/docs/12/manage-ag-overview.html)
 - `SCHEMA`: The name of the [schema](https://www.postgresql.org/docs/12/ddl-schemas.html) inside the database
-> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 If you're unsure what to provide for the `schema` parameter for a PostgreSQL connection URL, you can probably omit it. In that case, the default schema name `public` will be used.
 
@@ -86,7 +85,7 @@ DATABASE_URL="mysql://johndoe:randompassword@localhost:3306/mydb"
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database typically depends on the database you use. For MySQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database typically depends on the database you use. For MySQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 mysql://USER:PASSWORD@HOST:PORT/DATABASE
@@ -149,7 +148,7 @@ DATABASE_URL="mysql://janedoe:mypassword@server.us-east-2.psdb.cloud/mydb?sslacc
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database typically depends on the database you use. PlanetScale uses the MySQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database typically depends on the database you use. PlanetScale uses the MySQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 mysql://USER:PASSWORD@HOST:PORT/DATABASE
@@ -233,7 +232,7 @@ datasource db {
 
 The `url` is [set via an environment variable](/guides/development-environment/environment-variables) which is defined in `.env`. You now need to adjust the connection URL to point to your own database.
 
-The format of the [connection URL](/reference/database-reference/connection-urls) for your database depends on the database you use. CockroachDB uses the PostgreSQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database depends on the database you use. CockroachDB uses the PostgreSQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE?PARAMETERS

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database.mdx
@@ -39,7 +39,6 @@ Here's a short explanation of each component:
 - `HOST`: The host where a [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/#mongodb-binary-bin.mongod) (or [`mongos`](https://docs.mongodb.com/manual/reference/program/mongos/#mongodb-binary-bin.mongos)) instance is running
 - `PORT`: The port where your database server is running (typically `27017` for MongoDB)
 - `DATABASE`: The name of the database
-  > Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 <SwitchTech technologies={['node', 'mongodb']}>
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database.mdx
@@ -26,7 +26,7 @@ DATABASE_URL="mongodb+srv://test:test@cluster0.ns1yp.mongodb.net/myFirstDatabase
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database depends on the database you use. For MongoDB, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](https://www.prisma.io/docs/reference/database-reference/connection-urls) for your database depends on the database you use. For MongoDB, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 mongodb://USERNAME:PASSWORD@HOST:PORT/DATABASE
@@ -39,7 +39,7 @@ Here's a short explanation of each component:
 - `HOST`: The host where a [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/#mongodb-binary-bin.mongod) (or [`mongos`](https://docs.mongodb.com/manual/reference/program/mongos/#mongodb-binary-bin.mongos)) instance is running
 - `PORT`: The port where your database server is running (typically `27017` for MongoDB)
 - `DATABASE`: The name of the database
-> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
+  > Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 <SwitchTech technologies={['node', 'mongodb']}>
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
@@ -28,7 +28,7 @@ DATABASE_URL="postgresql://johndoe:randompassword@localhost:5432/mydb?schema=pub
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database depends on the database you use. For PostgreSQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database depends on the database you use. For PostgreSQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=SCHEMA
@@ -78,7 +78,7 @@ DATABASE_URL="mysql://johndoe:randompassword@localhost:3306/mydb"
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database typically depends on the database you use. For MySQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database typically depends on the database you use. For MySQL, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 mysql://USER:PASSWORD@HOST:PORT/DATABASE
@@ -90,7 +90,6 @@ Here's a short explanation of each component:
 - `PASSWORD`: The password for your database user
 - `PORT`: The port where your database server is running (typically `3306` for MySQL)
 - `DATABASE`: The name of the [database](https://dev.mysql.com/doc/refman/8.0/en/creating-database.html)
-> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 As an example, for a MySQL database hosted on AWS RDS, the [connection URL](/reference/database-reference/connection-urls) might look similar to this:
 
@@ -142,7 +141,7 @@ DATABASE_URL="mysql://janedoe:mypassword@server.us-east-2.psdb.cloud/mydb?sslacc
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database typically depends on the database you use. PlanetScale uses the MySQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database typically depends on the database you use. PlanetScale uses the MySQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 mysql://USER:PASSWORD@HOST:PORT/DATABASE
@@ -224,7 +223,7 @@ datasource db {
 
 The `url` is [set via an environment variable](/guides/development-environment/environment-variables) which is defined in `.env`. You now need to adjust the connection URL to point to your own database.
 
-The format of the [connection URL](/reference/database-reference/connection-urls) for your database depends on the database you use. CockroachDB uses the PostgreSQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database depends on the database you use. CockroachDB uses the PostgreSQL connection URL format, which has the following structure (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE?PARAMETERS

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database.mdx
@@ -26,7 +26,7 @@ DATABASE_URL="mongodb+srv://test:test@cluster0.ns1yp.mongodb.net/myFirstDatabase
 
 You now need to adjust the connection URL to point to your own database.
 
-The format of the connection URL for your database depends on the database you use. For MongoDB, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+The [format of the connection URL](/reference/database-reference/connection-urls) for your database depends on the database you use. For MongoDB, it looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
 
 ```no-lines
 mongodb://USERNAME:PASSWORD@HOST:PORT/DATABASE
@@ -39,7 +39,6 @@ Here's a short explanation of each component:
 - `HOST`: The host where a [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/#mongodb-binary-bin.mongod) (or [`mongos`](https://docs.mongodb.com/manual/reference/program/mongos/#mongodb-binary-bin.mongos)) instance is running
 - `PORT`: The port where your database server is running (typically `27017` for MongoDB)
 - `DATABASE`: The name of the database
-> Passwords with special characters such as '$', '%', '@' need to be [percent encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
 
 <SwitchTech technologies={['node', 'mongodb']}>
 


### PR DESCRIPTION
Percent encoding applies to any part of the URL, not just the password. I've removed the explicit mention of the password, and linked to our page that describes the URL format.