### PR TITLE
Fix CLI docs `migrate dev --create-only` example description

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -951,7 +951,7 @@ Apply all migrations, then create and apply any new migrations:
 prisma migrate dev
 ```
 
-Apply all migrations and create a new migration if there are schema changes, but do not apply it:
+Create a new migration if there are schema changes, but do not apply it:
 
 ```terminal
 prisma migrate dev --create-only


### PR DESCRIPTION
## Describe this PR

The **Prisma CLI Reference** docs are incorrect for the [`migrate dev --create-only` example](https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-dev);
the Docs state that using `--create-only` will "Apply all migrations", when it shouldn't (right?).

## Changes

* Remove incorrect "Apply all migrations..." text from `migrate dev --create-only` example

## What issue does this fix?

No specific issue for this, I went straight to fixing the inaccurate docs.

## Any other relevant information

N/A
