### PR TITLE
Update 03-fullstack.mdx: Wrong link for t3 stack in Supported Frameworks

### DIFF
--- a/content/200-concepts/050-overview/300-prisma-in-your-stack/03-fullstack.mdx
+++ b/content/200-concepts/050-overview/300-prisma-in-your-stack/03-fullstack.mdx
@@ -21,7 +21,7 @@ Here's a non-exhaustive list of frameworks and libraries you can use with Prisma
 - [Sveltekit](https://kit.svelte.dev/)
 - [Nuxt](https://nuxt.com/)
 - [Redwood](https://redwoodjs.com/)
-- [t3 stack — using tRPC](https://github.com/icflorescu/trpc-sveltekit)
+- [t3 stack — using tRPC](https://create.t3.gg/)
 
 ## Fullstack app example (e.g. Next.js)
 


### PR DESCRIPTION
## Describe this PR
The link for T3 stack at https://www.prisma.io/docs/concepts/overview/prisma-in-your-stack/fullstack#supported-frameworks is pointing to Sveltkit instead. Simply changing it to https://create.t3.gg/ instead. 
<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
