### PR TITLE
Remove internal message from 010-mental-model.mdx

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/010-mental-model.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/010-mental-model.mdx
@@ -173,6 +173,6 @@ Under the hood, the `migrate deploy` command:
 
 ![](../../../300-guides/050-database/100-developing-with-prisma-migrate/deploy-db.png)
 
-The command should be run in an automated CI/ CD environment, for example GitHub Actions. (link to example?)
+The command should be run in an automated CI/ CD environment, for example GitHub Actions.
 
 If you don't have a migration history (`/migrations`), i.e using `prisma db push`, you will have to continue using `prisma db push` in your staging and production environments. Beware of the changes being applied to the database schema as some of them might be destructive. For example, `prisma db push` can't tell when you're performing a column rename. It will prompt a database reset (drop and re-creation).


### PR DESCRIPTION
While reading the docs I saw a "(link to example?)" that seems to be an internal message that was pushed to production by accident.