### PR TITLE
fix duplicate SEO titles and expand description

### DIFF
--- a/content/800-data-platform/12-troubleshooting/index.mdx
+++ b/content/800-data-platform/12-troubleshooting/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Troubleshooting'
-metaTitle: 'Troubleshooting'
-metaDescription: 'Troubleshooting'
+metaTitle: 'Troubleshooting | Prisma Data Platform'
+metaDescription: 'Learn about some issues you may run into with the Prisma Data Platform, what they mean, and how to solve them.'
 toc: true
 tocDepth: 3
 ---

--- a/content/800-data-platform/index.mdx
+++ b/content/800-data-platform/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Prisma Data Platform'
-metaTitle: 'Prisma Data Platform'
-metaDescription: 'Prisma Data Platform'
+metaTitle: 'Prisma Data Platform Documentation'
+metaDescription: 'Get started with the Prisma Data Platform with its official documentation, and learn more about its features with reference documentation, guides, and more.'
 earlyaccess: false
 staticLink: true
 toc: false


### PR DESCRIPTION


Fixing duplicate SEO titles on PDP pages and expanding the meta description beyond the page title. 


