### PR TITLE
chore: convert active Preview features list into a table

### DIFF
--- a/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/050-client-preview-features.mdx
@@ -1,42 +1,45 @@
 ---
-title: Prisma Client and Prisma schema preview features
-metaDescription: Prisma Client and Prisma schema features that are currently in preview.
+title: Prisma Client and Prisma schema Preview features
+metaDescription: Prisma Client and Prisma schema features that are currently in Preview.
 ---
 
 <TopBlock>
 
-When we release a new Prisma Client or Prisma schema feature, it often starts in preview so that you can test it and submit your feedback. After we improve the feature with your feedback and are satisfied with the internal test results, we promote the feature to general availability.
+When we release a new Prisma Client or Prisma schema feature, it often starts in Preview so that you can test it and submit your feedback. After we improve the feature with your feedback and are satisfied with the internal test results, we promote the feature to general availability.
 
 For more information, see [ORM releases and maturity levels](/about/prisma/releases).
 
 </TopBlock>
 
-## Currently active preview features
+## Currently active Preview features
 
-The following [preview](/about/prisma/releases#preview) feature flags are available for Prisma Client and Prisma schema:
+The following [Preview](/about/prisma/releases#preview) feature flags are available for Prisma Client and Prisma schema:
 
-- [`fullTextSearch`](/concepts/components/prisma-client/full-text-search) since release [2.30.0](https://github.com/prisma/prisma/releases/tag/2.30.0) - [Submit feedback](https://github.com/prisma/prisma/issues/8877)
-- [`fullTextIndex`](/concepts/components/prisma-schema/indexes#full-text-indexes-mysql-and-mongodb) since release [3.6.0](https://github.com/prisma/prisma/releases/tag/3.6.0) - [Submit feedback](https://github.com/prisma/prisma/issues/10539)
-- [`metrics`](/concepts/components/prisma-client/metrics) since release [3.15.0](https://github.com/prisma/prisma/releases/tag/3.15.0) - [Submit feedback](https://github.com/prisma/prisma/issues/13579)
-- [`orderByNulls`](/concepts/components/prisma-client/filtering-and-sorting#sort-with-null-records-first-or-last) since release [4.1.0](https://github.com/prisma/prisma/releases/tag/4.1.0) - [Submit feedback](https://github.com/prisma/prisma/issues/14377)
-- [`tracing`](/concepts/components/prisma-client/opentelemetry-tracing) since release [4.2.0](https://github.com/prisma/prisma/releases/tag/4.2.0) - [Submit feedback](https://github.com/prisma/prisma/issues/14640)
-- [`filteredRelationCount`](/concepts/components/prisma-client/aggregation-grouping-summarizing#filter-the-relation-count) since release [4.3.0](https://github.com/prisma/prisma/releases/tag/4.3.0) - [Submit feedback](https://github.com/prisma/prisma/issues/15069)
-- [`fieldReference`](/reference/api-reference/prisma-client-reference#compare-columns-in-the-same-table) since release [4.3.0](https://github.com/prisma/prisma/releases/tag/4.3.0) - [Submit feedback](https://github.com/prisma/prisma/issues/15068)
-- [`multiSchema`](https://github.com/prisma/prisma/issues/1122#issuecomment-1231773471) since release [4.3.0](https://github.com/prisma/prisma/releases/tag/4.3.0) - [Submit feedback](https://github.com/prisma/prisma/issues/15077)
-- [`postgresqlExtensions`](/concepts/components/prisma-schema/postgresql-extensions) since release [4.5.0](https://github.com/prisma/prisma/releases/tag/4.5.0) - [Submit feedback](https://github.com/prisma/prisma/issues/15835)
-- [`deno`](/guides/deployment/deployment-guides/deploying-to-deno-deploy) since release [4.5.0](https://github.com/prisma/prisma/releases/tag/4.5.0) - [Submit feedback](https://github.com/prisma/prisma/issues/15844)
-- [`extendedWhereUnique`](/reference/api-reference/prisma-client-reference#filter-on-non-unique-fields-with-userwhereuniqueinput) since release [4.5.0](https://github.com/prisma/prisma/releases/tag/4.5.0) - [Submit feedback](https://github.com/prisma/prisma/issues/15837)
-- [`clientExtensions`](/concepts/components/prisma-client/client-extensions) since release [4.7.0](https://github.com/prisma/prisma/releases/tag/4.7.0) - [Submit feedback](https://github.com/prisma/prisma/issues/16500)
-- [`views`](/concepts/components/prisma-schema/views) since release [4.9.0](https://github.com/prisma/prisma/releases/tag/4.9.0) - [Submit feedback](https://github.com/prisma/prisma/issues/17335)
-- `jsonProtocol` since release [4.11.0](https://github.com/prisma/prisma/releases/tag/4.11.0) - [Submit feedback](https://github.com/prisma/prisma/issues/18095)
+| Feature                                                                                                                         | Released into Preview                                          |                          Feedback issue                          |
+| ------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------- | :--------------------------------------------------------------: |
+| [`fullTextSearch`](/concepts/components/prisma-client/full-text-search)                                                         | [2.30.0](https://github.com/prisma/prisma/releases/tag/2.30.0) | [Submit feedback](https://github.com/prisma/prisma/issues/10539) |
+| [`fullTextSearch`](/concepts/components/prisma-client/full-text-search)                                                         | [2.30.0](https://github.com/prisma/prisma/releases/tag/2.30.0) | [Submit feedback](https://github.com/prisma/prisma/issues/8877)  |
+| [`fullTextIndex`](/concepts/components/prisma-schema/indexes#full-text-indexes-mysql-and-mongodb)                               | [3.6.0](https://github.com/prisma/prisma/releases/tag/3.6.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/10539) |
+| [`metrics`](/concepts/components/prisma-client/metrics)                                                                         | [3.15.0](https://github.com/prisma/prisma/releases/tag/3.15.0) | [Submit feedback](https://github.com/prisma/prisma/issues/13579) |
+| [`orderByNulls`](/concepts/components/prisma-client/filtering-and-sorting#sort-with-null-records-first-or-last)                 | [4.1.0](https://github.com/prisma/prisma/releases/tag/4.1.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/14377) |
+| [`tracing`](/concepts/components/prisma-client/opentelemetry-tracing)                                                           | [4.2.0](https://github.com/prisma/prisma/releases/tag/4.2.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/14640) |
+| [`filteredRelationCount`](/concepts/components/prisma-client/aggregation-grouping-summarizing#filter-the-relation-count)        | [4.3.0](https://github.com/prisma/prisma/releases/tag/4.3.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/15069) |
+| [`fieldReference`](/reference/api-reference/prisma-client-reference#compare-columns-in-the-same-table)                          | [4.3.0](https://github.com/prisma/prisma/releases/tag/4.3.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/15068) |
+| [`multiSchema`](https://github.com/prisma/prisma/issues/1122#issuecomment-1231773471)                                           | [4.3.0](https://github.com/prisma/prisma/releases/tag/4.3.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/15077) |
+| [`postgresqlExtensions`](/concepts/components/prisma-schema/postgresql-extensions)                                              | [4.5.0](https://github.com/prisma/prisma/releases/tag/4.5.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/15835) |
+| [`deno`](/guides/deployment/deployment-guides/deploying-to-deno-deploy)                                                         | [4.5.0](https://github.com/prisma/prisma/releases/tag/4.5.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/15844) |
+| [`extendedWhereUnique`](/reference/api-reference/prisma-client-reference#filter-on-non-unique-fields-with-userwhereuniqueinput) | [4.5.0](https://github.com/prisma/prisma/releases/tag/4.5.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/15837) |
+| [`clientExtensions`](/concepts/components/prisma-client/client-extensions)                                                      | [4.7.0](https://github.com/prisma/prisma/releases/tag/4.7.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/16500) |
+| [`views`](/concepts/components/prisma-schema/views)                                                                             | [4.9.0](https://github.com/prisma/prisma/releases/tag/4.9.0)   | [Submit feedback](https://github.com/prisma/prisma/issues/17335) |
+| `jsonProtocol`                                                                                                                  | [4.11.0](https://github.com/prisma/prisma/releases/tag/4.11.0) | [Submit feedback](https://github.com/prisma/prisma/issues/18095) |
 
-To enable a preview feature, [add the feature flag to the `generator` block](#enabling-a-prisma-client-preview-feature) in your `schema.prisma` file. [Share your feedback on all preview features on GitHub](https://github.com/prisma/prisma/issues/3108).
+To enable a Preview feature, [add the feature flag to the `generator` block](#enabling-a-prisma-client-preview-feature) in your `schema.prisma` file. [Share your feedback on all Preview features on GitHub](https://github.com/prisma/prisma/issues/3108).
 
-## Enabling a Prisma Client preview feature
+## Enabling a Prisma Client Preview feature
 
-To enable a Prisma Client preview feature:
+To enable a Prisma Client Preview feature:
 
-1. Add the preview feature flag to the `generator` block:
+1. Add the Preview feature flag to the `generator` block:
 
    ```prisma
    generator client {
@@ -51,13 +54,13 @@ To enable a Prisma Client preview feature:
    npx prisma generate
    ```
 
-3. If you are using Visual Studio Code and the preview feature is not available in your `.ts` file after generating Prisma Client, run the **TypeScript: Restart TS server** command.
+3. If you are using Visual Studio Code and the Preview feature is not available in your `.ts` file after generating Prisma Client, run the **TypeScript: Restart TS server** command.
 
 ## Preview features promoted to general availability
 
-In the list below, you can find a history of Prisma Client and Prisma schema features that were in preview and are now in general availability. The features are sorted by the most recent version in which they were promoted to general availability.
+In the list below, you can find a history of Prisma Client and Prisma schema features that were in Preview and are now in general availability. The features are sorted by the most recent version in which they were promoted to general availability.
 
-| Feature                                                                                                                            | Released in preview                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |                Released in general availability                |
+| Feature                                                                                                                            | Released into Preview                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |               Released into General Availability               |
 | ---------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------: |
 | [`referentialIntegrity`](/concepts/components/prisma-schema/relations/relation-mode)                                               | [3.1.1](https://github.com/prisma/prisma/releases/tag/3.1.1)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |  [4.7.0](https://github.com/prisma/prisma/releases/tag/4.7.0)  |
 | [`interactiveTransactions`](/concepts/components/prisma-client/transactions#interactive-transactions)                              | <ul><li>[2.29.0](https://github.com/prisma/prisma/releases/tag/2.29.0)</li><li>with Data Proxy [4.6.0](https://github.com/prisma/prisma/releases/tag/4.6.0)</li></ul>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |  [4.7.0](https://github.com/prisma/prisma/releases/tag/4.7.0)  |

--- a/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
+++ b/content/200-concepts/100-components/250-preview-features/080-cli-preview-features.mdx
@@ -1,18 +1,18 @@
 ---
-title: Prisma CLI preview features
-metaDescription: Prisma CLI features that are currently in preview.
+title: Prisma CLI Preview features
+metaDescription: Prisma CLI features that are currently in Preview.
 tocDepth: 3
 ---
 
 <TopBlock>
 
-When we release a new Prisma CLI feature, it often starts in preview so that you can test it and submit your feedback. After we improve the feature with your feedback and are satisfied with the internal test results, we promote the feature to general availability.
+When we release a new Prisma CLI feature, it often starts in Preview so that you can test it and submit your feedback. After we improve the feature with your feedback and are satisfied with the internal test results, we promote the feature to general availability.
 
 For more information, see [ORM releases and maturity levels](/about/prisma/releases).
 
 </TopBlock>
 
-## Currently active preview features
+## Currently active Preview features
 
 There are currently no [Preview](/about/prisma/releases#preview) features for Prisma CLI.
 
@@ -24,7 +24,7 @@ The following [Preview](/about/prisma/releases#preview) CLI features are availab
 
 </TopBlock>
 
-## Enabling a Prisma Client preview feature
+## Enabling a Prisma Client Preview feature
 
 To enable a CLI Preview feature, use the `--preview-feature` flag when you run the command.
 
@@ -32,9 +32,9 @@ To enable a CLI Preview feature, use the `--preview-feature` flag when you run t
 
 ## Preview features promoted to general availability
 
-In the list below, you can find a history of Prisma CLI features that were in preview and are now in general availability. The features are sorted by the most recent version in which they were promoted to general availability.
+In the list below, you can find a history of Prisma CLI features that were in Preview and are now in general availability. The features are sorted by the most recent version in which they were promoted to general availability.
 
-| Features                                                                                                                      | Released in preview                                            | Released in general availability                               |
+| Features                                                                                                                      | Released in Preview                                            | Released in general availability                               |
 | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------- |
 | [`prisma migrate diff`](/guides/migrate/production-troubleshooting#fixing-failed-migrations-with-migrate-diff-and-db-execute) | [3.9.0](https://github.com/prisma/prisma/releases/tag/3.9.0)   | [3.13.0](https://github.com/prisma/prisma/releases/tag/3.13.0) |
 | [`prisma db execute`](/guides/migrate/production-troubleshooting#fixing-failed-migrations-with-migrate-diff-and-db-execute)   | [3.9.0](https://github.com/prisma/prisma/releases/tag/3.9.0)   | [3.13.0](https://github.com/prisma/prisma/releases/tag/3.13.0) |


### PR DESCRIPTION
This PR improves the aesthetic presentation of the active Preview features. We intend to add an external link icon for external links in the near future. Some spacing between the external links, in list of active Preview features, helps in making it less overwhelming (with the external link + icons)
Related PR:https://github.com/prisma/docs/pull/4611

Current:
<img width="508" alt="CleanShot 2023-05-31 at 22 48 04@2x" src="https://github.com/prisma/docs/assets/33921841/cd9879f2-5e45-4619-acfd-a0bf5fc3e083">


New:

<img width="503" alt="CleanShot 2023-05-31 at 22 46 41@2x" src="https://github.com/prisma/docs/assets/33921841/dc42f7df-6c0c-4162-9cf1-63589f0ac039">
