### PR TITLE
Exclude "About the docs" section from the search

### DIFF
--- a/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/01-writing-style.mdx
@@ -3,6 +3,7 @@ title: 'Writing style'
 metaTitle: 'Prisma docs style guide: writing style'
 metaDescription: 'This section of the style guide provides guidelines on tone of voice, audience, and other tonal matters.'
 tocDepth: 3
+search: false
 ---
 
 ## Audience

--- a/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/02-word-choice.mdx
@@ -3,6 +3,7 @@ title: 'Word choice'
 metaTitle: 'Prisma docs style guide: word choice'
 metaDescription: 'This section of the style guide provides guidelines on what terms and phrase constructions to use.'
 tocDepth: 3
+search: false
 ---
 
 ## Avoid words like "easy" and "just"

--- a/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -3,6 +3,7 @@ title: 'Spelling, punctuation, and formatting'
 metaTitle: 'Prisma docs style guide: spelling, punctuation, and formatting'
 metaDescription: 'This section of the style guide provides guidelines on how to present the information you add.'
 tocDepth: 3
+search: false
 ---
 
 ## Avoid contractions

--- a/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/04-schema-models.mdx
@@ -3,6 +3,7 @@ title: 'Docs example data model'
 metaTitle: 'Prisma docs style guide: example data model'
 metaDescription: 'This page describes the data models we use in our documentation examples.'
 tocDepth: 2
+search: false
 ---
 
 <TopBlock>

--- a/content/600-about/200-prisma-docs/20-style-guide/05-prisma-product-names.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/05-prisma-product-names.mdx
@@ -3,6 +3,7 @@ title: 'Prisma product and component names'
 metaTitle: 'Prisma docs style guide: Prisma product and component names'
 metaDescription: 'This section of the style guide provides guidelines on how to refer to Prisma products and components.'
 tocDepth: 3
+search: false
 ---
 
 ## Use the following forms

--- a/content/600-about/200-prisma-docs/20-style-guide/06-image-guidelines.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/06-image-guidelines.mdx
@@ -3,6 +3,7 @@ title: 'Prisma docs image guidelines'
 metaTitle: 'Prisma docs style guide: image guidelines'
 metaDescription: 'This page provides guidelines for images in our docs.'
 tocDepth: 2
+search: false
 ---
 
 ## Screenshots

--- a/content/600-about/200-prisma-docs/20-style-guide/07-user-interace-guidelines.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/07-user-interace-guidelines.mdx
@@ -3,6 +3,7 @@ title: 'User interface (GUI) guidelines'
 metaTitle: 'Prisma docs style guide: GUI guidelines'
 metaDescription: 'On this page you can find information about the Prisma guidelines for documenting UI elements and steps to walk users through interfaces.'
 tocDepth: 2
+search: false
 ---
 
 ## Use numbered lists to document UI steps

--- a/content/600-about/200-prisma-docs/20-style-guide/10-boilerplate-content.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/10-boilerplate-content.mdx
@@ -4,6 +4,7 @@ metaTitle: 'Boilerplate content'
 metaDescription: 'Boilerplate content for the Prisma docs.'
 tocDepth: 2
 hidePage: false
+search: false
 toc: true
 ---
 

--- a/content/600-about/200-prisma-docs/30-docs-components/01-mdx-examples.mdx
+++ b/content/600-about/200-prisma-docs/30-docs-components/01-mdx-examples.mdx
@@ -3,6 +3,7 @@ title: 'MDX components'
 metaTitle: 'MDX components in the Prisma docs'
 metaDescription: 'MDX components components available on the Prisma documentation site.'
 navTitle: 'MDX components'
+search: false
 ---
 
 <TopBlock>

--- a/content/600-about/200-prisma-docs/30-docs-components/index.mdx
+++ b/content/600-about/200-prisma-docs/30-docs-components/index.mdx
@@ -3,6 +3,7 @@ title: 'Prisma docs components'
 metaTitle: 'Prisma documentation components'
 metaDescription: 'This section describes the Prisma docs file format.'
 tocDepth: 3
+search: false
 ---
 
 ## In this section

--- a/content/600-about/200-prisma-docs/40-template.mdx
+++ b/content/600-about/200-prisma-docs/40-template.mdx
@@ -4,6 +4,7 @@ metaTitle: 'Writing template (About)'
 metaDescription: 'A template for writing Prisma Docs.'
 tocDepth: 2
 hidePage: false
+search: false
 toc: true
 ---
 

--- a/content/600-about/200-prisma-docs/index.mdx
+++ b/content/600-about/200-prisma-docs/index.mdx
@@ -4,6 +4,7 @@ metaTitle: 'About Prisma docs'
 metaDescription: 'About Prisma docs'
 toc: false
 staticLink: true
+search: false
 ---
 
 ## In this section


### PR DESCRIPTION
Exception: I've left the intro page for the style guide findable in search

