### PR TITLE
Remove stray periods from style guide headings

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
@@ -22,7 +22,7 @@ It's a good principle of technical communication to write as simply as possible.
 - Use tables to set out complex information
 - Use diagrams to make complex workflows or concepts easier to visualize
 
-## Tone of voice.
+## Tone of voice
 
 Write in a calm, assured tone of voice. Our tone is friendly and direct, but [we don't use slang](#avoid-emojis-slang-and-metaphors).
 
@@ -78,7 +78,7 @@ When you use jargon, follow these guidelines:
 
 - When you link to an external definition, choose a credible source. Wikipedia is acceptable, and official third-party documentation is better.
 
-## Use active voice.
+## Use active voice
 
 Use active voice instead of passive voice. It's a more concise and straightforward way to communicate. For example:
 


### PR DESCRIPTION
Remove stray periods in headings on the writing style page