### PR TITLE
Improve typescript types for prisma nextjs docs

### DIFF
--- a/content/300-guides/050-database/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/300-guides/050-database/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -23,10 +23,12 @@ The solution in this case is to instantiate a single instance `PrismaClient` and
 ```ts file=./db
 import { PrismaClient } from '@prisma/client'
 
-const globalForPrisma = global as unknown as { prisma: PrismaClient }
+const globalForPrisma = global as unknown as { 
+  prisma: PrismaClient | undefined 
+}
 
 export const prisma =
-  globalForPrisma.prisma ||
+  globalForPrisma.prisma ??
   new PrismaClient({
     log: ['query'],
   })


### PR DESCRIPTION
## Describe this PR

Improves the typescript types and operators in documentation to be more accurate.

This is because prior to instantiation, the global value for prisma is actually `undefined` as nothing has been instantiated.

## Changes

Add `undefined` to global type definition.

Replace `||` with `??`

## What issue does this fix?

[Link to issue](https://github.com/prisma/docs/issues/4566)

Addresses #4566 

## Any other relevant information
N/A