### PR TITLE
Update 100-connect-your-database.mdx

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
@@ -130,16 +130,6 @@ datasource db {
 }
 ```
 
-You will also need to [set the relation mode type to `prisma`](/concepts/components/prisma-schema/relations/relation-mode#emulate-relations-in-prisma-with-the-prisma-relation-mode) in the `datasource` block:
-
-```prisma file=schema.prisma highlight=4;add
-datasource db {
-  provider     = "mysql"
-  url          = env("DATABASE_URL")
-  relationMode = "prisma"
-}
-```
-
 The `url` is [set via an environment variable](/concepts/components/prisma-schema#accessing-environment-variables-from-the-schema) which is defined in `.env`:
 
 ```bash file=.env


### PR DESCRIPTION
## Describe this PR

`relationMode` attribute is no more required

## Changes

The `relationMode` attribute in the `datasource` is not required for version 4.12.0 onwards

