### PR TITLE
Removes OTEL error message

### DIFF
--- a/content/800-data-platform/050-data-proxy/900-considerations-limitations.mdx
+++ b/content/800-data-platform/050-data-proxy/900-considerations-limitations.mdx
@@ -15,7 +15,7 @@ We plan to expand the number of providers and regions. If we don't yet support a
 
 ### Recommended concurrent connections
 
-We recommend that you use a database that supports at least 20 concurrent connections. 
+We recommend that you use a database that supports at least 20 concurrent connections.
 
 You will probably not need to set a concurrency limit on AWS Lambda. If necessary, requests are queued until they can be processed.
 
@@ -23,7 +23,7 @@ For more information about configuring a maximum number of connections to the da
 
 ### Idle connections to the database
 
-The Data Proxy keeps several connection pools running to maintain open database connections even when your application does not run any queries. The connection pools and any remaining idle connections close after six minutes of inactivity (or when your application does not send any queries to the database). The number of idle connections to the database depends on the number of running connection pools at any point in time. 
+The Data Proxy keeps several connection pools running to maintain open database connections even when your application does not run any queries. The connection pools and any remaining idle connections close after six minutes of inactivity (or when your application does not send any queries to the database). The number of idle connections to the database depends on the number of running connection pools at any point in time.
 
 In each of the supported locations, the Data Proxy architecture includes multiple clusters that maintain idle connections to the database.
 
@@ -51,26 +51,23 @@ If you see `429` HTTP errors in your logs, this probably means that you hit the 
 
 ### Unsupported Prisma Client features
 
-#### Metrics and OpenTelemetry tracing preview features not supported
+#### Metrics preview feature not supported
 
-Data Proxy does not yet support the following Prisma Client preview features:
+Data Proxy does not yet support Prisma Client's [Metrics](/concepts/components/prisma-client/metrics) preview feature.
 
-- [Metrics](/concepts/components/prisma-client/metrics)
-- [OpenTelemetry tracing](/concepts/components/prisma-client/opentelemetry-tracing)
-
-To use the Data Proxy, you must first remove `metrics` and `tracing` from the `previewFeatures` section of your `schema.prisma` file.
+To use the Data Proxy, you must first remove `metrics` from the `previewFeatures` section of your `schema.prisma` file.
 
 For example:
 
 ```diff
    generator client {
      provider        = "prisma-client-js"
--     previewFeatures = ["metrics", "tracing"]
+-     previewFeatures = ["metrics"]
 +     previewFeatures = []
    }
 ```
 
-If you have one or more of the listed preview features enabled and you run `prisma generate --data-proxy`, the command shows an error.
+If you have the `metrics` preview feature enabled and you run `prisma generate --data-proxy`, the command shows an error.
 
 #### <inlinecode>$connect</inlinecode> and <inlinecode>$disconnect</inlinecode> not supported
 


### PR DESCRIPTION
Closes #4597

Removes mention of Open Telemetry being unusable in the section that says OTEL and Metrics are not able to be used with Data Proxy.