### PR TITLE
Docs: Fix query terms in full text search

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/060-full-text-search.mdx
@@ -87,16 +87,16 @@ To get a sense of how the query format works, consider the following text:
 
 Here's how the following queries would match that text:
 
-| Query                                   | Match? | Description                             |
-| :-------------------------------------- | :----- | :-------------------------------------- |
-| `fox & dog`                             | Yes    | The text contains 'fox' and 'dog'       |
-| `dog & fox`                             | Yes    | The text contains 'dog' and 'fox'       |
-| `dog & cat`                             | No     | The text contains 'dog' but not 'cat'   |
-| `!cat`                                  | Yes    | 'cat' is not in the text                |
-| <inlinecode>fox &#124; cat</inlinecode> | Yes    | The text contains 'fox' or 'cat'        |
-| <inlinecode>cat &#124; pig</inlinecode> | No     | The text doesn't contain 'cat' or 'pig' |
-| `fox <-> dog`                           | Yes    | 'dog' follows 'fox' in the text         |
-| `dog <-> fox`                           | No     | 'fox' doesn't follow 'dog' in the text  |
+| Query                                      | Match? | Description                             |
+| :----------------------------------------- | :----- | :-------------------------------------- |
+| `fox & dog`                                | Yes    | The text contains 'fox' and 'dog'       |
+| `dog & fox`                                | Yes    | The text contains 'dog' and 'fox'       |
+| `dog & !cat`                               | No     | The text contains 'dog' but not 'cat'   |
+| `!cat`                                     | Yes    | 'cat' is not in the text                |
+| <inlinecode>fox &#124; cat</inlinecode>    | Yes    | The text contains 'fox' or 'cat'        |
+| <inlinecode>!(cat &#124; pig)</inlinecode> | No     | The text doesn't contain 'cat' or 'pig' |
+| `fox <-> dog`                              | Yes    | 'dog' follows 'fox' in the text         |
+| `dog <-> fox`                              | No     | 'fox' doesn't follow 'dog' in the text  |
 
 For the full range of supported operations, see the [PostgreSQL full text search documentation](https://www.postgresql.org/docs/12/functions-textsearch.html).
 


### PR DESCRIPTION
## Describe this PR

There seem to have been some issues in the query terms for the docs of the fulltext search.

## Changes

* Fixed query terms (added some negations where needed)
