### PR TITLE
fix(client-reference): JSON => Json

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -5037,7 +5037,7 @@ const updatePosts = await prisma.post.updateMany({
 })
 ```
 
-## <inlinecode>JSON</inlinecode> filters
+## <inlinecode>Json</inlinecode> filters
 
 For use cases and advanced examples, see: [Working with `Json` fields](/concepts/components/prisma-client/working-with-fields/working-with-json-fields) <span class="concepts"></span>
 
@@ -5071,7 +5071,7 @@ The examples in this section assumes that the value of the `pet` field is:
 
 ### Remarks
 
-- The implementation of JSON filtering [differs between database connectors](/concepts/components/prisma-client/working-with-fields/working-with-json-fields)
+- The implementation of `Json` filtering [differs between database connectors](/concepts/components/prisma-client/working-with-fields/working-with-json-fields)
 - Filtering is case sensitive in PostgreSQL and does not yet support `mode`
 
 ### <inlinecode>path</inlinecode>


### PR DESCRIPTION
The filters are about our `Json` type, not `JSON` data in general.