### PR TITLE
Updates database provider from Heroku to Supabase

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/250-deploying-to-koyeb.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/250-deploying-to-koyeb.mdx
@@ -28,7 +28,7 @@ The focus of this guide is showing how to deploy projects using Prisma to Koyeb.
 
 ## Prerequisites
 
-- Hosted PostgreSQL database and a URL from which it can be accessed, e.g. `postgresql://username:password@your_postgres_db.cloud.com/db_identifier` (you can use Heroku, which offers a [free plan](https://dev.to/prisma/how-to-setup-a-free-postgresql-database-on-heroku-1dc1)).
+- Hosted PostgreSQL database and a URL from which it can be accessed, e.g. `postgresql://username:password@your_postgres_db.cloud.com/db_identifier` (you can use Supabase, which offers a [free plan](https://dev.to/prisma/set-up-a-free-postgresql-database-on-supabase-to-use-with-prisma-3pk6)).
 - [GitHub](https://github.com) account with an empty public repository we will use to push the code.
 - [Koyeb](https://koyeb.com) account.
 - Node.js installed.


### PR DESCRIPTION
Replacing Heroku free database with Supabase.
(Heroku no longer provides free database)

## What issue does this fix?

Fixes:
- https://github.com/prisma/docs/issues/4699
