### PR TITLE
feat: update `binaryTargets` reference for Linux Alpine arm64

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -174,13 +174,14 @@ A `generator` block accepts the following fields:
 #### <inlinecode>binaryTargets</inlinecode> options
 
 The following tables list all supported operating systems with the name of platform to specify in [`binaryTargets`](/concepts/components/prisma-schema/generators#binary-targets).
+Unless specified otherwise, the default supported CPU architecture is x86_64.
 
 ##### macOS
 
-| Build OS        | Prisma engine build name |
-| :-------------- | :----------------------- |
-| macOS Intel x86 | `darwin`                 |
-| macOS ARM64     | `darwin-arm64`           |
+| Build OS           | Prisma engine build name |
+| :----------------- | :----------------------- |
+| macOS Intel x86_64 | `darwin`                 |
+| macOS ARM64        | `darwin-arm64`           |
 
 ##### Windows
 
@@ -188,9 +189,7 @@ The following tables list all supported operating systems with the name of platf
 | :------- | :----------------------- |
 | Windows  | `windows`                |
 
-##### Linux (Alpine)
-
-Currently supported for x86_64 only.
+##### Linux (Alpine on x86_64 architectures)
 
 | Build OS            | Prisma engine build name     | OpenSSL |
 | :------------------ | :--------------------------- | :-----: |
@@ -198,6 +197,15 @@ Currently supported for x86_64 only.
 | Alpine (until 3.16) | `linux-musl`                 |  1.1.x  |
 
 \* Available in Prisma versions 4.8.0 and later.
+
+##### Linux (Alpine on AMD64 architectures)
+
+| Build OS            | Prisma engine build name           | OpenSSL |
+| :------------------ | :--------------------------------- | :-----: |
+| Alpine (3.17+)      | `linux-musl-arm64-openssl-3.0.x`\* |  3.0.x  |
+| Alpine (until 3.16) | `linux-musl-arm64-openssl-1.1.x`\* |  1.1.x  |
+
+\* Available in Prisma versions 4.10.0 and later.
 
 ##### Linux (Debian)
 
@@ -250,7 +258,7 @@ Currently supported for x86_64 only.
 | :-------------------- | :----------------------- | :-----: |
 | Arch Linux 2019.09.01 | `debian-openssl-1.1.x`   |  1.1.x  |
 
-##### Linux ARM64
+##### Linux ARM64 (all major distros but Alpine)
 
 | Build OS                 | Prisma engine build name    | OpenSSL |
 | :----------------------- | :-------------------------- | :-----: |
@@ -619,7 +627,7 @@ True or false value.
 | ----------- | --------------- |
 | PostgreSQL  | `bigint`        |
 | SQL Server  | `int`           |
-| MySQL       | `BIGINT`        |
+| MySQL       | `INT`           |
 | MongoDB     | `Long`          |
 | SQLite      | `INTEGER`       |
 | CockroachDB | `INTEGER`       |
@@ -1185,12 +1193,12 @@ Defines a single-field ID on the model.
 
 #### Arguments
 
-| Name        | Required | Type      | Description                                                                                                                                                                                                                                                    |
-| ----------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `map`       | **No**   | `String`  | The name of the underlying primary key constraint in the database.<br /><br /> Not supported for MySQL or MongoDB.                                                                                                                                             |
-| `length`    | **No**   | `number`  | Allows you to specify a maximum length for the subpart of the value to be indexed.<br /><br />MySQL only. In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later.                                                     |
-| `sort`      | **No**   | `String`  | Allows you to specify in what order the entries of the ID are stored in the database. The available options are `Asc` and `Desc`.<br /><br />SQL Server only. In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later. |
-| `clustered` | **No**   | `Boolean` | Defines whether the ID is clustered or non-clustered. Defaults to `true`. <br /><br />SQL Server only. In preview in versions 3.13.0 and later, and in general availability in versions 4.0.0 and later.                                                       |
+| Name        | Required | Type      | Description                                                                                                                                                                                                                                   |
+| ----------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `map`       | **No**   | `String`  |                                                                                                                                                                                                                                               |
+| `length`    | **No**   | `number`  | Allows you to specify a maximum length for the subpart of the value to be indexed.<br /><br />MySQL only. In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later.                                    |
+| `sort`      | **No**   | `String`  | Allows you to specify in what order the entries of the ID are stored in the database. The available options are `Asc` and `Desc`.<br /><br />In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later. |
+| `clustered` | **No**   | `Boolean` | Defines whether the ID is clustered or non-clustered. Defaults to `true`. <br /><br />SQL Server only. In preview in versions 3.13.0 and later, and in general availability in versions 4.0.0 and later.                                      |     |
 
 #### Signature
 
@@ -1464,14 +1472,14 @@ Defines a multi-field ID (composite ID) on the model.
 
 #### Arguments
 
-| Name        | Required | Type               | Description                                                                                                                                                                                                                                                    |
-| ----------- | -------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fields`    | **Yes**  | `FieldReference[]` | A list of field names - for example, `["firstname", "lastname"]`                                                                                                                                                                                               |
-| `name`      | **No**   | `String`           | The name that the Client API will expose for the argument covering all fields, e.g. `fullName` in `fullName: { firstName: "First", lastName: "Last"}`                                                                                                          |
-| `map`       | **No**   | `String`           | The name of the underlying primary key constraint in the database.<br /><br />Not supported for MySQL.                                                                                                                                                         |
-| `length`    | **No**   | `number`           | Allows you to specify a maximum length for the subpart of the value to be indexed.<br /><br />MySQL only. In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later.                                                     |
-| `sort`      | **No**   | `String`           | Allows you to specify in what order the entries of the ID are stored in the database. The available options are `Asc` and `Desc`.<br /><br />SQL Server only. In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later. |
-| `clustered` | **No**   | `Boolean`          | Defines whether the ID is clustered or non-clustered. Defaults to `true`.<br /><br />SQL Server only. In preview in versions 3.13.0 and later, and in general availability in versions 4.0.0 and later.                                                        |
+| Name        | Required | Type               | Description                                                                                                                                                                                                                                   |
+| ----------- | -------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `fields`    | **Yes**  | `FieldReference[]` | A list of field names - for example, `["firstname", "lastname"]`                                                                                                                                                                              |
+| `name`      | **No**   | `String`           | The name that the Client API will expose for the argument covering all fields, e.g. `fullName` in `fullName: { firstName: "First", lastName: "Last"}`                                                                                         |
+| `map`       | **No**   | `String`           | The name of the underlying primary key constraint in the database                                                                                                                                                                             |
+| `length`    | **No**   | `number`           | Allows you to specify a maximum length for the subpart of the value to be indexed.<br /><br />MySQL only. In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later.                                    |
+| `sort`      | **No**   | `String`           | Allows you to specify in what order the entries of the ID are stored in the database. The available options are `Asc` and `Desc`.<br /><br />In preview in versions 3.5.0 and later, and in general availability in versions 4.0.0 and later. |
+| `clustered` | **No**   | `Boolean`          | Defines whether the ID is clustered or non-clustered. Defaults to `true`.<br /><br />SQL Server only. In preview in versions 3.13.0 and later, and in general availability in versions 4.0.0 and later.                                       |     |
 
 The name of the `fields` argument on the `@@id` attribute can be omitted:
 
@@ -2605,14 +2613,11 @@ Defines meta information about the relation. [Learn more](/concepts/components/p
 
 #### Arguments
 
-| Name         | Type                                                                                                                                                | Required                                                                                                                          | Description                                                                                                                                                                     | Example                                               |
-| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------------------------------------- |
-| `name`       | `String`                                                                                                                                            | Sometimes (e.g. to disambiguate a relation)                                                                                       | Defines the name of the relationship. In an m-n-relation, it also determines the name of the underlying relation table.                                                         | `"CategoryOnPost"`, `"MyRelation"`                    |
-| `fields`     | `FieldReference[]`                                                                                                                                  | On [annotated](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields) relation fields | A list of [fields](/concepts/components/prisma-schema/data-model#defining-fields) of the _current_ model                                                                        | `["authorId"]`, `["authorFirstName, authorLastName"]` |
-| `references` | `FieldReference[]`                                                                                                                                  | On [annotated](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields) relation fields | A list of [fields](/concepts/components/prisma-schema/data-model#defining-fields) of the model on _the other side of the relation_                                              | `["id"]`, `["firstName, lastName"]`                   |
-| `map`        | `String`                                                                                                                                            | No                                                                                                                                | Defines a [custom name](/concepts/components/prisma-schema/names-in-underlying-database#constraint-and-index-names) for the foreign key in the database.                        | `["id"]`, `["firstName, lastName"]`                   |
-| `onUpdate`   | Enum. See [Types of referential actions](/concepts/components/prisma-schema/relations/referential-actions#types-of-referential-actions) for values. | No                                                                                                                                | Defines the [referential action](/concepts/components/prisma-schema/relations/referential-actions) to perform when a referenced entry in the referenced model is being updated. | `Cascade`, `NoAction`                                 |
-| `onDelete`   | Enum. See [Types of referential actions](/concepts/components/prisma-schema/relations/referential-actions#types-of-referential-actions) for values. | No                                                                                                                                | Defines the [referential action](/concepts/components/prisma-schema/relations/referential-actions) to perform when a referenced entry in the referenced model is being deleted. | `Cascade`, `NoAction`                                 |
+| Name         | Type               | Required                                                                                                                          | Description                                                                                                                        | Example                                               |
+| :----------- | :----------------- | :-------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------- |
+| `name`       | `String`           | Sometimes (e.g. to disambiguate a relation)                                                                                       | Defines the name of the relationship. In an m-n-relation, it also determines the name of the underlying relation table.            | `"CategoryOnPost"`, `"MyRelation"`                    |
+| `fields`     | `FieldReference[]` | On [annotated](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields) relation fields | A list of [fields](/concepts/components/prisma-schema/data-model#defining-fields) of the _current_ model                           | `["authorId"]`, `["authorFirstName, authorLastName"]` |
+| `references` | `FieldReference[]` | On [annotated](/concepts/components/prisma-schema/relations#annotated-relation-fields-and-relation-scalar-fields) relation fields | A list of [fields](/concepts/components/prisma-schema/data-model#defining-fields) of the model on _the other side of the relation_ | `["id"]`, `["firstName, lastName"]`                   |
 
 The name of the `name` argument on the `@relation` attribute can be omitted (`references` is required):
 


### PR DESCRIPTION
## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

- update `binaryTargets`'s reference to reflect the newest Linux Alpine arm64 support
- specify that Prisma supports `x86_64` architectures by default

## What issue does this fix?

Contributes to https://github.com/prisma/prisma/issues/8478
