### PR TITLE
Added missing @map("categories") attribute

### DIFF
--- a/content/300-guides/400-migrate-to-prisma/03-migrate-from-mongoose.mdx
+++ b/content/300-guides/400-migrate-to-prisma/03-migrate-from-mongoose.mdx
@@ -375,9 +375,9 @@ model posts {
   author       users  @relation(fields: [authorId], references: [id])
   authorId     String @map("author") @db.ObjectId
 
--  categories   String[] @db.ObjectId
-+  categories   categories[] @relation(fields: [categoryIds], references: [id])
-+  categoryIds String[]     @db.ObjectId
+-  categories  String[] @db.ObjectId
++  categories  categories[] @relation(fields: [categoryIds], references: [id])
++  categoryIds String[] @map("categories") @db.ObjectId
 }
 
 model users {


### PR DESCRIPTION
In the instructions of migrating a project from mongoose to prisma [here](https://www.prisma.io/docs/guides/migrate-to-prisma/migrate-from-mongoose#24-update-the-relations) in the Post <-> Category example, we mention add `@map("categories")` in the categoryIds field of posts model, but the code snippet doesn't reflect that.

## Describe this PR

Adds missing `@map("categories")` attribute

