### PR TITLE
Update outdated information in Bulk Operations Section

### DIFF
--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -295,8 +295,7 @@ Bulk writes allow you to write multiple records of the same type in a single tra
 
 - `updateMany`
 - `deleteMany`
-
-The ability to [create and upsert in bulk](https://github.com/prisma/prisma-client-js/issues/332) is being considered: feel free to chime in with your use case and upvote if you're interested.
+- `createMany`
 
 #### When to use bulk operations
 


### PR DESCRIPTION
createMany operation now creates records in a single transaction.

## Changes

Added `createMany` in the list and removed the Closed GitHub Issue link.

## What issue does this fix?

Fixes Outdated Information.

