### PR TITLE
Update 200-shadow-database.mdx

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -125,7 +125,7 @@ Database error: Error querying the database: db error: ERROR: permission denied 
 To resolve this error:
 
 - If you are working locally, we recommend that you update the database user's privileges.
-- If you are developing against a cloud-based database (for example, on Heroku, Digital Ocean and Vercel Postgres) see: [Cloud-hosted shadow databases](#cloud-hosted-shadow-databases-must-be-created-manually).
-- If you are developing against a cloud-based database (for example, on Heroku, Digital Ocean and Vercel Postgres) and are currently **prototyping** such that you don't care about generated migration files and only need to apply your Prisma data model to the database schema, you can run [`prisma db push`](/reference/api-reference/command-reference#db) instead of the `prisma migrate dev` command.
+- If you are developing against a cloud-based database (for example, on Heroku, Digital Ocean, or Vercel Postgres) see: [Cloud-hosted shadow databases](#cloud-hosted-shadow-databases-must-be-created-manually).
+- If you are developing against a cloud-based database (for example, on Heroku, Digital Ocean, or Vercel Postgres) and are currently **prototyping** such that you don't care about generated migration files and only need to apply your Prisma data model to the database schema, you can run [`prisma db push`](/reference/api-reference/command-reference#db) instead of the `prisma migrate dev` command.
 
 > **Important**: The shadow database is _only_ required in a development environment (specifically for the `prisma migrate dev` command) - you **do not** need to make any changes to your production environment.

--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -125,7 +125,7 @@ Database error: Error querying the database: db error: ERROR: permission denied 
 To resolve this error:
 
 - If you are working locally, we recommend that you update the database user's privileges.
-- If you are developing against a cloud-based database (for example, on Heroku and Digital Ocean) see: [Cloud-hosted shadow databases](#cloud-hosted-shadow-databases-must-be-created-manually).
-- If you are developing against a cloud-based database (for example, on Heroku and Digital Ocean) and are currently **prototyping** such that you don't care about generated migration files and only need to apply your Prisma data model to the database schema, you can run [`prisma db push`](/reference/api-reference/command-reference#db) instead of the `prisma migrate dev` command.
+- If you are developing against a cloud-based database (for example, on Heroku, Digital Ocean and Vercel Postgres) see: [Cloud-hosted shadow databases](#cloud-hosted-shadow-databases-must-be-created-manually).
+- If you are developing against a cloud-based database (for example, on Heroku, Digital Ocean and Vercel Postgres) and are currently **prototyping** such that you don't care about generated migration files and only need to apply your Prisma data model to the database schema, you can run [`prisma db push`](/reference/api-reference/command-reference#db) instead of the `prisma migrate dev` command.
 
 > **Important**: The shadow database is _only_ required in a development environment (specifically for the `prisma migrate dev` command) - you **do not** need to make any changes to your production environment.


### PR DESCRIPTION
mention Vercel Postgres

Current error when using `migrate dev`
```
npx prisma migrate dev 
Environment variables loaded from prisma/.env
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database "verceldb", schema "public" at "ep-old-salad-510503.eu-central-1.postgres.vercel-storage.com:5432"

Error: P3014

Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. Read more about the shadow database (and workarounds) at https://pris.ly/d/migrate-shadow

Original error: 
db error: ERROR: permission denied to create database
   0: schema_core::state::DevDiagnostic
             at schema-engine/core/src/state.rs:266
```