### PR TITLE
feature: Add search frontmatter tag

### DIFF
--- a/plugins/gatsby-algolia-indexer/gatsby-config.js
+++ b/plugins/gatsby-algolia-indexer/gatsby-config.js
@@ -103,6 +103,7 @@ module.exports = (options) => {
                 title
                 langSwitcher
                 dbSwitcher
+                search
               }
               tableOfContents
             }
@@ -111,12 +112,16 @@ module.exports = (options) => {
       }`,
       indexName,
       settings,
-      transformer: ({ data }) =>
-        data.allMdx.edges
+      transformer: ({ data }) => {
+        const noSearchFlag = Array.from(data.allMdx.edges).filter(
+          (e) => e.node.frontmatter.search !== false
+        )
+        return noSearchFlag
           .map((edge) => edge.node)
           .map(unnestFrontmatter)
           .map(handleRawBody)
-          .reduce((acc, cur) => [...acc, ...cur], []),
+          .reduce((acc, cur) => [...acc, ...cur], [])
+      },
     },
   ]
 

--- a/src/hooks/useAllArticlesQuery.ts
+++ b/src/hooks/useAllArticlesQuery.ts
@@ -16,6 +16,7 @@ export const useAllArticlesQuery = () => {
               preview
               earlyaccess
               langSwitcher
+              search
               dbSwitcher
               hidePage
               codeStyle

--- a/src/interfaces/Article.interface.ts
+++ b/src/interfaces/Article.interface.ts
@@ -10,6 +10,7 @@ export interface ArticleFrontmatter {
   metaDescription?: string
   langSwitcher?: string[]
   dbSwitcher?: string[]
+  search?: boolean
   staticLink?: boolean
   duration?: string
   experimental?: boolean

--- a/src/templates/docs.tsx
+++ b/src/templates/docs.tsx
@@ -82,6 +82,7 @@ export const query = graphql`
         metaTitle
         metaDescription
         langSwitcher
+        search
         dbSwitcher
         toc
         tocDepth


### PR DESCRIPTION
**⚠️ Near duplicate of https://github.com/prisma/docs/pull/3731**

## Describe this PR

Quoted from the issue:

```
Can we have a new page front matter tag: excludeFromSearch search?

Update, 21-july-2022: the docs team would like to change the proposal slightly, so I've edited this ticket.

This would be a boolean value.
If the tag is set to false (search: false), then the page would be excluded from
our internal site search
external searches (e.g. Google)
If the tag is omitted, then it will default to true (in other words, the page will be included in search results).
This would be useful for pages we don't want to pollute the search results, such as style guide pages.

If a page has this tag set to false in conjunction with the [hidePage](https://www.prisma.io/docs/about/prisma-docs/style-guide/frontmatter#hidepage) tag, then it would be completely invisible to users (except if they know the URL). This could be useful to let the docs team publish draft pages.

This would be really useful to the docs team, so if it's viable to implement we'd appreciate it!
```

## Changes

Added new frontmatter tag called `search`. The initial data for all mdx files is filtered out when searching for instances of `search: false` set in the frontmatter of the mdx files. 

If `search` tag is not set, it resolves as `null`, but it **does not get filtered out**. Only tags set specifically with `false` are filtered out. 

This PR presents an example on the mdx file for `200-command-reference.mdx`, which has been tested in a mock-prod env using `npm run build & npm run serve`.

## What issue does this fix?

[Fixes #3358 ](https://github.com/prisma/docs/issues/3358)

## Any other relevant information

N/A