### PR TITLE
fix: add view keyword to prism-prisma.js

### DIFF
--- a/src/components/shortcodes/prism/prism-prisma.js
+++ b/src/components/shortcodes/prism/prism-prisma.js
@@ -1,7 +1,7 @@
 import Prism from 'prism-react-renderer/prism'
 ;(typeof global !== 'undefined' ? global : window).Prism = Prism
 Prism.languages.prisma = Prism.languages.extend('clike', {
-  keyword: /\b(?:datasource|enum|generator|model|type)\b/,
+  keyword: /\b(?:datasource|enum|generator|model|type|view)\b/,
   'type-class-name': /(\s+)[A-Z]\w+/, ///(\b)(\s+)[A-Z]\w+/
 })
 


### PR DESCRIPTION
Before 
https://www.prisma.io/docs/concepts/components/prisma-schema/views#add-views-to-your-prisma-schema
<img width="550" alt="Screenshot 2023-04-26 at 17 02 15" src="https://user-images.githubusercontent.com/1328733/234617998-d4cb0dbf-73e6-4022-ae66-1813a7d5fbeb.png">

After
<img width="553" alt="Screenshot 2023-04-26 at 17 09 35" src="https://user-images.githubusercontent.com/1328733/234620067-d5971dc7-7a1c-477b-b063-55fdffc0404a.png">
