### PR TITLE
fix: Find upper level heading of visible section

### DIFF
--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -129,6 +129,7 @@ const useIntersectionObserver = (
       const filteredVisible = visibleHeadings.filter(
         (e) => parseInt(e.target.tagName.charAt(1)) <= depth
       )
+
       if (visibleHeadings.length) {
         const visibleId = `#${visibleHeadings[0].target.id}`
         const firstH = allHeadings.filter((e: any, idx: number) =>
@@ -174,7 +175,6 @@ const TOC = ({ headings, tocDepth }: any) => {
   return (
     <nav aria-label="Table of contents">
       <ChapterTitle>ON THIS PAGE</ChapterTitle>
-      {activeId}
       <Headings headings={headings} activeId={activeId} depth={tocDepth} />
     </nav>
   )


### PR DESCRIPTION
## Describe this PR

The current way the TOC highlighting is structured does not identify for minor headings' placement. So as the default is 2, and the value of tocDepth is always minimum 2, we need to indentify _at least_ the second level heading containing a particular intersected section. 

For example: If we are located on a section under a `h4` element, the tocDepth defines that not only will it only show headings at least up to the `h2` level on the right, but it will not take into account any other headings, if they are intersecting. If we were to navigate to a section that is not included on the depth level of 2 or less, nothing would be highlighted on the right as the logic does not know which section that id belongs to.

So on a page like `/concepts/components/prisma-client/raw-database-access#tagged-template-helpers`, the visibleHeadings (before filtering based on tocDepth) and filteredVisible (after filtering) appear as such:

| visibleHeadings | filteredVisible | 
| ----- | ----- |
| <img width="500" alt="Screenshot 2023-05-26 at 16 24 24" src="https://github.com/prisma/docs/assets/14851246/0da10072-9789-4d7e-9d4c-3f2b3b1117c0"> | <img width="514" alt="Screenshot 2023-05-26 at 16 24 31" src="https://github.com/prisma/docs/assets/14851246/ee4e2c1f-7399-4c9f-8d35-80ad8e34403e"> |

The goal of this PR is to have a solution that finds the `visibleHeadings[0]`'s (index 0 as we favor the top-most visible section) upper-level heading up to the h2 level.

## Changes

Update toc's visibleHeadings logic.

| before | after |
| ----- | ----- |
| https://github.com/prisma/docs/assets/14851246/80677fb4-d732-416a-9200-fd5e30de1d0c | https://github.com/prisma/docs/assets/14851246/02ed14a8-60a1-45be-8aff-98891b92885b |

On the videos above you can see the difference on scrolling through a page (in this case, `/concepts/components/prisma-client/raw-database-access`)

## What issue does this fix?

Fixes #3955 

## Any other relevant information

N/a
