### PR TITLE
fix: broken guide link in doc for `prototyping-schema-db-push`

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
@@ -44,7 +44,7 @@ See [Schema prototyping with `db push`](/guides/database/prototyping-schema-db-p
 
 ## Can I use Prisma Migrate and <inlinecode>db push</inlinecode> together?
 
-Yes, you can [use `db push` and Prisma Migrate together in your development workflow](/guides/database/prototyping-schema-db-push) <span class="guide"></span>. For example, you can:
+Yes, you can [use `db push` and Prisma Migrate together in your development workflow](/guides/migrate/prototyping-schema-db-push) <span class="guide"></span>. For example, you can:
 
 - Use `db push` to prototype a schema at the start of a project and initialize a migration history when you are happy with the first draft
 - Use `db push` to prototype a change to an existing schema, then run `prisma migrate dev` to generate a migration from your changes (you will be asked to reset)


### PR DESCRIPTION
This commit fixes a broken link that was leading to a 404-error page. Right-click action will redirect to a proper page but on-click leads to 404-error page.

## Describe this PR

 - `prototyping-schema-db-push` guide exists under migrate page but existing link in the current page leads to 404-error page.

## Changes

- updated working link

## What issue does this fix?

- redirects to correct guide page for on-click action.
