### PR TITLE
Use globalThis instead of global

### DIFF
--- a/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
@@ -96,7 +96,7 @@ As a workaround, you can store `PrismaClient` as a global variable in developmen
 ```ts file=client.ts
 import { PrismaClient } from '@prisma/client'
 
-const globalForPrisma = global as unknown as { prisma: PrismaClient }
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient }
 
 export const prisma =
   globalForPrisma.prisma || new PrismaClient()

--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -18,12 +18,12 @@ In development, the command `next dev` clears Node.js cache on run. This in turn
 
 ## Solution
 
-The solution in this case is to instantiate a single instance `PrismaClient` and save it on the [`global`](https://nodejs.org/api/globals.html#globals_global) object. Then we keep a check to only instantiate `PrismaClient` if it's not on the `global` object otherwise use the same instance again if already present to prevent instantiating extra `PrismaClient` instances.
+The solution in this case is to instantiate a single instance `PrismaClient` and save it on the [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) object. Then we keep a check to only instantiate `PrismaClient` if it's not on the `globalThis` object otherwise use the same instance again if already present to prevent instantiating extra `PrismaClient` instances.
 
 ```ts file=./db
 import { PrismaClient } from '@prisma/client'
 
-const globalForPrisma = global as unknown as {
+const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 


### PR DESCRIPTION
Node's `global` object is deprecated - we should use `globalThis` instead, [as instructed in the NodeJS docs](https://nodejs.org/api/globals.html#global). 

This also fixes things to work as intended when testing locally under the Vercel Edge runtime (which doesn't support `global`).