### PR TITLE
fix(filtering-and-sorting): Capitalize "Sorting" + small changes

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'Filtering and sorting'
-metaTitle: 'Filtering and sorting (Concepts)'
-metaDescription: 'Use Prisma Client API to filter records by any combination of fields or related record fields, and sort the results.'
+title: 'Filtering and Sorting'
+metaTitle: 'Filtering and Sorting (Concepts)'
+metaDescription: 'Use Prisma Client API to filter records by any combination of fields or related record fields, and/or sort query results.'
 tocDepth: 3
 ---
 
 <TopBlock>
 
-Prisma Client supports filtering and sorting with the `where` and `orderBy` query options respectively.
+Prisma Client supports [filtering](#filtering) with the `where` query option, and [sorting](#sorting) with the `orderBy` query option.
 
 </TopBlock>
 


### PR DESCRIPTION
This pages really presents 2 concepts that are on the same level. Capitalizing both makes that clearer. (Same for the other change)
