### PR TITLE
add Node.js 18.x to system requirements

### DIFF
--- a/content/400-reference/100-system-requirements.mdx
+++ b/content/400-reference/100-system-requirements.mdx
@@ -9,11 +9,9 @@ The [latest version of Prisma](https://www.npmjs.com/package/@prisma/client) req
 
 |                       | Minimum required version |
 | :-------------------- | :----------------------- |
-| Node.js               | 14.17.X / 16.X           |
+| Node.js               | 14.17.X / 16.X / 18.X    |
 | TypeScript (optional) | 4.1.X                    |
 | Yarn (optional)       | 1.19.2                   |
-
-Notes:
 
 - Prisma supports and tests all _Active LTS_ and _Maintenance LTS_ **Node.js** releases. [Releases that are not in these states like _Current_, and also odd-numbered versions](https://nodejs.org/en/about/releases/) probably also work, but are not recommended for production use.
 - **TypeScript** is only required for TypeScript users.

--- a/content/400-reference/100-system-requirements.mdx
+++ b/content/400-reference/100-system-requirements.mdx
@@ -13,6 +13,8 @@ The [latest version of Prisma](https://www.npmjs.com/package/@prisma/client) req
 | TypeScript (optional) | 4.1.X                    |
 | Yarn (optional)       | 1.19.2                   |
 
+Notes:
+
 - Prisma supports and tests all _Active LTS_ and _Maintenance LTS_ **Node.js** releases. [Releases that are not in these states like _Current_, and also odd-numbered versions](https://nodejs.org/en/about/releases/) probably also work, but are not recommended for production use.
 - **TypeScript** is only required for TypeScript users.
 - When using **Yarn 1**, `1.19.2` is the minimum version compatible with Prisma Client.


### PR DESCRIPTION
Since Node.js 18 is now LTS we can add it to the list explicitly