### PR TITLE
fix: add missing binary targets to the "Prisma schema reference" page

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -191,16 +191,18 @@ The following tables list all supported operating systems with the name of platf
 
 ##### Linux (Alpine)
 
-Currently supported for x86_64 only.
-
-| Build OS            | Prisma engine build name     | OpenSSL |
-| :------------------ | :--------------------------- | :-----: |
-| Alpine (3.17+)      | `linux-musl-openssl-3.0.x`\* |  3.0.x  |
-| Alpine (until 3.16) | `linux-musl`                 |  1.1.x  |
+| Build OS                        | Prisma engine build name             | OpenSSL |
+| :------------------------------ | :----------------------------------- | :-----: |
+| Alpine (3.16 and older), x86_64 | `linux-musl`                         |  1.1.x  |
+| Alpine (3.17 and newer), x86_64 | `linux-musl-openssl-3.0.x`\*         |  3.0.x  |
+| Alpine (3.16 and older), ARM64  | `linux-musl-arm64-openssl-1.1.x`\*\* |  1.1.x  |
+| Alpine (3.17 and newer), ARM64  | `linux-musl-arm64-openssl-3.0.x`\*\* |  3.0.x  |
 
 \* Available in Prisma versions 4.8.0 and later.
 
-##### Linux (Debian)
+\*\* Available in Prisma versions 4.10.0 and later.
+
+##### Linux (Debian), x86_64
 
 | Build OS             | Prisma engine build name | OpenSSL |
 | :------------------- | :----------------------- | :-----: |
@@ -208,8 +210,9 @@ Currently supported for x86_64 only.
 | Debian 9 (Stretch)   | `debian-openssl-1.1.x`   |  1.1.x  |
 | Debian 10 (Buster)   | `debian-openssl-1.1.x`   |  1.1.x  |
 | Debian 11 (Bullseye) | `debian-openssl-1.1.x`   |  1.1.x  |
+| Debian 12 (Bookworm) | `debian-openssl-3.0.x`   |  3.0.x  |
 
-##### Linux (Ubuntu)
+##### Linux (Ubuntu), x86_64
 
 | Build OS               | Prisma engine build name | OpenSSL |
 | :--------------------- | :----------------------- | :-----: |
@@ -220,15 +223,16 @@ Currently supported for x86_64 only.
 | Ubuntu 20.04 (focal)   | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 21.04 (hirsute) | `debian-openssl-1.1.x`   |  1.1.x  |
 | Ubuntu 22.04 (jammy)   | `debian-openssl-3.0.x`   |  3.0.x  |
+| Ubuntu 23.04 (lunar)   | `debian-openssl-3.0.x`   |  3.0.x  |
 
-##### Linux (CentOS)
+##### Linux (CentOS), x86_64
 
 | Build OS | Prisma engine build name | OpenSSL |
 | :------- | :----------------------- | :-----: |
 | CentOS 7 | `rhel-openssl-1.0.x`     |  1.0.x  |
-| CentOS   | `rhel-openssl-1.0.x`     |  1.0.x  |
+| CentOS 8 | `rhel-openssl-1.1.x`     |  1.1.x  |
 
-##### Linux (Fedora)
+##### Linux (Fedora), x86_64
 
 | Build OS  | Prisma engine build name | OpenSSL |
 | :-------- | :----------------------- | :-----: |
@@ -236,28 +240,32 @@ Currently supported for x86_64 only.
 | Fedora 29 | `rhel-openssl-1.1.x`     |  1.1.x  |
 | Fedora 30 | `rhel-openssl-1.1.x`     |  1.1.x  |
 | Fedora 36 | `rhel-openssl-3.0.x`     |  3.0.x  |
+| Fedora 37 | `rhel-openssl-3.0.x`     |  3.0.x  |
+| Fedora 38 | `rhel-openssl-3.0.x`     |  3.0.x  |
 
-##### Linux (Linux Mint)
+##### Linux (Linux Mint), x86_64
 
 | Build OS      | Prisma engine build name | OpenSSL |
 | :------------ | :----------------------- | :-----: |
 | Linux Mint 18 | `debian-openssl-1.0.x`   |  1.0.x  |
 | Linux Mint 19 | `debian-openssl-1.1.x`   |  1.1.x  |
+| Linux Mint 20 | `debian-openssl-1.1.x`   |  1.1.x  |
 | Linux Mint 21 | `debian-openssl-3.0.x`   |  3.0.x  |
 
-##### Linux (Arch Linux)
+##### Linux (Arch Linux), x86_64
 
 | Build OS              | Prisma engine build name | OpenSSL |
 | :-------------------- | :----------------------- | :-----: |
 | Arch Linux 2019.09.01 | `debian-openssl-1.1.x`   |  1.1.x  |
+| Arch Linux 2023.04.23 | `debian-openssl-3.0.x`   |  3.0.x  |
 
-##### Linux ARM64
+##### Linux (most distributions except Alpine), ARM64
 
-| Build OS                 | Prisma engine build name    | OpenSSL |
-| :----------------------- | :-------------------------- | :-----: |
-| Linux ARM64-based distro | `linux-arm64-openssl-1.0.x` |  1.0.x  |
-| Linux ARM64-based distro | `linux-arm64-openssl-1.1.x` |  1.1.x  |
-| Linux ARM64-based distro | `linux-arm64-openssl-3.0.x` |  3.0.x  |
+| Build OS                       | Prisma engine build name    | OpenSSL |
+| :----------------------------- | :-------------------------- | :-----: |
+| Linux ARM64 glibc-based distro | `linux-arm64-openssl-1.0.x` |  1.0.x  |
+| Linux ARM64 glibc-based distro | `linux-arm64-openssl-1.1.x` |  1.1.x  |
+| Linux ARM64 glibc-based distro | `linux-arm64-openssl-3.0.x` |  3.0.x  |
 
 ### Examples
 


### PR DESCRIPTION
## Describe this PR

This PR adds missing binary targets to the "`binaryTargets` options"
section of the "Prisma schema reference" page, and fixes incorrect or
outdated information.

Most of these tables will not be necessary anymore once we unify glibc
engines on x86_64 as well, but for now we have to maintain them while
they are here.

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

- Add missing `linux-musl-arm64-openssl-1.1.x` and
  `linux-musl-arm64-openssl-3.0.x` targets.
- Remove outdated comment about Alpine not being supported on ARM64.
- Adjust the "Linux ARM64" section accordingly to reflect that this
  binary target is only for glibc-based distros but not Alpine.
- Add the CPU architecture where appropriate.
- Fix incorrect entry in the CentOS section.
- Add missing entries to the rest of the sections.

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Closes: https://github.com/prisma/client-planning/issues/372

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
