### PR TITLE
Correct typo in name of `pnpm-workspace.yaml`

### DIFF
--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/425-nextjs-prisma-client-monorepo.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/425-nextjs-prisma-client-monorepo.mdx
@@ -40,7 +40,7 @@ Assume you have a monorepo with the following structure:
 │       │       └── test.js
 │       ├── next.config.js
 │       └── package.json
-├── pnpm-workspaces.yaml
+├── pnpm-workspace.yaml
 ├── package.json
 └── vercel.json
 ```


### PR DESCRIPTION
## Describe this PR

Typo fix for this page in the docs: https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-monorepo

## Changes

Change `pnpm-workspaces.yaml` to `pnpm-workspace.yaml`. As per the `pnpm` docs, this is the correct way to name it: https://pnpm.io/pnpm-workspace_yaml