### PR TITLE
fix(should-you): link "make the right thing easy"

### DIFF
--- a/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
+++ b/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
@@ -57,7 +57,7 @@ No matter if you're a SQL newcomer or veteran, Prisma will give you a significan
 
 Here are a couple of the guiding principles and general practices we apply when designing and building our tools:
 
-- [make the right thing easy](https://lengstorf.com/right-thing-easy-thing/)
+- [make the right thing easy](https://www.jason.af/right-thing-easy-thing/)
 - [pit of success](https://blog.codinghorror.com/falling-into-the-pit-of-success/)
 - offer intelligent autocompletion where possible
 - build powerful editor extensions (e.g. for [VS Code](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma))


### PR DESCRIPTION
## Describe this PR 

The https://lengstorf.com domain redirects to https://jason.af, which broke the link to https://www.jason.af/right-thing-easy-thing/.

## Changes

- updated to use the new domain
