### PR TITLE
Fixes Incorrect Prisma version mentioned for directUrl

### DIFF
--- a/content/800-data-platform/050-data-proxy/700-prisma-cli-with-data-proxy.mdx
+++ b/content/800-data-platform/050-data-proxy/700-prisma-cli-with-data-proxy.mdx
@@ -11,7 +11,7 @@ Currently, you can only use [Prisma Client](/concepts/components/prisma-client) 
 
 When using Prisma CLI, you need a direct (non-Data Proxy) database connection if you apply schema changes to your database with [Prisma Migrate](/concepts/components/prisma-migrate/get-started) or [`db push`](/concepts/components/prisma-migrate/db-push), or if you [introspect](/concepts/components/introspection) your database. See [Prisma CLI commands that require a direct database connection](#prisma-cli-commands-that-require-a-direct-database-connection).
 
-In Prisma versions 4.9.0 and later, you can [set a direct database connection URL in your Prisma schema](#set-a-direct-database-connection-url-in-your-prisma-schema).
+In Prisma versions 4.10.0 and later, you can [set a direct database connection URL in your Prisma schema](#set-a-direct-database-connection-url-in-your-prisma-schema).
 
 In earlier versions, you must add an [environment variable](/guides/development-environment/environment-variables) with the direct database connection URL and overwrite the [`DATABASE_URL` environment variable](/guides/development-environment/environment-variables#example-set-the-database_url-environment-variable-in-an-env-file) when you need a direct connection.
 


### PR DESCRIPTION
directUrl was released in Prisma version 4.10.0 and not in 4.9.0. This PR mentions the correct version for directUrl.


