### PR TITLE
fix: right-side toc

### DIFF
--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -59,6 +59,7 @@ const ListItem = styled.li<ItemProps>`
 const Headings = ({ headings, activeId, depth = 2 }: any) => {
   const isActive = (url: string) => url.replace(/inlinecode/g, '').slice(1) === activeId
   const isAnyChildActive = (children: any[]) => children.some((child: any) => isActive(child.url))
+  const finalDepth = depth ?? 2
   const navItems = (headings: any, activeId: any, depth: any) => (
     <HeadingList>
       {headings.map((heading: any) => (
@@ -77,7 +78,7 @@ const Headings = ({ headings, activeId, depth = 2 }: any) => {
       ))}
     </HeadingList>
   )
-  return navItems(headings, activeId, depth)
+  return navItems(headings, activeId, finalDepth)
 }
 
 const getIds = (headings: TableOfContents[], tocDepth: number) => {
@@ -120,7 +121,7 @@ const useIntersectionObserver = (setActiveId: any, idList: any[]) => {
         const sortedVisibleHeadings = visibleHeadings.sort(
           (a, b): any => getIndexFromId(a.target.id) > getIndexFromId(b.target.id)
         )
-
+        console.log(sortedVisibleHeadings)
         setActiveId(sortedVisibleHeadings[0].target.id)
       }
     }

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -121,7 +121,6 @@ const useIntersectionObserver = (setActiveId: any, idList: any[]) => {
         const sortedVisibleHeadings = visibleHeadings.sort(
           (a, b): any => getIndexFromId(a.target.id) > getIndexFromId(b.target.id)
         )
-        console.log(sortedVisibleHeadings)
         setActiveId(sortedVisibleHeadings[0].target.id)
       }
     }

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -56,10 +56,10 @@ const ListItem = styled.li<ItemProps>`
   }
 `
 
-const Headings = ({ headings, activeId, depth = 2 }: any) => {
+const Headings = ({ headings, activeId, depth = 1 }: any) => {
   const isActive = (url: string) => url?.replace(/inlinecode/g, '').slice(1) === activeId
   const isAnyChildActive = (children: any[]) => children.some((child: any) => isActive(child.url))
-  const finalDepth = depth ?? 2
+  const finalDepth = depth ?? 1
   const navItems = (headings: any, activeId: any, depth: any) => (
     <HeadingList>
       {headings.map((heading: any) => (

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -105,7 +105,7 @@ const useIntersectionObserver = (setActiveId: any, idList: any[], tocDepth: numb
       }, headingElementsRef.current)
 
       // Get all headings that are currently visible on the page
-      const visibleHeadings: any[] = []
+      let visibleHeadings: any[] = []
       Object.keys(headingElementsRef.current).forEach((key) => {
         const headingElement = headingElementsRef.current[key]
         if (headingElement.isIntersecting) visibleHeadings.push(headingElement)
@@ -113,17 +113,13 @@ const useIntersectionObserver = (setActiveId: any, idList: any[], tocDepth: numb
 
       const getIndexFromId = (id: any) => idList.findIndex((heading) => heading.id === id)
       // If there is only one visible heading, this is our "active" heading
-      if (
-        visibleHeadings.length === 1 &&
-        parseInt(visibleHeadings[0].target.tagName.charAt(1)) <= depth
-      ) {
+      visibleHeadings = visibleHeadings.filter((e) => parseInt(e.target.tagName.charAt(1)) <= depth)
+
+      if (visibleHeadings.length === 1) {
         setActiveId(visibleHeadings[0].target.id)
         // If there is more than one visible heading,
         // choose the one that is closest to the top of the page
-      } else if (
-        visibleHeadings.length > 1 &&
-        parseInt(visibleHeadings[0].target.tagName.charAt(1)) <= depth
-      ) {
+      } else if (visibleHeadings.length > 1) {
         const sortedVisibleHeadings = visibleHeadings.sort(
           (a, b): any => getIndexFromId(a.target.id) > getIndexFromId(b.target.id)
         )
@@ -148,6 +144,9 @@ const TOC = ({ headings, tocDepth }: any) => {
   const [activeId, setActiveId] = React.useState()
   const idList = getIds(headings, tocDepth || 2)
   useIntersectionObserver(setActiveId, idList, tocDepth)
+  React.useEffect(() => {
+    console.log(activeId)
+  }, [activeId])
   return (
     <nav aria-label="Table of contents">
       <ChapterTitle>ON THIS PAGE</ChapterTitle>

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -71,7 +71,7 @@ const Headings = ({ headings, activeId, depth = 1 }: any) => {
 
           {heading.items &&
             heading.items.length > 0 &&
-            depth > 1 &&
+            depth > 2 &&
             //isAnyChildActive(heading.items) &&
             navItems(heading.items, activeId, depth - 1)}
         </ListItem>
@@ -94,8 +94,9 @@ const getIds = (headings: TableOfContents[], tocDepth: number) => {
   }, [])
 }
 
-const useIntersectionObserver = (setActiveId: any, idList: any[]) => {
+const useIntersectionObserver = (setActiveId: any, idList: any[], tocDepth: number) => {
   const headingElementsRef: any = React.useRef({})
+  const depth = tocDepth ?? 2
   React.useEffect(() => {
     const callback = (headings: any) => {
       headingElementsRef.current = headings.reduce((map: any, headingElement: any) => {
@@ -111,13 +112,18 @@ const useIntersectionObserver = (setActiveId: any, idList: any[]) => {
       })
 
       const getIndexFromId = (id: any) => idList.findIndex((heading) => heading.id === id)
-
       // If there is only one visible heading, this is our "active" heading
-      if (visibleHeadings.length === 1) {
+      if (
+        visibleHeadings.length === 1 &&
+        parseInt(visibleHeadings[0].target.tagName.charAt(1)) <= depth
+      ) {
         setActiveId(visibleHeadings[0].target.id)
         // If there is more than one visible heading,
         // choose the one that is closest to the top of the page
-      } else if (visibleHeadings.length > 1) {
+      } else if (
+        visibleHeadings.length > 1 &&
+        parseInt(visibleHeadings[0].target.tagName.charAt(1)) <= depth
+      ) {
         const sortedVisibleHeadings = visibleHeadings.sort(
           (a, b): any => getIndexFromId(a.target.id) > getIndexFromId(b.target.id)
         )
@@ -141,7 +147,7 @@ const useIntersectionObserver = (setActiveId: any, idList: any[]) => {
 const TOC = ({ headings, tocDepth }: any) => {
   const [activeId, setActiveId] = React.useState()
   const idList = getIds(headings, tocDepth || 2)
-  useIntersectionObserver(setActiveId, idList)
+  useIntersectionObserver(setActiveId, idList, tocDepth)
   return (
     <nav aria-label="Table of contents">
       <ChapterTitle>ON THIS PAGE</ChapterTitle>

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -57,7 +57,7 @@ const ListItem = styled.li<ItemProps>`
 `
 
 const Headings = ({ headings, activeId, depth = 2 }: any) => {
-  const isActive = (url: string) => url.replace(/inlinecode/g, '').slice(1) === activeId
+  const isActive = (url: string) => url?.replace(/inlinecode/g, '').slice(1) === activeId
   const isAnyChildActive = (children: any[]) => children.some((child: any) => isActive(child.url))
   const finalDepth = depth ?? 2
   const navItems = (headings: any, activeId: any, depth: any) => (
@@ -65,7 +65,7 @@ const Headings = ({ headings, activeId, depth = 2 }: any) => {
       {headings.map((heading: any) => (
         <ListItem key={heading.url} isActive={isActive(heading.url)}>
           <a
-            href={`${heading.url.replace(/inlinecode/g, '')}`}
+            href={`${heading.url?.replace(/inlinecode/g, '')}`}
             dangerouslySetInnerHTML={{ __html: stringify(heading.title) }}
           />
 


### PR DESCRIPTION
## Describe this PR

TOC on the right was not highlighting the title for content correctly. This was due to the full depth of the items under the main heading not being displayed.

This PR fixes this ongoing issue for other pages. You can also observe this issue on pages such as: https://www.prisma.io/docs/concepts/components/prisma-schema, where you can see the "syntax" section gets un-highlighted as you go on the page.

## Changes

Update elements displayed on right-side TOC.

| before | after |
| ----- | ----- |
| <img width="979" alt="Screenshot 2023-04-06 at 15 13 51" src="https://user-images.githubusercontent.com/14851246/230404296-cf55a3ec-12c2-482c-b7fb-d893d3d462e5.png"> | <img width="970" alt="Screenshot 2023-04-06 at 15 13 03" src="https://user-images.githubusercontent.com/14851246/230403947-340f7c80-a37c-4f5b-8c9d-0075d2c22061.png"> | 

## What issue does this fix?

Fixes #4627 

## Any other relevant information

N/a
