### PR TITLE
Missing `await` in Prisma's Sequelize comparison

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
+++ b/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
@@ -186,7 +186,7 @@ Sequelize [doesn't offer a dedicated API for relation filters](https://github.co
 Cursor-style pagination:
 
 ```ts
-const page = prisma.post.findMany({
+const page = await prisma.post.findMany({
   before: {
     id: 242,
   },
@@ -197,7 +197,7 @@ const page = prisma.post.findMany({
 Offset pagination:
 
 ```ts
-const cc = prisma.post.findMany({
+const cc = await prisma.post.findMany({
   skip: 200,
   first: 20,
 })

--- a/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
+++ b/content/200-concepts/300-more/400-comparisons/02-prisma-and-sequelize.mdx
@@ -301,7 +301,7 @@ await User.update({
 **Prisma**
 
 ```ts
-const user = prisma.user.delete({
+const user = await prisma.user.delete({
   where: {
     id: 10,
   },


### PR DESCRIPTION
## Slightly Inaccurate Documentation Example
The docs are missing an `await` for a `delete()`. [Here is the example with the missing `await`](https://www.prisma.io/docs/concepts/more/comparisons/prisma-and-sequelize#deleting-objects)


[Here is a correct example of `delete()` from elsewhere in the docs](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#delete-the-user-record-with-an-id-of-1):
![image](https://user-images.githubusercontent.com/43216761/221657068-f3167b4a-42b6-486d-98c9-fbc92b61217e.png)


## Changes
Added the missing `await` to the Markdown file.

## Any other relevant information

See links from description:
[Missing `await`](https://www.prisma.io/docs/concepts/more/comparisons/prisma-and-sequelize#deleting-objects)
[Correct usage](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#delete-the-user-record-with-an-id-of-1)