### PR TITLE
chore: update command `migrate diff` & `db execute` references

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -892,7 +892,7 @@ prisma db seed
 
 <Admonition type="info">
 
-The `db execute` command is generally available in versions 3.13.0 and later. It is available in preview in versions 3.9.0 and later using the `--preview-feature` CLI flag.
+The `db execute` command is Generally Available in versions 3.13.0 and later. If you're using a version before 3.13.0 and later than 3.9.0, it is available behind a `--preview-feature` CLI flag.
 
 </Admonition>
 
@@ -1186,7 +1186,7 @@ prisma migrate status
 
 <Admonition type="info">
 
-The `migrate diff` command is generally available in versions 3.13.0 and later. It is available in preview in versions 3.9.0 and later using the `--preview-feature` CLI flag.
+The `migrate diff` command is Generally Available in versions 3.13.0 and later. If you're using a version before 3.13.0 and later than 3.9.0, it is available behind a `--preview-feature` CLI flag.
 
 </Admonition>
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -892,7 +892,7 @@ prisma db seed
 
 <Admonition type="info">
 
-The `db execute` command is Generally Available in versions 3.13.0 and later. If you're using a version before 3.13.0 and later than 3.9.0, it is available behind a `--preview-feature` CLI flag.
+The `db execute` command is Generally Available in versions 3.13.0 and later. If you're using a version between 3.9.0 and 3.13.0, it is available behind a `--preview-feature` CLI flag.
 
 </Admonition>
 
@@ -1186,7 +1186,7 @@ prisma migrate status
 
 <Admonition type="info">
 
-The `migrate diff` command is Generally Available in versions 3.13.0 and later. If you're using a version before 3.13.0 and later than 3.9.0, it is available behind a `--preview-feature` CLI flag.
+The `migrate diff` command is Generally Available in versions 3.13.0 and later. If you're using a version between 3.9.0 and 3.13.0, it is available behind a `--preview-feature` CLI flag.
 
 </Admonition>
 


### PR DESCRIPTION
Clarify versions `migrate diff` and `db execute` are available