### PR TITLE
Fixing a minor typo.

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
@@ -6,7 +6,7 @@ metaDescription: 'This page explains how to add computed fields to Prisma Client
 
 <TopBlock>
 
-Computed fields allow you to derive a new field based on existing data. A common example is when you compute a full name from a first and last name. In your database, you may only store the first and last name, but you can define a function the computes a full name by combining the first and last name. This field is read-only and stored in your application's memory, not in your database.
+Computed fields allow you to derive a new field based on existing data. A common example is when you compute a full name from a first and last name. In your database, you may only store the first and last name, but you can define a function that computes a full name by combining the first and last name. This field is read-only and stored in your application's memory, not in your database.
 
 </TopBlock>
 


### PR DESCRIPTION
In the Computed Fields intro, there is a typo when describing the ability to create a function.

## Describe this PR

Intro to Computed Fields should have 'that' instead of 'the' when describing the ability to define a function.

## Changes

Changed the word "the" to "that" in the Computed Fields documentation intro.

## What issue does this fix?

No issue documented that relates to this typo.

## Any other relevant information

Nothing of note.
