### PR TITLE
:cyclone: Move database deconnection to the finally block

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database.mdx
@@ -25,14 +25,14 @@ async function main() {
 }
 
 main()
-  .then(async () => {
-    await prisma.$disconnect()
-  })
-  .catch(async (e) => {
-    console.error(e)
-    await prisma.$disconnect()
-    process.exit(1)
-  })
+	.then(async () => {
+		console.log('Success');
+	})
+	.catch(async (e) => {
+		console.error(e);
+		process.exit(1);
+	})
+	.finally(async () => await prisma.$disconnect());
 ```
 
 </SwitchTech>
@@ -50,15 +50,16 @@ async function main() {
   // ... you will write your Prisma Client queries here
 }
 
+
 main()
-  .then(async () => {
-    await prisma.$disconnect()
-  })
-  .catch(async (e) => {
-    console.error(e)
-    await prisma.$disconnect()
-    process.exit(1)
-  })
+	.then(async () => {
+		console.log('Success');
+	})
+	.catch(async (e) => {
+		console.error(e);
+		process.exit(1);
+	})
+	.finally(async () => await prisma.$disconnect());
 ```
 
 </SwitchTech>


### PR DESCRIPTION
## Describe this PR

The purpose of this PR is to refactor the legacy code which disconnects the database twice : 

1 . In the `Success` phase of the promise.
2. In the `Failed` phase of the promise.

It is possible to set `await prisma.$disconnect()` in the `finally` block of the code you provided. This ensures that the connection to the database is always properly closed, regardless of whether the `then` or `catch` block is executed.

## Changes

I have added a new block `finally` and moved `prisma.$disconnect()` inside it.

### Before

```typescript
main()
  .then(async () => {
    await prisma.$disconnect()
  })
  .catch(async (e) => {
    console.error(e)
    await prisma.$disconnect()
    process.exit(1)
  })
```
### After

```typescript

main()
	.then(async () => {
		console.log('Success');
	})
	.catch(async (e) => {
		console.error(e);
		process.exit(1);
	})
	.finally(async () => await prisma.$disconnect());

```