### PR TITLE
docs: add specific notes for serverless deployments when using Supabase

### DIFF
--- a/content/300-guides/050-database/880-supabase.mdx
+++ b/content/300-guides/050-database/880-supabase.mdx
@@ -31,14 +31,14 @@ Many aspects of using Prisma with Supabase are just like using Prisma with any o
 ## Specific considerations
 
 If you'd like to use the [connection pooling feature](https://supabase.com/docs/guides/integrations/prisma#connection-pooling-with-supabase) available with Supabase, you will
-need to add `pgbouncer=true` to the end of your `DATABASE_URL` string.
+need to add `pgbouncer=true` to the end of the `DATABASE_URL` environment variable used in the `datasource.url` property:
 
 ```env file=.env
 # Connect to Supabase with PgBouncer.
 DATABASE_URL="postgres://postgres:__PASSWORD__@db.__YOUR_SUPABASE_PROJECT__.supabase.co:6543/postgres?pgbouncer=true"
 ```
 
-If you would like to use the Prisma CLI in order to perform other actions on your database (e.g. migrations) you will need to add a `DIRECT_URL` string so that the CLI can bypass PgBouncer:
+If you would like to use the Prisma CLI in order to perform other actions on your database (e.g. migrations) you will need to add a `DIRECT_URL` environment variable to use in the `datasource.directUrl` property so that the CLI can bypass PgBouncer:
 
 ```env file=.env highlight=4-5;add
 # Connect to Supabase with PgBouncer.

--- a/content/300-guides/050-database/880-supabase.mdx
+++ b/content/300-guides/050-database/880-supabase.mdx
@@ -30,19 +30,27 @@ Many aspects of using Prisma with Supabase are just like using Prisma with any o
 
 ## Specific considerations
 
-If your application is being deployed to a serverless environment, make sure that you follow our general guidance on [connection pooling](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#recommended-connection-pool-size-1). Supabase makes this easy by [providing connection pooling](https://supabase.com/docs/guides/integrations/prisma#connection-pooling-with-supabase) compatible with PgBouncer.
-
-In short, you will need to update your Prisma schema to include `url` as well as `direct_url` as discussed [here](https://www.prisma.io/docs/data-platform/data-proxy/prisma-cli-with-data-proxy#set-a-direct-database-connection-url-in-your-prisma-schema). In addition, you will need to add `pgbouncer=true` to the end of your `DATABASE_URL` string.
+If you'd like to use the [connection pooling feature](https://supabase.com/docs/guides/integrations/prisma#connection-pooling-with-supabase) available with Supabase, you will
+need to add `pgbouncer=true` to the end of your `DATABASE_URL` string.
 
 ```env file=.env
-# Connection to Supabase with PgBouncer. Used by Prisma Client.
+# Connect to Supabase with PgBouncer.
+DATABASE_URL="postgres://postgres:__PASSWORD__@db.__YOUR_SUPABASE_PROJECT__.supabase.co:6543/postgres?pgbouncer=true"
+```
+
+If you would like to use the Prisma CLI in order to perform other actions on your database (e.g. migrations) you will need to add a `DIRECT_URL` string so that the CLI can bypass PgBouncer:
+
+```env file=.env highlight=4-5;add
+# Connect to Supabase with PgBouncer.
 DATABASE_URL="postgres://postgres:__PASSWORD__@db.__YOUR_SUPABASE_PROJECT__.supabase.co:6543/postgres?pgbouncer=true"
 
 # Direct connection to the database. Used for migrations.
 DIRECT_URL="postgres://postgres:__PASSWORD__@db.__YOUR SUPABASE_PROJECT__.supabase.co:5432/postgres"
 ```
 
-```prisma file=schema.prisma
+You can then update your `schema.prisma` to use the new direct URL:
+
+```prisma file=schema.prisma highlight=4;add
 datasource db {
   provider  = "postgresql"
   url       = env("DATABASE_URL")
@@ -50,8 +58,16 @@ datasource db {
 }
 ```
 
+More information about the `directUrl` field can be found [here](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#fields:~:text=the%20shadow%20database.-,directUrl,-No).
+
+<Admonition type="info">
+
+We strongly recommend using `pgbouncer` in addition to `DIRECT_URL`. You will gain the great developer experience of the Prisma CLI while also allowing for connections to be pooled regardless of deployment strategy. While this is not strictly necessary for every app, serverless solutions will inevitably require connection pooling.
+
+</Admonition>
+
 ## Getting started with Supabase
 
-Supabase has a great guide for connecting a database provided by Supabase to your Prisma project available [here](https://supabase.com/docs/guides/integrations/prisma).
+If you're interested in learning more, Supabase has a great guide for connecting a database provided by Supabase to your Prisma project available [here](https://supabase.com/docs/guides/integrations/prisma).
 
-If you're running into issues integrating with Supabase, check out these [specific troubleshooting tips](https://supabase.com/docs/guides/integrations/prisma#troubleshooting) or check out [Prisma's GitHub Discussions](https://github.com/prisma/prisma/discussions) for more help.
+If you're running into issues integrating with Supabase, check out these [specific troubleshooting tips](https://supabase.com/docs/guides/integrations/prisma#troubleshooting) or [Prisma's GitHub Discussions](https://github.com/prisma/prisma/discussions) for more help.

--- a/content/300-guides/050-database/880-supabase.mdx
+++ b/content/300-guides/050-database/880-supabase.mdx
@@ -28,6 +28,28 @@ Many aspects of using Prisma with Supabase are just like using Prisma with any o
 - use [`db push`](/concepts/components/prisma-migrate/db-push) to push changes in your schema to Supabase
 - use [Prisma Client](/concepts/components/prisma-client) in your application to talk to the database server at Supabase
 
+## Specific considerations
+
+If your application is being deployed to a serverless environment, make sure that you follow our general guidance on [connection pooling](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#recommended-connection-pool-size-1). Supabase makes this easy by [providing connection pooling](https://supabase.com/docs/guides/integrations/prisma#connection-pooling-with-supabase) compatible with PgBouncer.
+
+In short, you will need to update your Prisma schema to include `url` as well as `direct_url` as discussed [here](https://www.prisma.io/docs/data-platform/data-proxy/prisma-cli-with-data-proxy#set-a-direct-database-connection-url-in-your-prisma-schema). In addition, you will need to add `pgbouncer=true` to the end of your `DATABASE_URL` string.
+
+```env file=.env
+# Connection to Supabase with PgBouncer. Used by Prisma Client.
+DATABASE_URL="postgres://postgres:__PASSWORD__@db.__YOUR_SUPABASE_PROJECT__.supabase.co:6543/postgres?pgbouncer=true"
+
+# Direct connection to the database. Used for migrations.
+DIRECT_URL="postgres://postgres:__PASSWORD__@db.__YOUR SUPABASE_PROJECT__.supabase.co:5432/postgres"
+```
+
+```prisma file=schema.prisma
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+```
+
 ## Getting started with Supabase
 
 Supabase has a great guide for connecting a database provided by Supabase to your Prisma project available [here](https://supabase.com/docs/guides/integrations/prisma).


### PR DESCRIPTION
## Describe this PR

This adds a Supabase specific section on deployment to serverless envs. Notably, it calls out the need for `pgbouncer=true` to be appended to the end of the `DATABASE_URL` connection string.
