### PR TITLE
update: plugin for custom image function

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
@@ -23,6 +23,12 @@ const results = await prisma.post.findMany({
 
 ![](../../../doc-images/offset-skip-take.png)
 
+<img
+  src="../../../doc-images/offset-skip-take.png"
+  alt="Prisma Data Platform - Create project - Paste database connection string, select Data Proxy region, enable static IPs"
+  width="200px"
+/>
+
 To implement pages of results, you would just `skip` the number of pages multiplied by the number of results you show per page.
 
 ### ✔ Pros of offset pagination

--- a/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
@@ -23,11 +23,6 @@ const results = await prisma.post.findMany({
 
 ![](../../../doc-images/offset-skip-take.png)
 
-<img
-  src="../../../doc-images/offset-skip-take.png"
-  alt="Prisma Data Platform - Create project - Paste database connection string, select Data Proxy region, enable static IPs"
-  width="200px"
-/>
 
 To implement pages of results, you would just `skip` the number of pages multiplied by the number of results you show per page.
 

--- a/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/054-pagination.mdx
@@ -23,7 +23,6 @@ const results = await prisma.post.findMany({
 
 ![](../../../doc-images/offset-skip-take.png)
 
-
 To implement pages of results, you would just `skip` the number of pages multiplied by the number of results you show per page.
 
 ### ✔ Pros of offset pagination

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -29,9 +29,10 @@ let plugins: any = [
           },
         },
         {
-          resolve: `gatsby-remark-images`,
+          resolve: `gatsby-remark-image-custom`,
           options: {
             disableBgImageOnAlpha: true,
+            quality: 100,
           },
         },
         {

--- a/plugins/gatsby-remark-image-custom/constants.js
+++ b/plugins/gatsby-remark-image-custom/constants.js
@@ -1,0 +1,17 @@
+exports.DEFAULT_OPTIONS = {
+  maxWidth: 650,
+  wrapperStyle: ``,
+  backgroundColor: `white`,
+  linkImagesToOriginal: true,
+  showCaptions: false,
+  markdownCaptions: false,
+  withWebp: false,
+  tracedSVG: false,
+  loading: `lazy`,
+  disableBgImageOnAlpha: false,
+  disableBgImage: false,
+}
+
+exports.imageClass = `gatsby-resp-image-image`
+exports.imageWrapperClass = `gatsby-resp-image-wrapper`
+exports.imageBackgroundClass = `gatsby-resp-image-background-image`

--- a/plugins/gatsby-remark-image-custom/gatsby-browser.js
+++ b/plugins/gatsby-remark-image-custom/gatsby-browser.js
@@ -1,0 +1,43 @@
+const {
+  DEFAULT_OPTIONS,
+  imageClass,
+  imageBackgroundClass,
+  imageWrapperClass,
+} = require(`./constants`)
+
+exports.onRouteUpdate = (apiCallbackContext, pluginOptions) => {
+  const options = Object.assign({}, DEFAULT_OPTIONS, pluginOptions)
+
+  const imageWrappers = document.querySelectorAll(`.${imageWrapperClass}`)
+
+  // https://css-tricks.com/snippets/javascript/loop-queryselectorall-matches/
+  // for cross-browser looping through NodeList without polyfills
+  for (let i = 0; i < imageWrappers.length; i++) {
+    const imageWrapper = imageWrappers[i]
+
+    const backgroundElement = imageWrapper.querySelector(`.${imageBackgroundClass}`)
+    const imageElement = imageWrapper.querySelector(`.${imageClass}`)
+
+    const onImageLoad = () => {
+      backgroundElement.style.transition = `opacity 0.5s 0.5s`
+      imageElement.style.transition = `opacity 0.5s`
+      onImageComplete()
+    }
+
+    const onImageComplete = () => {
+      backgroundElement.style.opacity = 0
+      imageElement.style.opacity = 1
+      imageElement.style.color = `inherit`
+      imageElement.style.boxShadow = `inset 0px 0px 0px 400px ${options.backgroundColor}`
+      imageElement.removeEventListener(`load`, onImageLoad)
+      imageElement.removeEventListener(`error`, onImageComplete)
+    }
+
+    imageElement.style.opacity = 0
+    imageElement.addEventListener(`load`, onImageLoad)
+    imageElement.addEventListener(`error`, onImageComplete)
+    if (imageElement.complete) {
+      onImageComplete()
+    }
+  }
+}

--- a/plugins/gatsby-remark-image-custom/gatsby-ssr.js
+++ b/plugins/gatsby-remark-image-custom/gatsby-ssr.js
@@ -1,0 +1,25 @@
+const React = require('react')
+const { imageClass } = require(`./constants`)
+
+exports.onRenderBody = ({ setHeadComponents }) => {
+  const style = `
+  .${imageClass} {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    vertical-align: middle;
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: transparent;
+  }`
+    .replace(/\s*\n\s*/g, ``)
+    .replace(/: /g, `:`)
+    .replace(/ \{/g, `{`)
+
+  setHeadComponents([
+    <style type="text/css" key="gatsby-remark-images-styles">
+      {style}
+    </style>,
+  ])
+}

--- a/plugins/gatsby-remark-image-custom/index.js
+++ b/plugins/gatsby-remark-image-custom/index.js
@@ -1,0 +1,444 @@
+const {
+  DEFAULT_OPTIONS,
+  imageClass,
+  imageBackgroundClass,
+  imageWrapperClass,
+} = require(`./constants`)
+const visitWithParents = require(`unist-util-visit-parents`)
+const getDefinitions = require(`mdast-util-definitions`)
+const path = require(`path`)
+const queryString = require(`query-string`)
+const isRelativeUrl = require(`is-relative-url`)
+const _ = require(`lodash`)
+const { fluid, stats, traceSVG } = require(`gatsby-plugin-sharp`)
+const Promise = require(`bluebird`)
+const cheerio = require(`cheerio`)
+const slash = require(`slash`)
+const chalk = require(`chalk`)
+
+// If the image is relative (not hosted elsewhere)
+// 1. Find the image file
+// 2. Find the image's size
+// 3. Filter out any responsive image fluid sizes that are greater than the image's width
+// 4. Create the responsive images.
+// 5. Set the html w/ aspect ratio helper.
+module.exports = (
+  { files, markdownNode, markdownAST, pathPrefix, getNode, reporter, cache, compiler },
+  pluginOptions
+) => {
+  const options = _.defaults(pluginOptions, { pathPrefix }, DEFAULT_OPTIONS)
+
+  const findParentLinks = ({ children }) =>
+    children.some(
+      (node) => (node.type === `html` && !!node.value.match(/<a /)) || node.type === `link`
+    )
+
+  const getWidthOverride = (node) => {
+    if (!node.value || !node.value.match(/width/)) return null
+
+    // extract width in pixels, as an integer (or null)
+    const regex = /width="([0-9]+)(?:px)?"/g
+    const match = regex.exec(node.value)
+    if (!match) return
+    return parseInt(match[1])
+  }
+
+  // Get all the available definitions in the markdown tree
+  const definitions = getDefinitions(markdownAST)
+
+  // This will allow the use of html image tags
+  // const rawHtmlNodes = select(markdownAST, `html`)
+  let rawHtmlNodes = []
+  visitWithParents(markdownAST, [`html`, `jsx`], (node, ancestors) => {
+    const inLink = ancestors.some(findParentLinks)
+    const width = getWidthOverride(node) || null
+
+    rawHtmlNodes.push({ node, inLink, width })
+  })
+
+  // This will only work for markdown syntax image tags
+  let markdownImageNodes = []
+
+  visitWithParents(markdownAST, [`image`, `imageReference`], (node, ancestors) => {
+    const inLink = ancestors.some(findParentLinks)
+
+    markdownImageNodes.push({ node, inLink })
+  })
+
+  const getImageInfo = (uri) => {
+    const { url, query } = queryString.parseUrl(uri)
+    return {
+      ext: path.extname(url).split(`.`).pop(),
+      url,
+      query,
+    }
+  }
+
+  const getImageCaption = (node, overWrites) => {
+    const getCaptionString = () => {
+      const captionOptions = Array.isArray(options.showCaptions)
+        ? options.showCaptions
+        : options.showCaptions === true
+        ? [`title`, `alt`]
+        : false
+
+      if (captionOptions) {
+        for (const option of captionOptions) {
+          switch (option) {
+            case `title`:
+              if (node.title) {
+                return node.title
+              }
+              break
+            case `alt`:
+              if (overWrites.alt) {
+                return overWrites.alt
+              }
+              if (node.alt) {
+                return node.alt
+              }
+              break
+          }
+        }
+      }
+
+      return ``
+    }
+
+    const captionString = getCaptionString()
+
+    if (!options.markdownCaptions || !compiler) {
+      return _.escape(captionString)
+    }
+
+    return compiler.generateHTML(compiler.parseString(captionString))
+  }
+
+  // Takes a node and generates the needed images and then returns
+  // the needed HTML replacement for the image
+  const generateImagesAndUpdateNode = async function (
+    node,
+    resolve,
+    inLink,
+    overWrites = {},
+    width = null
+  ) {
+    // Check if this markdownNode has a File parent. This plugin
+    // won't work if the image isn't hosted locally.
+    const parentNode = getNode(markdownNode.parent)
+    let imagePath
+    if (parentNode && parentNode.dir) {
+      imagePath = slash(path.join(parentNode.dir, getImageInfo(node.url).url))
+    } else {
+      return null
+    }
+
+    const imageNode = _.find(files, (file) => {
+      if (file && file.absolutePath) {
+        return file.absolutePath === imagePath
+      }
+      return null
+    })
+
+    if (!imageNode || !imageNode.absolutePath) {
+      return resolve()
+    }
+
+    // If width attribute is set then overwrite gatsby-config's maxWidth
+    const args = width ? { ...options, maxWidth: `${width}px` } : options
+
+    let fluidResult = await fluid({
+      file: imageNode,
+      args,
+      reporter,
+      cache,
+    })
+
+    if (!fluidResult) {
+      return resolve()
+    }
+
+    const originalImg = fluidResult.originalImg
+    const fallbackSrc = fluidResult.src
+    const srcSet = fluidResult.srcSet
+    const presentationWidth = width ? width : fluidResult.presentationWidth
+
+    // Generate default alt tag
+    const srcSplit = getImageInfo(node.url).url.split(`/`)
+    const fileName = srcSplit[srcSplit.length - 1]
+    const fileNameNoExt = fileName.replace(/\.[^/.]+$/, ``)
+    const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `)
+
+    const alt = _.escape(overWrites.alt ? overWrites.alt : node.alt ? node.alt : defaultAlt)
+
+    const title = node.title ? _.escape(node.title) : alt
+
+    const loading = options.loading
+
+    if (![`lazy`, `eager`, `auto`].includes(loading)) {
+      reporter.warn(
+        reporter.stripIndent(`
+          ${chalk.bold(loading)} is an invalid value for the ${chalk.bold(
+          `loading`
+        )} option. Please pass one of "lazy", "eager" or "auto".
+        `)
+      )
+    }
+
+    // Create our base image tag
+    let imageTag = `
+        <img
+          class="${imageClass}"
+          alt="${alt}"
+          title="${title}"
+          src="${fallbackSrc}"
+          srcset="${srcSet}"
+          sizes="${fluidResult.sizes}"
+          loading="${loading}"
+        />
+      `.trim()
+
+    // if options.withWebp is enabled, generate a webp version and change the image tag to a picture tag
+    if (options.withWebp) {
+      const webpFluidResult = await fluid({
+        file: imageNode,
+        args: _.defaults(
+          { toFormat: `WEBP` },
+          // override options if it's an object, otherwise just pass through defaults
+          options.withWebp === true ? {} : options.withWebp,
+          pluginOptions,
+          DEFAULT_OPTIONS
+        ),
+        reporter,
+      })
+
+      if (!webpFluidResult) {
+        return resolve()
+      }
+
+      imageTag = `
+        <picture>
+          <source
+            srcset="${webpFluidResult.srcSet}"
+            sizes="${webpFluidResult.sizes}"
+            type="${webpFluidResult.srcSetType}"
+          />
+          <source
+            srcset="${srcSet}"
+            sizes="${fluidResult.sizes}"
+            type="${fluidResult.srcSetType}"
+          />
+          <img
+            class="${imageClass}"
+            src="${fallbackSrc}"
+            alt="${alt}"
+            title="${title}"
+            loading="${loading}"
+          />
+        </picture>
+        `.trim()
+    }
+
+    let placeholderImageData = fluidResult.base64
+
+    // if options.tracedSVG is enabled generate the traced SVG and use that as the placeholder image
+    if (options.tracedSVG) {
+      let args = typeof options.tracedSVG === `object` ? options.tracedSVG : {}
+
+      // Translate Potrace constants (e.g. TURNPOLICY_LEFT, COLOR_AUTO) to the values Potrace expects
+      const { Potrace } = require(`potrace`)
+      const argsKeys = Object.keys(args)
+      args = argsKeys.reduce((result, key) => {
+        const value = args[key]
+        result[key] = Potrace.hasOwnProperty(value) ? Potrace[value] : value
+        return result
+      }, {})
+
+      const tracedSVG = await traceSVG({
+        file: imageNode,
+        args,
+        fileArgs: args,
+        cache,
+        reporter,
+      })
+
+      // Escape single quotes so the SVG data can be used in inline style attribute with single quotes
+      placeholderImageData = tracedSVG.replace(/'/g, `\\'`)
+    }
+
+    const ratio = `${(1 / fluidResult.aspectRatio) * 100}%`
+
+    const wrapperStyle =
+      typeof options.wrapperStyle === `function`
+        ? options.wrapperStyle(fluidResult)
+        : options.wrapperStyle
+
+    // Construct new image node w/ aspect ratio placeholder
+    const imageCaption = options.showCaptions && getImageCaption(node, overWrites)
+
+    let removeBgImage = false
+    if (options.disableBgImageOnAlpha) {
+      const imageStats = await stats({ file: imageNode, reporter })
+      if (imageStats && imageStats.isTransparent) removeBgImage = true
+    }
+    if (options.disableBgImage) {
+      removeBgImage = true
+    }
+
+    const bgImage = removeBgImage
+      ? ``
+      : ` background-image: url('${placeholderImageData}'); background-size: cover;`
+
+    let rawHTML = `
+    <span
+      class="${imageBackgroundClass}"
+      style="padding-bottom: ${ratio}; position: relative; bottom: 0; left: 0;${bgImage} display: block;"
+    ></span>
+    ${imageTag}
+    `.trim()
+
+    // Make linking to original image optional.
+    if (!inLink && options.linkImagesToOriginal) {
+      rawHTML = `
+    <a
+      class="gatsby-resp-image-link"
+      href="${originalImg}"
+      style="display: block"
+      target="_blank"
+      rel="noopener"
+    >
+      ${rawHTML}
+    </a>
+      `.trim()
+    }
+
+    rawHTML = `
+      <span
+        class="${imageWrapperClass}"
+        style="position: relative; display: block; margin-left: auto; margin-right: auto; ${
+          imageCaption ? `` : wrapperStyle
+        } max-width: ${presentationWidth}px;"
+      >
+        ${rawHTML}
+      </span>
+      `.trim()
+
+    // Wrap in figure and use title as caption
+    if (imageCaption) {
+      rawHTML = `
+    <figure class="gatsby-resp-image-figure" style="${wrapperStyle}">
+      ${rawHTML}
+      <figcaption class="gatsby-resp-image-figcaption">${imageCaption}</figcaption>
+    </figure>
+        `.trim()
+    }
+
+    return rawHTML
+  }
+
+  return Promise.all(
+    // Simple because there is no nesting in markdown
+    markdownImageNodes.map(
+      ({ node, inLink }) =>
+        new Promise(async (resolve, reject) => {
+          const overWrites = {}
+          let refNode
+          if (!node.hasOwnProperty(`url`) && node.hasOwnProperty(`identifier`)) {
+            //consider as imageReference node
+            refNode = node
+            node = definitions(refNode.identifier)
+            // pass original alt from referencing node
+            overWrites.alt = refNode.alt
+            if (!node) {
+              // no definition found for image reference,
+              // so there's nothing for us to do.
+              return resolve()
+            }
+          }
+          const fileType = getImageInfo(node.url).ext
+
+          // Ignore gifs as we can't process them,
+          // svgs as they are already responsive by definition
+          if (isRelativeUrl(node.url) && fileType !== `gif` && fileType !== `svg`) {
+            const rawHTML = await generateImagesAndUpdateNode(node, resolve, inLink, overWrites)
+
+            if (rawHTML) {
+              // Replace the image or ref node with an inline HTML node.
+              if (refNode) {
+                node = refNode
+              }
+              node.type = `html`
+              node.value = rawHTML
+            }
+            return resolve(node)
+          } else {
+            // Image isn't relative so there's nothing for us to do.
+            return resolve()
+          }
+        })
+    )
+  ).then((markdownImageNodes) =>
+    // HTML image node stuff
+    Promise.all(
+      // Complex because HTML nodes can contain multiple images
+      rawHtmlNodes.map(
+        ({ node, inLink, width }) =>
+          new Promise(async (resolve, reject) => {
+            if (!node.value) {
+              return resolve()
+            }
+
+            const $ = cheerio.load(node.value)
+            if ($(`img`).length === 0) {
+              // No img tags
+              return resolve()
+            }
+
+            let imageRefs = []
+            $(`img`).each(function () {
+              imageRefs.push($(this))
+            })
+
+            for (let thisImg of imageRefs) {
+              // Get the details we need.
+              let formattedImgTag = {}
+              formattedImgTag.url = thisImg.attr(`src`)
+              formattedImgTag.title = thisImg.attr(`title`)
+              formattedImgTag.alt = thisImg.attr(`alt`)
+
+              if (!formattedImgTag.url) {
+                return resolve()
+              }
+
+              const fileType = getImageInfo(formattedImgTag.url).ext
+
+              // Ignore gifs as we can't process them,
+              // svgs as they are already responsive by definition
+              if (isRelativeUrl(formattedImgTag.url) && fileType !== `gif` && fileType !== `svg`) {
+                const rawHTML = await generateImagesAndUpdateNode(
+                  formattedImgTag,
+                  resolve,
+                  inLink,
+                  {},
+                  width
+                )
+
+                if (rawHTML) {
+                  // Replace the image string
+                  thisImg.replaceWith(rawHTML)
+                } else {
+                  return resolve()
+                }
+              }
+            }
+
+            // Replace the image node with an inline HTML node.
+            node.type = `html`
+            node.value = $(`body`).html() // fix for cheerio v1
+
+            return resolve(node)
+          })
+      )
+    ).then((htmlImageNodes) => markdownImageNodes.concat(htmlImageNodes).filter((node) => !!node))
+  )
+}

--- a/plugins/gatsby-remark-image-custom/package.json
+++ b/plugins/gatsby-remark-image-custom/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@bonobolabs/gatsby-remark-images-custom-widths",
+  "description": "gatsby-remark-images but with support for custom image widths",
+  "version": "0.0.7",
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "contributors": [
+    "Alex Louden <alex@louden.com>"
+  ],
+  "bugs": {
+    "url": "https://github.com/Bonobolabs/gatsby-remark-image-custom-widths/issues"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.7.2",
+    "chalk": "^2.4.2",
+    "cheerio": "^1.0.0-rc.3",
+    "is-relative-url": "^3.0.0",
+    "lodash": "^4.17.15",
+    "mdast-util-definitions": "^1.2.5",
+    "potrace": "^2.1.2",
+    "query-string": "^6.8.3",
+    "slash": "^3.0.0",
+    "unist-util-select": "^1.5.0",
+    "unist-util-visit-parents": "^2.1.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.7.0",
+    "@babel/core": "^7.7.2",
+    "babel-preset-gatsby-package": "^0.2.10",
+    "cross-env": "^5.2.1",
+    "hast-util-to-html": "^6.0.2",
+    "mdast-util-to-hast": "^6.0.2"
+  },
+  "homepage": "https://github.com/Bonobolabs/gatsby-remark-image-custom-widths",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "image",
+    "markdown",
+    "remark",
+    "responsive images"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "peerDependencies": {
+    "gatsby": "^4.0.0",
+    "gatsby-plugin-sharp": "^4.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-images"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore **/__tests__",
+    "prepare": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+  },
+  "engines": {
+    "node": ">=14.15.0"
+  }
+}

--- a/src/components/shortcodes/index.tsx
+++ b/src/components/shortcodes/index.tsx
@@ -43,11 +43,6 @@ const shortcodes = {
   TopBlock,
   FootNote,
   Admonition,
-  img: (props: any) => (
-    <a href={props.src} target="_blank">
-      <img {...props} />
-    </a>
-  ),
   AlgoliaTerm: () => <span style={{ display: 'none' }} />,
   Quiz,
   Tip: (props: any) => <Tip>{props.children}</Tip>,

--- a/src/components/shortcodes/index.tsx
+++ b/src/components/shortcodes/index.tsx
@@ -43,6 +43,14 @@ const shortcodes = {
   TopBlock,
   FootNote,
   Admonition,
+  img: (props: any) =>
+    /^https?:\/\//i.test(props.src) ? (
+      <a href={props.src} target="_blank">
+        <img {...props} />
+      </a>
+    ) : (
+      <img {...props} />
+    ),
   AlgoliaTerm: () => <span style={{ display: 'none' }} />,
   Quiz,
   Tip: (props: any) => <Tip>{props.children}</Tip>,


### PR DESCRIPTION
## Describe this PR

Custom image plugin for processing mdx images with the following additional features over `gatsby-remark-images` plugin
- Customise width of individual images:
   This can be done by using the `img` tag and adding a `width` attribute. Ex:
   ```
   <img
       src="../../../image-folder/image-name.png"
       alt="Alt for image"
       width="200px"
   />
  ```

  You can still use the mdx format for images in other cases: `![](../../../image-folder/image-name.png)`
- Clicking on the image will open it in full size 

## Changes
Removed the old `gatsby-remark-images` and created a custom plugin with the above features


## What issue does this fix?

Fixes #4344 

