### PR TITLE
Add tip about the satisfies operator

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/99-prisma-validator.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/99-prisma-validator.mdx
@@ -6,7 +6,9 @@ metaDescription: 'The Prisma validator is a utility function that takes a genera
 
 <TopBlock>
 
-> TIP! Are you using typescript 4.9 or later? Then you can use the `satisfies` operator instead of the prisma validator. This will avoid the (very small) run-time overhead introduced by the validator function. For a deeper explanation, see [this](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb) article.
+<Admonition type="tip">
+💡 Are you using typescript 4.9 or later? Then you can use the `satisfies` operator instead of the prisma validator. This will avoid the (very small) run-time overhead introduced by the validator function. For a deeper explanation, see [this](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb) article.
+</Admonition>
 
 The [`Prisma.validator`](/reference/api-reference/prisma-client-reference#prismavalidator) <span class="api"></span> is a utility function that takes a generated type and returns a type-safe object which adheres to the generated types model fields.
 

--- a/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/99-prisma-validator.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/99-prisma-validator.mdx
@@ -6,6 +6,8 @@ metaDescription: 'The Prisma validator is a utility function that takes a genera
 
 <TopBlock>
 
+> TIP! Are you using typescript 4.9 or later? Then you can use the `satisfies` operator instead of the prisma validator. This will avoid the (very small) run-time overhead introduced by the validator function. For a deeper explanation, see [this](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb) article.
+
 The [`Prisma.validator`](/reference/api-reference/prisma-client-reference#prismavalidator) <span class="api"></span> is a utility function that takes a generated type and returns a type-safe object which adheres to the generated types model fields.
 
 This page introduces the `Prisma.validator` and offers some motivations behind why you might choose to use it.


### PR DESCRIPTION
Add info that users might prefer satisfies instead of the validator function.

## Describe this PR
Changed the docs page about the `Prisma.validator`.
Added tip about using the satisfies operator instead of the validator function.

## Changes

Small "info box" at the top of the docs page

## What issue does this fix?

## Any other relevant information
At least for me, intellisense (vs code with a pnpm monorepe) does **NOT** work inside the validator function. This gives a somewhat cumbersome DX where i had to move the code outside to a normal
`const thingQuery: Prisma.ThingArgs = { ... }`
where i got intellisense to construct my query. Then I had to move the query object back into the validator function which narrowed the type for me. This back and forth felt really non-optimal. Trying to google the issue I stumbled upon the [blog post ](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb) about using satisfies instead. Using satisfies operator I get perfect intellisense **and** narrowed types. Hurray!