### PR TITLE
docs: add channel_binding documentation

### DIFF
--- a/content/200-concepts/200-database-connectors/03-postgresql.mdx
+++ b/content/200-concepts/200-database-connectors/03-postgresql.mdx
@@ -83,6 +83,7 @@ The following arguments can be used:
 | `socket_timeout`   | No       |                        | Maximum number of seconds to wait until a single query terminates                                                                                                                 |
 | `pgbouncer`        | No       | `false`                | Configure the Engine to [enable PgBouncer compatibility mode](/guides/performance-and-optimization/connection-management/configure-pg-bouncer)                                    |
 | `application_name` | No       |                        | Since 3.3.0: Specifies a value for the application_name configuration parameter                                                                                                   |
+| `channel_binding`  | No       | `prefer`               | Since 4.8.0: Specifies a value for the channel_binding configuration parameter                                                                                                    |
 | `options`          | No       |                        | Since 3.8.0: Specifies command line options to send to the server at connection start                                                                                             |
 
 As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds. You can use the following arguments:


### PR DESCRIPTION
## Describe this PR

Added channel_binding Postgres query parameters documentation.

quaint: https://github.com/prisma/quaint/pull/424

prisma-engines: https://github.com/prisma/prisma-engines/pull/3527

ping: @pimeys 

I made some assumptions as top the version this will be released in as application_name and options both specify the version since when they are available.

## Changes

Added documentation for the Postgres channel_binding configuration parameter.

## What issue does this fix?



## Any other relevant information

