### PR TITLE
typo fix in cotent/400-reference/200-api-reference/050-prisma-client-reference#select

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1742,7 +1742,7 @@ const result = await prisma.user.findUnique({
 </cmdResult>
 </CodeWithResult>
 
-##### Select the `name` and `profileViews` fields of a multiple `User` records
+##### Select the `email` and `role` fields of a multiple `User` records
 
 <CodeWithResult>
 <cmd>


### PR DESCRIPTION
## Describe this PR
 
Typo fix.

## Changes

Select `name` and `profileViews` should be `email` and `role` as shown in the example below

## What issue does this fix?

doc

## Any other relevant information
