### PR TITLE
fix: Fix clipping on headings with inlinecode

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -397,3 +397,7 @@ a.question::before {
 .gatsby-resp-image-wrapper {
   margin-left: inherit !important;
 }
+
+h2:has(inlinecode) {
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Describe this PR

Headings with  `<inlinecode />` elements currently show a clipping due to the styling applied to said elements.

<img width="656" alt="Screenshot 2023-06-22 at 09 56 47" src="https://github.com/prisma/docs/assets/14851246/7ee7fbfc-db92-4688-a204-200587c605b6">

## Changes

Update `<h2 />` elements with `<inlinecode />` elements with an updated`line-height: 1.5;`.

## What issue does this fix?

Fixes #2870 

## Any other relevant information

N/a