### PR TITLE
Fix text saying batch inserts are not supported

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -813,7 +813,7 @@ const user = await prisma.user.create({
 
 ##### Create multiple new records
 
-Prisma Client does not yet support batch inserts at a database level. Follow [issue #332 on GitHub](https://github.com/prisma/prisma-client-js/issues/332) for updates.
+Prisma Client supports efficient batch inserts with the [`createMany`](#createmany) query. However, there are scenarios where using `create` to insert multiple records is necessary or desired.
 
 The following example results in **two** `INSERT` statements:
 


### PR DESCRIPTION
Doc for create says batch inserts not supported. Does not reflect recent addition of createMany query.

## Describe this PR

Docs said batch inserts are not supported and included a link to a Github issue. createMany was added recently, so this is no longer correct.

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
