### PR TITLE
Add note about using `upsert` as `findOrCreate`

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -789,7 +789,7 @@ From version 4.6.0, Prisma carries out upserts with database native SQL commands
 
 Prisma does not have a `findOrCreate` query. You can use `upsert` as a workaround. To make `upsert` behave like a `findOrCreate` method, provide an empty `update` parameter to `upsert`. 
 
-<Admonition type="info">
+<Admonition type="warning">
 
 A limitation to using `upsert` as a workaround for `findOrCreate` is that `upsert` will only accept unique model fields in the `where` condition. So it's not possible to use `upsert` to emulate `findOrCreate` if the `where` condition contains non-unique fields. 
 

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -787,6 +787,14 @@ From version 4.6.0, Prisma carries out upserts with database native SQL commands
 
 </Admonition>
 
+Prisma does not have a `findOrCreate` query. You can use `upsert` as a workaround. To make `upsert` behave like a `findOrCreate` method, provide an empty `update` parameter to `upsert`. 
+
+<Admonition type="info">
+
+A limitation to using `upsert` as a workaround for `findOrCreate` is that `upsert` will only accept unique model fields in the `where` condition. So it's not possible to use `upsert` to emulate `findOrCreate` if the `where` condition contains non-unique fields. 
+
+</Admonition>
+
 ### Update a number field
 
 Use [atomic number operations](/reference/api-reference/prisma-client-reference#atomic-number-operations) <span class="api"></span> to update a number field **based on its current value** - for example, increment or multiply. The following query increments the `views` and `likes` fields by `1`:


### PR DESCRIPTION

Adds a note about using `upsert` as a workaround for `findOrCreate`. 

Fixes #640
