### PR TITLE
Prisma Client reference - add link from create query to createMany query notes

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -813,7 +813,7 @@ const user = await prisma.user.create({
 
 ##### Create multiple new records
 
-Prisma Client supports efficient batch inserts with the [`createMany`](#createmany) query. However, there are scenarios where using `create` to insert multiple records is necessary or desired.
+In most cases, you can carry out batch inserts with the [`createMany`](#createmany) query. However, [there are scenarios where `create` is the best option to insert multiple records](#remarks-10).
 
 The following example results in **two** `INSERT` statements:
 


### PR DESCRIPTION
In the `create` docs, where we mention you can use `createMany` to create multiple records, link to the remarks in the `createMany` explanation, to make it clear what the scenarios are where `create` is a better option to create multiple records. 