### PR TITLE
Blogging platform schema example

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/04-data-model.mdx
@@ -52,13 +52,13 @@ model Post {
   published  Boolean    @default(false)
   author     User       @relation(fields: [authorId], references: [id])
   authorId   Int
-  categories Category[] @relation(references: [id])
+  categories Category[]
 }
 
 model Category {
   id    Int    @id @default(autoincrement())
   name  String
-  posts Post[] @relation(references: [id])
+  posts Post[]
 }
 
 enum Role {


### PR DESCRIPTION
Implicit many-to-many relation should not have references argument defined in relational databases

## Describe this PR

Adjusted code example in documentation for relational database in /prisma-schema/data-model .

## Changes

Removed @relation from the sample code where many-to-many relation is defined between Category and Post for a relational database

