### PR TITLE
fix: invalid prisma schema example

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
@@ -53,7 +53,7 @@ main()
 
 ```js no-copy
 {
-  id: '1',
+  id: 1,
   firstName: 'Aurelia',
   lastName: 'Schneider',
   email: 'Jalen_Berge40@hotmail.com',

--- a/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
@@ -80,21 +80,20 @@ generator client {
 }
 
 model User {
-  id    Int     @id @default(autoincrement())
-  email String  @unique
-  name  String?
-
-  posts Post[]
+  id         Int     @id @default(cuid())
+  email      String  @unique
+  firstName  String
+  lastName   String
+  posts      Post[]
 }
 
 model Post {
-  id        Int     @id @default(autoincrement())
-  title     String
-  published Boolean @default(true)
-  content   String?
-
-  authorId Int?
-  author   User? @relation(fields: [authorId], references: [id])
+  id         Int     @id @default(cuid())
+  title      String
+  published  Boolean @default(true)
+  content    String?
+  authorId   Int?
+  author     User? @relation(fields: [authorId], references: [id])
 }
 ```
 

--- a/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/062-computed-fields.mdx
@@ -53,7 +53,7 @@ main()
 
 ```js no-copy
 {
-  id: 'clgzkgy2j00004tc6iwu3gkzu',
+  id: '1',
   firstName: 'Aurelia',
   lastName: 'Schneider',
   email: 'Jalen_Berge40@hotmail.com',
@@ -80,7 +80,7 @@ generator client {
 }
 
 model User {
-  id         Int     @id @default(cuid())
+  id         Int     @id @default(autoincrement())
   email      String  @unique
   firstName  String
   lastName   String
@@ -88,7 +88,7 @@ model User {
 }
 
 model Post {
-  id         Int     @id @default(cuid())
+  id         Int     @id @default(autoincrement())
   title      String
   published  Boolean @default(true)
   content    String?


### PR DESCRIPTION
## Describe this PR

I updated the Prisma schema example [here](https://www.prisma.io/docs/concepts/components/prisma-client/computed-fields#using-a-prisma-client-extension).

## Changes

Please take a look at the changelog below.

## What issue does this fix?

Nope.

## Any other relevant information

Nope.