### PR TITLE
Clarify the `$runCommandRaw` docs

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -587,19 +587,26 @@ For MongoDB in versions `3.9.0` and later, Prisma Client exposes three methods t
 
 ### <inlinecode>$runCommandRaw</inlinecode>
 
-`$runCommandRaw` runs a raw MongoDB command against the database. As input, it accepts all [MongoDB user commands](https://www.mongodb.com/docs/manual/reference/command/#user-commands) with the following exceptions:
+`$runCommandRaw` runs a raw MongoDB command against the database. As input, it accepts all [MongoDB database commands](https://www.mongodb.com/docs/manual/reference/command/), with the following exceptions:
 
-- find
-- aggregate (use [`aggregateRaw`](#aggregateraw) instead)
+- find (use [`aggregateRaw`](#aggregateraw) instead)
+- aggregate (use [`findRaw`](#findraw) instead)
+
+To use a MongoDB database command, you must connect to the database with an appropriate role for that command.
 
 **TBA: **
 
 - In the example below, use an object ID, as it's more important
+
   - The user is free to generate an objectid if he/she needs.
+
 - How to tell Prisma that `_id` is an `ObjectID`
+
   - This is a datamodel specific problem. It’s documented [here](https://www.prisma.io/docs/concepts/database-connectors/mongodb#using-objectid). TLDR: id String @id @default(auto()) @map("\_id") @db.ObjectId (with @default(auto()) removing the need to manually generated an ObjectID)
+
 - Can you pass a string? If so, how?
   - You’re free to pass a string if you need to, I suppose JSON.parse("your string") would be the solution. (I’m not sure I see the value though)
+  - Note for Nurul - did not answer how to pass a string, because it sounds like an edge case - but the user might want to know the above workaround
 
 For example, the following query inserts two records with the same `_id`, bypassing normal document validation:
 

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -587,12 +587,10 @@ For MongoDB in versions `3.9.0` and later, Prisma Client exposes three methods t
 
 ### <inlinecode>$runCommandRaw</inlinecode>
 
-`$runCommandRaw` runs a raw MongoDB command against the database.
+`$runCommandRaw` runs a raw MongoDB command against the database. As input, it accepts all [MongoDB user commands](https://www.mongodb.com/docs/manual/reference/command/#user-commands) with the following exceptions: - , as documented [here](https://www.mongodb.com/docs/manual/reference/command/#query-and-write-operation-commands) (this is probably the bits missing in the doc) (The link has an anchor on query and write operation commands, but really, it’s all commands listed here except the ones mentioned in the docs: find & aggregate)
 
 **TBA: **
 
-- What input the command accepts
-  - `$runCommandRaw` accepts all MongoDB commands documented [here](https://www.mongodb.com/docs/manual/reference/command/#query-and-write-operation-commands) (this is probably the bits missing in the doc) (The link has an anchor on query and write operation commands, but really, it’s all commands listed here except the ones mentioned in the docs: find & aggregate)
 - In the example below, use an object ID, as it's more important
   - The user is free to generate an objectid if he/she needs.
 - How to tell Prisma that `_id` is an `ObjectID`

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -172,7 +172,7 @@ The `$queryRawUnsafe` method allows you to pass a raw string (or template string
 
 <Admonition type="warning">
 
-By using this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data, be it confidential or otherwise sensitive, to being modified, or even destroyed.
+If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your confidential or sensitive data, to modification or even destruction.<br /><br />
 
 We strongly advise that you use the `$queryRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
 
@@ -327,7 +327,7 @@ The `$executeRawUnsafe` method allows you to pass a raw string (or template stri
 
 <Admonition type="warning">
 
-By using this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data, be it confidential or otherwise sensitive, to being modified, or even destroyed.
+If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your confidential or sensitive data, to modification or even destruction.<br /><br />
 
 We strongly advise that you use the `$executeRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
 
@@ -592,23 +592,12 @@ For MongoDB in versions `3.9.0` and later, Prisma Client exposes three methods t
 - find (use [`aggregateRaw`](#aggregateraw) instead)
 - aggregate (use [`findRaw`](#findraw) instead)
 
-To use a MongoDB database command, you must connect to the database with an appropriate role for that command.
+Note:
 
-**TBA: **
+- The object that you pass when you invoke `$runCommandRaw` must follow the syntax of `db.runCommand`. For more information, see the MongoDB documentation.
+- To use a MongoDB database command, you must connect to the database with an appropriate role for that command.
 
-- In the example below, use an object ID, as it's more important
-
-  - The user is free to generate an objectid if he/she needs.
-
-- How to tell Prisma that `_id` is an `ObjectID`
-
-  - This is a datamodel specific problem. It’s documented [here](https://www.prisma.io/docs/concepts/database-connectors/mongodb#using-objectid). TLDR: id String @id @default(auto()) @map("\_id") @db.ObjectId (with @default(auto()) removing the need to manually generated an ObjectID)
-
-- Can you pass a string? If so, how?
-  - You’re free to pass a string if you need to, I suppose JSON.parse("your string") would be the solution. (I’m not sure I see the value though)
-  - Note for Nurul - did not answer how to pass a string, because it sounds like an edge case - but the user might want to know the above workaround
-
-For example, the following query inserts two records with the same `_id`, bypassing normal document validation:
+In the following example, a query inserts two records with the same `_id`. This bypasses normal document validation.
 
 ```ts no-lines
 prisma.$runCommandRaw({

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -172,7 +172,7 @@ The `$queryRawUnsafe` method allows you to pass a raw string (or template string
 
 <Admonition type="warning">
 
-If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your confidential or sensitive data, to modification or even destruction.<br /><br />
+If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or destruction.<br /><br />
 
 We strongly advise that you use the `$queryRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
 
@@ -327,7 +327,7 @@ The `$executeRawUnsafe` method allows you to pass a raw string (or template stri
 
 <Admonition type="warning">
 
-If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your confidential or sensitive data, to modification or even destruction.<br /><br />
+If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or destruction.<br /><br />
 
 We strongly advise that you use the `$executeRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
 

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -592,10 +592,10 @@ For MongoDB in versions `3.9.0` and later, Prisma Client exposes three methods t
 - find (use [`aggregateRaw`](#aggregateraw) instead)
 - aggregate (use [`findRaw`](#findraw) instead)
 
-Note:
+When you use `$runCommandRaw` to run a MongoDB database command, note the following:
 
-- The object that you pass when you invoke `$runCommandRaw` must follow the syntax of `db.runCommand`. For more information, see the MongoDB documentation.
-- To use a MongoDB database command, you must connect to the database with an appropriate role for that command.
+- The object that you pass when you invoke `$runCommandRaw` must follow the syntax of the MongoDB database command.
+- You must connect to the database with an appropriate role for the MongoDB database command.
 
 In the following example, a query inserts two records with the same `_id`. This bypasses normal document validation.
 

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -587,7 +587,20 @@ For MongoDB in versions `3.9.0` and later, Prisma Client exposes three methods t
 
 ### <inlinecode>$runCommandRaw</inlinecode>
 
-`$runCommandRaw` runs a raw MongoDB command against the database. For example, this query inserts two records with the same `_id`, bypassing normal document validation:
+`$runCommandRaw` runs a raw MongoDB command against the database.
+
+**TBA: **
+
+- What input the command accepts
+  - `$runCommandRaw` accepts all MongoDB commands documented [here](https://www.mongodb.com/docs/manual/reference/command/#query-and-write-operation-commands) (this is probably the bits missing in the doc) (The link has an anchor on query and write operation commands, but really, it’s all commands listed here except the ones mentioned in the docs: find & aggregate)
+- In the example below, use an object ID, as it's more important
+  - The user is free to generate an objectid if he/she needs.
+- How to tell Prisma that `_id` is an `ObjectID`
+  - This is a datamodel specific problem. It’s documented [here](https://www.prisma.io/docs/concepts/database-connectors/mongodb#using-objectid). TLDR: id String @id @default(auto()) @map("\_id") @db.ObjectId (with @default(auto()) removing the need to manually generated an ObjectID)
+- Can you pass a string? If so, how?
+  - You’re free to pass a string if you need to, I suppose JSON.parse("your string") would be the solution. (I’m not sure I see the value though)
+
+For example, the following query inserts two records with the same `_id`, bypassing normal document validation:
 
 ```ts no-lines
 prisma.$runCommandRaw({
@@ -614,7 +627,7 @@ prisma.$runCommandRaw({
 
 <Admonition type="warning">
 
-Note that the `$runCommandRaw` command should not be used for queries which contain the `"find"` or `"aggregate"` commands, as you may be unable to fetch all data. This is because MongoDB returns a [cursor](https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/) that is attached to your MongoDB session, and you may not hit the same MongoDB session every time. For these queries, you should use the specialised [`findRaw`](#findraw) and [`aggregateRaw`](#aggregateraw) methods instead.
+Do not use `$runCommandRaw` for queries which contain the `"find"` or `"aggregate"` commands, because you might be unable to fetch all data. This is because MongoDB returns a [cursor](https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/) that is attached to your MongoDB session, and you might not hit the same MongoDB session every time. For these queries, you should use the specialised [`findRaw`](#findraw) and [`aggregateRaw`](#aggregateraw) methods instead.
 
 </Admonition>
 

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -172,7 +172,7 @@ The `$queryRawUnsafe` method allows you to pass a raw string (or template string
 
 <Admonition type="warning">
 
-If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or destruction.<br /><br />
+If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
 We strongly advise that you use the `$queryRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
 
@@ -327,7 +327,7 @@ The `$executeRawUnsafe` method allows you to pass a raw string (or template stri
 
 <Admonition type="warning">
 
-If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or destruction.<br /><br />
+If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
 We strongly advise that you use the `$executeRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
 

--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -587,7 +587,10 @@ For MongoDB in versions `3.9.0` and later, Prisma Client exposes three methods t
 
 ### <inlinecode>$runCommandRaw</inlinecode>
 
-`$runCommandRaw` runs a raw MongoDB command against the database. As input, it accepts all [MongoDB user commands](https://www.mongodb.com/docs/manual/reference/command/#user-commands) with the following exceptions: - , as documented [here](https://www.mongodb.com/docs/manual/reference/command/#query-and-write-operation-commands) (this is probably the bits missing in the doc) (The link has an anchor on query and write operation commands, but really, it’s all commands listed here except the ones mentioned in the docs: find & aggregate)
+`$runCommandRaw` runs a raw MongoDB command against the database. As input, it accepts all [MongoDB user commands](https://www.mongodb.com/docs/manual/reference/command/#user-commands) with the following exceptions:
+
+- find
+- aggregate (use [`aggregateRaw`](#aggregateraw) instead)
 
 **TBA: **
 


### PR DESCRIPTION
- Add clarification about which MongoDB commands are supported
- Add notes about how to use the command
- Unrelated drive-by fix: tidy up the two warnings about SQL injection attacks on the page