### PR TITLE
Adds the generate command's  --generator argument

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -444,7 +444,7 @@ Watching... /home/prismauser/prisma/prisma-play/prisma/schema.prisma
 
 </CodeWithResult>
 
-##### Run the `generate` command with a specific generator
+##### Run the `generate` command with only a specific generator
 
 ```terminal
 prisma generate --generator client

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -376,9 +376,10 @@ generator client {
 
 #### Arguments
 
-| Argument   | Required | Description                                                                                                                                         | Default                                     |
-| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `--schema` | No       | Specifies the path to the desired `schema.prisma` file to be processed instead of the default path. Both absolute and relative paths are supported. | `./schema.prisma`, `./prisma/schema.prisma` |
+| Argument      | Required | Description                                                                                                                                                                                  | Default                                     |     |
+| ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | --- |
+| `--schema`    | No       | Specifies the path to the desired `schema.prisma` file to be processed instead of the default path. Both absolute and relative paths are supported.                                          | `./schema.prisma`, `./prisma/schema.prisma` |     |
+| `--generator` | No       | Specifies which generator to use to generate assets. This option may be provided multiple times to include multiple generators. By default, all generators in the target schema will be run. |                                             |
 
 #### Examples
 
@@ -442,6 +443,18 @@ Watching... /home/prismauser/prisma/prisma-play/prisma/schema.prisma
 </cmdResult>
 
 </CodeWithResult>
+
+##### Run the `generate` command with a specific generator
+
+```terminal
+prisma generate --generator client
+```
+
+##### Run the `generate` command with multiple specific generators
+
+```terminal
+prisma generate --generator client --generator zod_schemas
+```
 
 #### Generated Assets
 


### PR DESCRIPTION
## Describe this PR

The Prisma CLI's `generate` command has a new argument name `--generator`. This PR should document that new argument and provide examples of how it can be used.

## What issue does this fix?

Fixes #4485 
