### PR TITLE
Updated Code for instantiating single PrismaClient instance

### DIFF
--- a/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
@@ -89,25 +89,21 @@ As a workaround, you can store `PrismaClient` as a global variable in developmen
 ```ts file=client.ts
 import { PrismaClient } from '@prisma/client'
 
-// add prisma to the NodeJS global type
-interface CustomNodeJsGlobal extends NodeJS.Global {
-  prisma: PrismaClient
-}
+const globalForPrisma = global as unknown as { prisma: PrismaClient }
 
-// Prevent multiple instances of Prisma Client in development
-declare const global: CustomNodeJsGlobal
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: ['query'],
+  })
 
-const prisma = global.prisma || new PrismaClient()
-
-if (process.env.NODE_ENV === 'development') global.prisma = prisma
-
-export default prisma
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 ```
 
 The way that you import and use the client does not change:
 
 ```ts file=app.ts
-import prisma from './client'
+import { prisma } from './client'
 
 async function main() {
   const allUsers = await prisma.user.findMany()

--- a/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
@@ -92,8 +92,7 @@ import { PrismaClient } from '@prisma/client'
 const globalForPrisma = global as unknown as { prisma: PrismaClient }
 
 export const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient()
+  globalForPrisma.prisma || new PrismaClient()
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 ```

--- a/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
@@ -93,9 +93,7 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient }
 
 export const prisma =
   globalForPrisma.prisma ||
-  new PrismaClient({
-    log: ['query'],
-  })
+  new PrismaClient()
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 ```


### PR DESCRIPTION
## Describe this PR

The current code snippet was using outdated `NodeJS.Global` interface that was removed in Node version 16.
The new snippet is used from our related Help Article for the same topic: https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices

## Changes

Refactored code snippet

## What issue does this fix?

Fixes Outdated code snippet that doesn't work in node version > 16

