### PR TITLE
Update 10-postgresql-extensions.mdx

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/10-postgresql-extensions.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/10-postgresql-extensions.mdx
@@ -86,9 +86,11 @@ To [introspect](/concepts/components/introspection) PostgreSQL extensions curren
 Many PostgreSQL extensions are not relevant to the Prisma schema. For example, some extensions are intended for database administration tasks that do not change the schema. If all these extensions were included, the list of extensions would be very long. To avoid this, Prisma maintains an allowlist of known relevant extensions. The current allowlist is the following:
 
 - [`citext`](https://www.postgresql.org/docs/current/citext.html): provides a case-insensitive character string type, `citext`
-- [`pgcrypto`](https://www.postgresql.org/docs/current/pgcrypto.html): provides cryptographic functions
-- [`uuid-ossp`](https://www.postgresql.org/docs/current/uuid-ossp.html): provides functions, like `uuid_generate_v4()`, to generate universally unique identifiers (UUIDs)
+- [`pgcrypto`](https://www.postgresql.org/docs/current/pgcrypto.html): provides cryptographic functions, like `gen_random_uuid()`, to generate universally unique identifiers (UUIDs v4)
+- [`uuid-ossp`](https://www.postgresql.org/docs/current/uuid-ossp.html): provides functions, like `uuid_generate_v4()`, to generate universally unique identifiers (UUIDs v4)
 - [`postgis`](https://postgis.net/): adds GIS (Geographic Information Systems) support
+
+**Note**: Since PostgreSQL v13, `gen_random_uuid()` can be used without an extension to generate universally unique identifiers (UUIDs v4).
 
 Extensions are introspected as follows:
 


### PR DESCRIPTION
Document that PostgreSQL v13 and up don't need an extension for generating a UUID v4
