### PR TITLE
docs: fix reference to postgresql docs of 'create role'

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -108,7 +108,7 @@ In order to create and delete the shadow database when using development command
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SQLite               | No special requirements.                                                                                                                                                                                              |
 | MySQL                | Database user must have `CREATE, ALTER, DROP, REFERENCES ON *.*` privileges                                                                                                                                           |
-| PostgreSQL           | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createdatabase.html))                                       |
+| PostgreSQL           | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createrole.html))                                       |
 | Microsoft SQL Server | The user must be a site admin or have the `SERVER` securable. See the [official documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine?view=sql-server-ver15). |
 
 > If you use a cloud-hosted database for development and can not use these permissions, see: [Cloud-hosted shadow databases](#cloud-hosted-shadow-databases-must-be-created-manually)


### PR DESCRIPTION
## Describe this PR
Fix reference link of create-role
<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

- Change the reference link to the docs of postgresql, from [sql-createdatabase.html](https://www.postgresql.org/docs/12/sql-createdatabase.html) to [sql-createrole.html](https://www.postgresql.org/docs/12/sql-createrole.html)

## What issue does this fix?

I think the reference link is supposed to point the create-role page, not create-database.
<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information
No
<!-- Add any other information you deem to be relevant to the PR -->
