### PR TITLE
fix: remove ".ts" from import statement in Unit Testing guide

### DIFF
--- a/content/300-guides/150-testing/100-unit-testing.mdx
+++ b/content/300-guides/150-testing/100-unit-testing.mdx
@@ -268,7 +268,7 @@ The **_singleton_** example uses the singleton client instance to call the mock 
 <tab>
 
 ```ts
-import { createUser, updateUsername } from './src/functions-without-context.ts'
+import { createUser, updateUsername } from './src/functions-without-context'
 import { prismaMock } from './../singleton'
 
 test('should create new user ', async () => {


### PR DESCRIPTION


## Describe this PR

Doing `import { createUser, updateUsername } from '../functions-without-context.ts'` results into the following error error: 

`error TS2691: An import path cannot end with a '.ts' extension. Consider importing '../functions-without-context' instead.`

## Changes

Remove `.ts` from the import statement

## What issue does this fix?

Fixes #4557
