### PR TITLE
fix: postgres extensions typo for pg_trgm

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/10-postgresql-extensions.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/10-postgresql-extensions.mdx
@@ -51,13 +51,13 @@ datasource db {
 
 ## How to represent PostgreSQL extensions in your Prisma schema
 
-To represent PostgreSQL extensions in your Prisma schema, add the `extensions` field to the `datasource` block of your `schema.prisma` file with an array of the extensions that you require. For example, the following schema lists the `hstore`, `pg_tgrm` and `postgis` extensions:
+To represent PostgreSQL extensions in your Prisma schema, add the `extensions` field to the `datasource` block of your `schema.prisma` file with an array of the extensions that you require. For example, the following schema lists the `hstore`, `pg_trgm` and `postgis` extensions:
 
 ```prisma file=schema.prisma
 datasource db {
   provider = "postgresql"
   url      = env("TEST_DATABASE_URL")
-  extensions = [hstore(schema: "myHstoreSchema"), pg_tgrm, postgis(version: "2.1")]
+  extensions = [hstore(schema: "myHstoreSchema"), pg_trgm, postgis(version: "2.1")]
 }
 ```
 


### PR DESCRIPTION
## Describe this PR

I noticed a typo with the Postgres extensions. The `pg_trgm` had the `r` and `g` flipped.

## Changes

Changed all instances of `pg_tgrm` to `pg_trgm`.

## What issue does this fix?

None of the currently open issues.

## Any other relevant information

Link to extension: https://www.postgresql.org/docs/current/pgtrgm.html
