### PR TITLE
fix: update code selected color

### DIFF
--- a/src/components/shortcodes/prism/index.css
+++ b/src/components/shortcodes/prism/index.css
@@ -40,7 +40,9 @@ pre[class*='language-'].is-terminal code {
 }
 
 code[class*='language-'].is-terminal::selection,
-pre[class*='language-'].is-terminal::selection {
+pre[class*='language-'].is-terminal::selection,
+code[class*='language-'].is-terminal ::selection,
+pre[class*='language-'].is-terminal ::selection {
   background-color: #a0aec0;
 }
 

--- a/src/components/shortcodes/prism/index.css
+++ b/src/components/shortcodes/prism/index.css
@@ -39,6 +39,11 @@ pre[class*='language-'].is-terminal code {
   color: var(--code-inline-bgd-color) !important;
 }
 
+code[class*='language-'].is-terminal::selection,
+pre[class*='language-'].is-terminal::selection {
+  background-color: #a0aec0;
+}
+
 .is-terminal .line-no {
   color: var(--header-btn-color) !important;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -12,7 +12,7 @@ body {
   /* Generic */
   --main-font-color: #1a202c;
   --main-bgd-color: #f7fafc;
-  --selection-bgd-color: #a0aec0;
+  --selection-bgd-color: #0c344b;
   --white-color: #ffffff;
   --link-color: #3182ce;
   --border-color: #e2e8f0;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -12,7 +12,7 @@ body {
   /* Generic */
   --main-font-color: #1a202c;
   --main-bgd-color: #f7fafc;
-  --selection-bgd-color: #0c344b;
+  --selection-bgd-color: #a0aec0;
   --white-color: #ffffff;
   --link-color: #3182ce;
   --border-color: #e2e8f0;
@@ -393,7 +393,6 @@ a.question::before {
     display: none;
   }
 }
-
 
 .gatsby-resp-image-wrapper {
   margin-left: inherit !important;


### PR DESCRIPTION
## Describe this PR

Code highlight on selection is not readable on dark mode.

## Changes

Update value for background color on selected state for `(pre|code)[class*='language-'].is-terminal`. Regular code blocks (i.e. not `is-terminal`) remain with the same selection highlight color.

from:

![](https://user-images.githubusercontent.com/3276261/142734025-69b60b6b-3dd9-4e04-94c0-c60de755b294.png)

to:

<img width="719" alt="Screenshot 2023-03-24 at 14 24 38" src="https://user-images.githubusercontent.com/14851246/227551626-b23698cd-2498-48a7-b73d-47395db4e926.png">

## What issue does this fix?

Fixes #2564 

## Any other relevant information

N/a
