### PR TITLE
Update 090-raw-database-access.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/090-raw-database-access.mdx
@@ -589,8 +589,8 @@ For MongoDB in versions `3.9.0` and later, Prisma Client exposes three methods t
 
 `$runCommandRaw` runs a raw MongoDB command against the database. As input, it accepts all [MongoDB database commands](https://www.mongodb.com/docs/manual/reference/command/), with the following exceptions:
 
-- find (use [`aggregateRaw`](#aggregateraw) instead)
-- aggregate (use [`findRaw`](#findraw) instead)
+- `find` (use [`aggregateRaw`](#aggregateraw) instead)
+- `aggregate` (use [`findRaw`](#findraw) instead)
 
 When you use `$runCommandRaw` to run a MongoDB database command, note the following:
 


### PR DESCRIPTION
Add backticks around the MongoDB commands `find` and `aggregate` to differentiate them from normal text