### PR TITLE
fix: typo `includeDeleted`

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/053-middleware/100-soft-delete-middleware.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-middleware/100-soft-delete-middleware.mdx
@@ -595,7 +595,7 @@ Number of SOFT deleted posts: 95
 
 ### Can I add a global <inlinecode>includeDeleted</inlinecode> to the <inlinecode>Post</inlinecode> model?
 
-You may be tempted to 'hack' your API by adding a `includedDeleted` property to the `Post` model and make the following query possible:
+You may be tempted to 'hack' your API by adding a `includeDeleted` property to the `Post` model and make the following query possible:
 
 ```ts
 prisma.post.findMany({ where: { includeDeleted: true } })


### PR DESCRIPTION
## Describe this PR
I found a typo on the docs. So I decided to fix it and open a PR.

## Changes
Fixed a typo: `includedDeleted => includeDeleted` at the end of the soft delete middleware page `100-soft-delete-middleware.mdx`.

## What issue does this fix?
The last paragraph on [Middleware Sample: Soft Delete(Reference)](https://www.prisma.io/docs/concepts/components/prisma-client/middleware/soft-delete-middleware#can-i-add-a-global-includedeleted-to-the-post-model)
