### PR TITLE
Docs: Unaffected row highlighting instead of actual affected row

### DIFF
--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection.mdx
@@ -396,7 +396,7 @@ These changes are relevant for the generated Prisma Client API where using lower
 
 Because [relation fields](/concepts/components/prisma-schema/relations#relation-fields) are _virtual_ (i.e. they _do not directly manifest in the database_), you can manually rename them in your Prisma schema without touching the database:
 
-```prisma file=prisma/schema.prisma highlight=7,15,22,23;edit
+```prisma file=prisma/schema.prisma highlight=8,15,22,23;edit
 model Post {
   id        Int      @id @default(autoincrement())
   title     String   @db.VarChar(255)


### PR DESCRIPTION
## Describe this PR

In the introspection documents related to Typescript/Javascript for Postgres, after manual editing, the affected row is highlighted in the given example code. But for the Postgres example, it highlights the unaffected row instead of the affected row. The issue only exists for Postgresql.


## Changes
- Updated the line number that needed to be highlighted.

## Any other relevant information

The following shows the difference between the Postgres example and the MySQL example.
MySQL

![mysql](https://github.com/prisma/docs/assets/9814784/8dc53eac-512d-40fa-8e98-3636ae969df7)

Postgres

![postgress](https://github.com/prisma/docs/assets/9814784/cca31c92-92e1-4eaf-becd-d6c5d7f3c94e)

