### PR TITLE
fix: unit test from Unit Testing guide failing to run 

### DIFF
--- a/content/300-guides/150-testing/100-unit-testing.mdx
+++ b/content/300-guides/150-testing/100-unit-testing.mdx
@@ -294,6 +294,7 @@ test('should update a users name ', async () => {
     id: 1,
     name: 'Rich Haines',
     email: 'hello@prisma.io',
+    acceptTermsAndConditions: true,
   }
 
   prismaMock.user.update.mockResolvedValue(user)
@@ -302,6 +303,7 @@ test('should update a users name ', async () => {
     id: 1,
     name: 'Rich Haines',
     email: 'hello@prisma.io',
+    acceptTermsAndConditions: true,
   })
 })
 


### PR DESCRIPTION
## Describe this PR

The guide at https://www.prisma.io/docs/guides/testing/unit-testing has with-singleton.ts, and attempting to run it results in error 
```Argument of type '{ id: number; name: string; email: string; }' is not assignable to parameter of type 'User | Prisma__UserClient<User, never>'.
      Property 'acceptTermsAndConditions' is missing in type '{ id: number; name: string; email: string; }' but required in type 'User'.

    29   prismaMock.user.update.mockResolvedValue(user)
                                                  ~~~~

      node_modules/.prisma/client/index.d.ts:21:3
        21   acceptTermsAndConditions: boolean
             ~~~~~~~~~~~~~~~~~~~~~~~~
        'acceptTermsAndConditions' is declared here.
``` 

## Changes

Included missing field acceptTermsAndConditions from type User.

Note that I'm a beginner at it, and just pull requesting what works to fix the issue. I'm not sure if this is a correct solution - although the tests do run afterwards successfully - this is only a proposition for the issue I presented.

## What issue does this fix?

Fixes https://github.com/prisma/docs/issues/4560
