### PR TITLE
Fix incorrect TypeORM reference in the Sequelize migration docs

### DIFF
--- a/content/300-guides/400-migrate-to-prisma/02-migrate-from-sequelize.mdx
+++ b/content/300-guides/400-migrate-to-prisma/02-migrate-from-sequelize.mdx
@@ -1134,7 +1134,7 @@ model User {
 
 ### Implicit many-to-many relations
 
-Similar to the `belongsToMany()` association method in Sequelize, Prisma allows you to [model many-to-many relations _implicitly_](/concepts/components/prisma-schema/relations#implicit-vs-explicit-many-to-many-relations). That is, a many-to-many relation where you do not have to manage the [relation table](/concepts/components/prisma-schema/relations/many-to-many-relations#relation-tables) (also sometimes called JOIN table) _explicitly_ in your schema. Here is an example with TypeORM:
+Similar to the `belongsToMany()` association method in Sequelize, Prisma allows you to [model many-to-many relations _implicitly_](/concepts/components/prisma-schema/relations#implicit-vs-explicit-many-to-many-relations). That is, a many-to-many relation where you do not have to manage the [relation table](/concepts/components/prisma-schema/relations/many-to-many-relations#relation-tables) (also sometimes called JOIN table) _explicitly_ in your schema. Here is an example with Sequelize:
 
 ```js
 module.exports = (sequelize, DataTypes) => {


### PR DESCRIPTION
## Describe this PR

When going through the Sequelize migration docs, I noticed an incorrect reference to TypeORM. This PR updates the reference to correctly point to Sequelize.

## Changes

Update "TypeORM" -> "Sequelize"

## What issue does this fix?

N/A

## Any other relevant information

N/A
