### PR TITLE
Adds warning about skipDuplicates in MongoDB

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -266,6 +266,12 @@ const createMany = await prisma.user.createMany({
 
 </CodeWithResult>
 
+<Admonition type="warning">
+
+Note `skipDuplicates` is not supported when using MongoDB.
+
+</Admonition>
+
 `createMany` uses a single `INSERT INTO` statement with multiple values, which is generally more efficient than a separate `INSERT` per row:
 
 ```sql

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -268,7 +268,7 @@ const createMany = await prisma.user.createMany({
 
 <Admonition type="warning">
 
-Note `skipDuplicates` is not supported when using MongoDB.
+Note `skipDuplicates` is not supported when using MongoDB or SQLServer.
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1240,7 +1240,7 @@ const deleteUser = await prisma.user.delete({
 | Name              | Type                              | Required | Description                                                                                                                                                                                                                                                                   |
 | ----------------- | --------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `data`            | `Enumerable<UserCreateManyInput>` | **Yes**  | Wraps all the model fields in a type so that they can be provided when creating new records. It also includes relation fields which lets you perform (transactional) nested inserts. Fields that are marked as optional or have default values in the datamodel are optional. |
-| `skipDuplicates?` | `boolean`                         | No       | Do not insert records with unique fields or ID fields that already exist. Only supported by databases that support [`ON CONFLICT DO NOTHING`](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT).                                                           |
+| `skipDuplicates?` | `boolean`                         | No       | Do not insert records with unique fields or ID fields that already exist. Only supported by databases that support [`ON CONFLICT DO NOTHING`](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT). This includes MongoDB and SQLServer                       |
 
 #### Return type
 
@@ -1251,7 +1251,7 @@ const deleteUser = await prisma.user.delete({
 #### Remarks
 
 - `createMany` is not supported by SQLite.
-- The `skipDuplicates` option is not supported by MongoDB.
+- The `skipDuplicates` option is not supported by MongoDB and SQLServer.
 - You **cannot** create or connect relations - you cannot nest `create`, `createMany`, `connect`, `connectOrCreate` inside a top-level `createMany`
 - You can nest a [`createMany`](#createmany-1) inside an `update` or `create` query - for example, add a `User` and two `Post` records at the same time.
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1240,7 +1240,7 @@ const deleteUser = await prisma.user.delete({
 | Name              | Type                              | Required | Description                                                                                                                                                                                                                                                                   |
 | ----------------- | --------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `data`            | `Enumerable<UserCreateManyInput>` | **Yes**  | Wraps all the model fields in a type so that they can be provided when creating new records. It also includes relation fields which lets you perform (transactional) nested inserts. Fields that are marked as optional or have default values in the datamodel are optional. |
-| `skipDuplicates?` | `boolean`                         | No       | Do not insert records with unique fields or ID fields that already exist. Only supported by databases that support [`ON CONFLICT DO NOTHING`](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT). This includes MongoDB and SQLServer                       |
+| `skipDuplicates?` | `boolean`                         | No       | Do not insert records with unique fields or ID fields that already exist. Only supported by databases that support [`ON CONFLICT DO NOTHING`](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT). This excludes MongoDB and SQLServer                       |
 
 #### Return type
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1251,6 +1251,7 @@ const deleteUser = await prisma.user.delete({
 #### Remarks
 
 - `createMany` is not supported by SQLite.
+- The `skipDuplicates` option is not supported by MongoDB.
 - You **cannot** create or connect relations - you cannot nest `create`, `createMany`, `connect`, `connectOrCreate` inside a top-level `createMany`
 - You can nest a [`createMany`](#createmany-1) inside an `update` or `create` query - for example, add a `User` and two `Post` records at the same time.
 


### PR DESCRIPTION
Closes #4593 

This PR adds a note in the Prisma Client API reference and Prisma Client CRUD concepts page that `skipDuplicates` is not supported by MongoDB.