### PR TITLE
feat: remove references to introspection-engine and PRISMA_INTROSPECTION_ENGINE

### DIFF
--- a/content/200-concepts/100-components/08-prisma-engines/index.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/index.mdx
@@ -40,11 +40,6 @@ Use the following environment variables to specify custom locations for your bin
 - [`PRISMA_INTROSPECTION_ENGINE_BINARY`](/reference/api-reference/environment-variables-reference#prisma_introspection_engine_binary) <span class="api"></span> (Introspection engine)
 - [`PRISMA_FMT_BINARY`](/reference/api-reference/environment-variables-reference#prisma_fmt_binary) <span class="api"></span> (for `npx prisma format`)
 
-<Admonition type="warning">
-
-- The Introspection Engine is served by the Migration Engine from [4.9.0](https://github.com/prisma/prisma/releases/tag/4.9.0). Therefore, the `PRISMA_INTROSPECTION_ENGINE` environment variable will not be used.
-
-</Admonition>
 
 #### Setting the environment variable
 

--- a/content/200-concepts/100-components/08-prisma-engines/index.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/index.mdx
@@ -37,7 +37,14 @@ Use the following environment variables to specify custom locations for your bin
 - [`PRISMA_QUERY_ENGINE_LIBRARY`](/reference/api-reference/environment-variables-reference#prisma_query_engine_library) <span class="api"></span> (Query engine, library)
 - [`PRISMA_QUERY_ENGINE_BINARY`](/reference/api-reference/environment-variables-reference#prisma_query_engine_binary) <span class="api"></span> (Query engine, binary)
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](/reference/api-reference/environment-variables-reference#prisma_migration_engine_binary) <span class="api"></span> (Migration engine)
+- [`PRISMA_INTROSPECTION_ENGINE_BINARY`](/reference/api-reference/environment-variables-reference#prisma_introspection_engine_binary) <span class="api"></span> (Introspection engine)
 - [`PRISMA_FMT_BINARY`](/reference/api-reference/environment-variables-reference#prisma_fmt_binary) <span class="api"></span> (for `npx prisma format`)
+
+<Admonition type="warning">
+
+- The Introspection Engine is served by the Migration Engine from [4.9.0](https://github.com/prisma/prisma/releases/tag/4.9.0). Therefore, the `PRISMA_INTROSPECTION_ENGINE` environment variable will not be used.
+
+</Admonition>
 
 #### Setting the environment variable
 

--- a/content/200-concepts/100-components/08-prisma-engines/index.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/index.mdx
@@ -37,7 +37,6 @@ Use the following environment variables to specify custom locations for your bin
 - [`PRISMA_QUERY_ENGINE_LIBRARY`](/reference/api-reference/environment-variables-reference#prisma_query_engine_library) <span class="api"></span> (Query engine, library)
 - [`PRISMA_QUERY_ENGINE_BINARY`](/reference/api-reference/environment-variables-reference#prisma_query_engine_binary) <span class="api"></span> (Query engine, binary)
 - [`PRISMA_MIGRATION_ENGINE_BINARY`](/reference/api-reference/environment-variables-reference#prisma_migration_engine_binary) <span class="api"></span> (Migration engine)
-- [`PRISMA_INTROSPECTION_ENGINE_BINARY`](/reference/api-reference/environment-variables-reference#prisma_introspection_engine_binary) <span class="api"></span> (Introspection engine)
 - [`PRISMA_FMT_BINARY`](/reference/api-reference/environment-variables-reference#prisma_fmt_binary) <span class="api"></span> (for `npx prisma format`)
 
 #### Setting the environment variable

--- a/content/300-guides/050-database/880-troubleshooting-orm/050-creating-bug-reports.mdx
+++ b/content/300-guides/050-database/880-troubleshooting-orm/050-creating-bug-reports.mdx
@@ -133,7 +133,6 @@ prisma               : 2.22.0
 Current platform     : darwin
 Query Engine         : query-engine 60cc71d884972ab4e897f0277c4b84383dddaf6c (at ../../../../../.npm/_npx/31227/lib/node_modules/prisma/node_modules/@prisma/engines/query-engine-darwin)
 Migration Engine     : migration-engine-cli 60cc71d884972ab4e897f0277c4b84383dddaf6c (at ../../../../../.npm/_npx/31227/lib/node_modules/prisma/node_modules/@prisma/engines/migration-engine-darwin)
-Introspection Engine : introspection-core 60cc71d884972ab4e897f0277c4b84383dddaf6c (at ../../../../../.npm/_npx/31227/lib/node_modules/prisma/node_modules/@prisma/engines/introspection-engine-darwin)
 Format Binary        : prisma-fmt 60cc71d884972ab4e897f0277c4b84383dddaf6c (at ../../../../../.npm/_npx/31227/lib/node_modules/prisma/node_modules/@prisma/engines/prisma-fmt-darwin)
 Default Engines Hash : 60cc71d884972ab4e897f0277c4b84383dddaf6c
 Studio               : 0.379.0

--- a/content/300-guides/200-deployment/110-deployment-guides/800-use-prisma-with-serverless-framework.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/800-use-prisma-with-serverless-framework.mdx
@@ -175,7 +175,6 @@ Serverless: Copy prisma schema for app...
 Serverless: Generate prisma client for app...
 Serverless: Remove unused prisma engine:
 Serverless: - node_modules/.prisma/client/libquery_engine-darwin.dylib.node
-Serverless: - node_modules/@prisma/engines/introspection-engine-darwin
 Serverless: - node_modules/@prisma/engines/libquery_engine-darwin.dylib.node
 Serverless: - node_modules/@prisma/engines/migration-engine-darwin
 Serverless: - node_modules/@prisma/engines/prisma-fmt-darwin

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -142,7 +142,6 @@ prisma               : 2.21.0-dev.4
 Current platform     : windows
 Query Engine         : query-engine 2fb8f444d9cdf7c0beee7b041194b42d7a9ce1e6 (at C:\Users\veroh\AppData\Roaming\npm\node_modules\@prisma\cli\query-engine-windows.exe)
 Migration Engine     : migration-engine-cli 2fb8f444d9cdf7c0beee7b041194b42d7a9ce1e6 (at C:\Users\veroh\AppData\Roaming\npm\node_modules\@prisma\cli\migration-engine-windows.exe)
-Introspection Engine : introspection-core 2fb8f444d9cdf7c0beee7b041194b42d7a9ce1e6 (at C:\Users\veroh\AppData\Roaming\npm\node_modules\@prisma\cli\introspection-engine-windows.exe)
 Format Binary        : prisma-fmt 60ba6551f29b17d7d6ce479e5733c70d9c00860e (at node_modules\@prisma\engines\prisma-fmt-windows.exe)
 Default Engines Hash : 60ba6551f29b17d7d6ce479e5733c70d9c00860e
 Studio               : 0.365.0
@@ -173,7 +172,6 @@ prisma               : 2.21.0-dev.4
 Current platform     : windows
 Query Engine         : query-engine 2fb8f444d9cdf7c0beee7b041194b42d7a9ce1e6 (at C:\Users\veroh\AppData\Roaming\npm\node_modules\@prisma\cli\query-engine-windows.exe)
 Migration Engine     : migration-engine-cli 2fb8f444d9cdf7c0beee7b041194b42d7a9ce1e6 (at C:\Users\veroh\AppData\Roaming\npm\node_modules\@prisma\cli\migration-engine-windows.exe)
-Introspection Engine : introspection-core 2fb8f444d9cdf7c0beee7b041194b42d7a9ce1e6 (at C:\Users\veroh\AppData\Roaming\npm\node_modules\@prisma\cli\introspection-engine-windows.exe)
 Format Binary        : prisma-fmt 60ba6551f29b17d7d6ce479e5733c70d9c00860e (at node_modules\@prisma\engines\prisma-fmt-windows.exe)
 Default Engines Hash : 60ba6551f29b17d7d6ce479e5733c70d9c00860e
 Studio               : 0.365.0
@@ -205,7 +203,6 @@ Environment variables loaded from prisma\.env
   "current-platform": "windows",
   "query-engine": "query-engine 60ba6551f29b17d7d6ce479e5733c70d9c00860e (at node_modules\\@prisma\\engines\\query-engine-windows.exe)",
   "migration-engine": "migration-engine-cli 60ba6551f29b17d7d6ce479e5733c70d9c00860e (at node_modules\\@prisma\\engines\\migration-engine-windows.exe)",
-  "introspection-engine": "introspection-core 60ba6551f29b17d7d6ce479e5733c70d9c00860e (at node_modules\\@prisma\\engines\\introspection-engine-windows.exe)",
   "format-binary": "prisma-fmt 60ba6551f29b17d7d6ce479e5733c70d9c00860e (at node_modules\\@prisma\\engines\\prisma-fmt-windows.exe)",
   "default-engines-hash": "60ba6551f29b17d7d6ce479e5733c70d9c00860e",
   "studio": "0.365.0"

--- a/content/400-reference/200-api-reference/250-error-reference.mdx
+++ b/content/400-reference/200-api-reference/250-error-reference.mdx
@@ -412,7 +412,7 @@ Original error: {error_code}<br />
 
 "Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here about how to handle this: [https://pris.ly/d/migrate-no-direct-ddl](https://pris.ly/d/migrate-no-direct-ddl)"
 
-### <inlinecode>prisma db pull</inlinecode> (Introspection Engine)
+### <inlinecode>prisma db pull</inlinecode>
 
 #### <inlinecode>P4000</inlinecode>
 

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -178,6 +178,20 @@ Note: This can only have an effect if the engine type of CLI or Client are set t
 PRISMA_MIGRATION_ENGINE_BINARY=custom/my-migration-engine-unix
 ```
 
+#### <inlinecode>PRISMA_INTROSPECTION_ENGINE_BINARY</inlinecode>
+
+`PRISMA_INTROSPECTION_ENGINE_BINARY` is used to set a custom location for your own introspection engine binary.
+
+```env
+PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
+```
+
+<Admonition type="warning">
+
+- The Introspection Engine is served by the Migration Engine from [4.9.0](https://github.com/prisma/prisma/releases/tag/4.9.0). Therefore, the `PRISMA_INTROSPECTION_ENGINE` environment variable will not be used.
+
+</Admonition>
+
 #### <inlinecode>PRISMA_FMT_BINARY</inlinecode>
 
 `PRISMA_FMT_BINARY` is used to set a custom location for your own format engine binary.

--- a/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
+++ b/content/400-reference/200-api-reference/300-environment-variables-reference.mdx
@@ -178,14 +178,6 @@ Note: This can only have an effect if the engine type of CLI or Client are set t
 PRISMA_MIGRATION_ENGINE_BINARY=custom/my-migration-engine-unix
 ```
 
-#### <inlinecode>PRISMA_INTROSPECTION_ENGINE_BINARY</inlinecode>
-
-`PRISMA_INTROSPECTION_ENGINE_BINARY` is used to set a custom location for your own introspection engine binary.
-
-```env
-PRISMA_INTROSPECTION_ENGINE_BINARY=custom/my-introspection-engine-unix
-```
-
 #### <inlinecode>PRISMA_FMT_BINARY</inlinecode>
 
 `PRISMA_FMT_BINARY` is used to set a custom location for your own format engine binary.


### PR DESCRIPTION
DO NOT MERGE UNTIL `prisma@4.10.0` is ready to be released.

## Describe this PR

Follow-up for https://github.com/prisma/prisma/pull/17301.
We've stopped using the `introspection-engine` binary in `prisma@4.9.0-dev.*`. As a result, the `PRISMA_INTROSPECTION_ENGINE` environment variable is now ignored. I've also removed mentions to `introspection-engine` in the snippets reporting the output of `prisma version`.

## Changes

Remove references to `PRISMA_INTROSPECTION_ENGINE` and `introspection-engine`.

## What issue does this fix?

Contributes to https://github.com/prisma/prisma/issues/17300.
