### PR TITLE
Update Database Provider from heroku to supabase

### DIFF
--- a/content/400-reference/300-database-reference/02-connection-urls.mdx
+++ b/content/400-reference/300-database-reference/02-connection-urls.mdx
@@ -17,7 +17,7 @@ The connection URL is provided via the `url` field of a `datasource` block in yo
 - **Port**: The port on which your database server is running
 - **Database name**: The name of the database you want to use
 
-Make sure you have this information at hand when getting started with Prisma. If you don't have a database server running yet, you can either use a local SQLite database file (see the [Quickstart](/getting-started/quickstart)) or [setup a free PostgreSQL database on Heroku](https://dev.to/prisma/how-to-setup-a-free-postgresql-database-on-heroku-1dc1).
+Make sure you have this information at hand when getting started with Prisma. If you don't have a database server running yet, you can either use a local SQLite database file (see the [Quickstart](/getting-started/quickstart)) or [setup a free PostgreSQL database on Supabase](https://dev.to/prisma/set-up-a-free-postgresql-database-on-supabase-to-use-with-prisma-3pk6).
 
 </TopBlock>
 


### PR DESCRIPTION
Replacing Heroku free database with Supabase.
(Heroku no longer provides free database)

## What issue does this fix?

Fixes: 
- https://github.com/prisma/docs/issues/4699
