### PR TITLE
Updated the prisma.schema file

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/125-creating-the-prisma-schema.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/125-creating-the-prisma-schema.mdx
@@ -26,8 +26,16 @@ model Post {
   slug     String    @unique
   title    String
   body     String
+  comments Comment[]
   author   User      @relation(fields: [authorId], references: [id])
   authorId String    @db.ObjectId
+}
+
+model Comment {
+  id      String     @id @default(auto()) @map("_id") @db.ObjectId
+  comment String
+  post    Post       @relation(fields: [postId], references: [id])
+  postId  String     @db.ObjectId
 }
 
 model User {


### PR DESCRIPTION


## Describe this PR

I have added the missing comment type which is required to complete the getting started guide for MongoDB.

## Changes

Added the Comment type
Added a comments field within the Post type

## What issue does this fix?

When adding comments later in the guide it fails due to the missing Comment type in the model

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
