### PR TITLE
Just fixed an invalid link

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -232,7 +232,7 @@ model Customer {}
 
 Prisma supports formatting `.prisma` files automatically. There are two ways to format `.prisma` files:
 
-- Run the [`prisma format`](/reference/api-reference/command-reference#forma) <span class="api"></span> command.
+- Run the [`prisma format`](/reference/api-reference/command-reference#format) <span class="api"></span> command.
 - Install the [Prisma VS Code extension](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma) and invoke the [VS Code format action](https://code.visualstudio.com/docs/editor/codebasics#_formatting) - manually or on save.
 
 There are no configuration options - [formatting rules](#formatting-rules) are fixed (similar to Golang's `gofmt` but unlike Javascript's `prettier`):


### PR DESCRIPTION
## Describe this PR
the link to the format api section was missing `t` at the end.

```diff
- https://www.prisma.io/docs/reference/api-reference/command-reference#forma
+ https://www.prisma.io/docs/reference/api-reference/command-reference#format
```
https://user-images.githubusercontent.com/19385183/221333028-f292476f-0155-47f4-bff8-d961aa6207df.mov

## Changes
just added missing `t` at the end of the link.

## What issue does this fix?
invalid link in the doc