### PR TITLE
fix: second-level parent collapse

### DIFF
--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -56,10 +56,6 @@ const ListItem = styled.li`
       padding: 0;
       border: 0;
 
-      &.more-left {
-        left: 10px;
-      }
-
       .right,
       .down {
         transition: opacity 0.5s linear;
@@ -247,11 +243,7 @@ const TreeNode = ({
         >
           {hasExpandButton ? (
             <span className="collapse-title" onClick={collapse}>
-              <button
-                aria-label="collapse"
-                className={`item-collapser ${level > 3 ? 'more-left' : ''}`}
-                onClick={justExpand}
-              >
+              <button aria-label="collapse" className={`item-collapser`} onClick={justExpand}>
                 {/* Fix for issue https://github.com/prisma/prisma2-docs/issues/161 */}
                 <ArrowRight className={`right ${isOpen}`} />
                 <ArrowDown className={`down ${isOpen}`} />

--- a/src/components/sidebar/treeNode.tsx
+++ b/src/components/sidebar/treeNode.tsx
@@ -130,6 +130,7 @@ const ListItem = styled.li`
     // }
   }
   .collapse-title {
+    position: relative;
     cursor: pointer;
     svg {
       transition: transform 0.2s ease;


### PR DESCRIPTION
## Describe this PR

Currently on second-level parent items, on the sidebar menu, the triangle indicator that signals for a collapsible menu is not showing.

## Changes

Added a missing `position: relative;` to the class `.collapse-title`.

| before | after |
| ----- | ----- |
| <img width="331" alt="Screenshot 2023-01-10 at 19 34 31" src="https://user-images.githubusercontent.com/14851246/211645046-ce4c4e99-85ae-494d-8f84-89e8cc2f1338.png"> | <img width="361" alt="Screenshot 2023-01-10 at 19 31 35" src="https://user-images.githubusercontent.com/14851246/211645068-322a392a-3f89-4953-a3ee-571923d82f2b.png"> |


## What issue does this fix?

[Fixes #3943](https://github.com/prisma/docs/issues/3943)

## Any other relevant information

N/A
