### PR TITLE
Add indexes to the explicit relations example

### DIFF
--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/200-working-with-many-to-many-relations.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/200-working-with-many-to-many-relations.mdx
@@ -98,8 +98,7 @@ model PostTags {
   postId Int?
   tagId  Int?
   
-  @@index([postId])
-  @@index([tagId])
+  @@index([postId, tagId])
 }
 
 model Tag {

--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/200-working-with-many-to-many-relations.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/200-working-with-many-to-many-relations.mdx
@@ -97,6 +97,9 @@ model PostTags {
   tag    Tag?  @relation(fields: [tagId], references: [id])
   postId Int?
   tagId  Int?
+  
+  @@index([postId])
+  @@index([tagId])
 }
 
 model Tag {


### PR DESCRIPTION
It's a standard optimization to index the foreign keys on the explicit relations table, so I think it would be a good idea to improve the example by adding the indexes here. This is the only place I could find in the docs of an explicit relations example, so we should help newcomers see a perfect implementation of how to do it! What do you think? Perhaps a compound index is better here, but I didn't want to make too many assumptions, and maybe that's why indexes are left out of this example altogether. I do think it's better to have some type of index as opposed to none at all. 

## Describe this PR

Improving the documentation for many-to-many relations 

## Changes

Added indexes to the foreign keys in the explicit relations example 
