### PR TITLE
getting started: add SQLite to the tutorial

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
@@ -3,7 +3,7 @@ title: 'Connect your database'
 metaTitle: 'Connect your database'
 metaDescription: 'Connect your database to your project'
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'sqlite']
 toc: false
 ---
 
@@ -288,6 +288,21 @@ Your connection string is displayed as part of the welcome text when starting Co
 
 </SwitchTech>
 
+<SwitchTech technologies={['*', 'sqlite']}>
+
+```prisma file=prisma/schema.prisma
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+```
+
+The [format of the connection URL](/reference/database-reference/connection-urls#sqlite) for your database depends on the database you use.
+
+For SQLite, the `file:` prefix is used to denote a file based on disk. Setting the datasource to `file:./development.db.sqlite` will create a `dev.db` database file in the same location as your `schema.prisma` file.
+
+</SwitchTech>
+
 <SwitchTech technologies={['node', 'postgresql']}>
 
 <NavigationLinksContainer>
@@ -418,6 +433,32 @@ Your connection string is displayed as part of the welcome text when starting Co
 
 </SwitchTech>
 
+<SwitchTech technologies={['node', 'sqlite']}>
+
+<NavigationLinksContainer>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="/getting-started/setup-prisma/start-from-scratch/relational-databases-node-sqlite"
+  arrowLeft
+>
+  Installation
+</ButtonLink>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="./using-prisma-migrate-node-sqlite"
+  arrow
+>
+  Using Prisma Migrate
+</ButtonLink>
+
+</NavigationLinksContainer>
+
+</SwitchTech>
+
 <SwitchTech technologies={['typescript', 'postgresql']}>
 
 <NavigationLinksContainer>
@@ -539,6 +580,32 @@ Your connection string is displayed as part of the welcome text when starting Co
   color="dark"
   type="primary"
   href="./using-prisma-migrate-typescript-cockroachdb"
+  arrow
+>
+  Using Prisma Migrate
+</ButtonLink>
+
+</NavigationLinksContainer>
+
+</SwitchTech>
+
+<SwitchTech technologies={['typescript', 'sqlite']}>
+
+<NavigationLinksContainer>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-sqlite"
+  arrowLeft
+>
+  Installation
+</ButtonLink>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="./using-prisma-migrate-typescript-sqlite"
   arrow
 >
   Using Prisma Migrate

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate.mdx
@@ -3,7 +3,7 @@ title: 'Using Prisma Migrate'
 metaTitle: 'Using Prisma Migrate'
 metaDescription: 'Create database tables with Prisma Migrate'
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'sqlite']
 toc: false
 ---
 
@@ -165,6 +165,55 @@ model Post {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   title     String   @db.VarChar(255)
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}
+
+model User {
+  id      Int      @id @default(autoincrement())
+  email   String   @unique
+  name    String?
+  posts   Post[]
+  profile Profile?
+}
+```
+
+To map your data model to the database schema, you need to use the `prisma migrate` CLI commands:
+
+```terminal
+npx prisma migrate dev --name init
+```
+
+This command does two things:
+
+1. It creates a new SQL migration file for this migration
+1. It runs the SQL migration file against the database
+
+> **Note**: `generate` is called under the hood by default, after running `prisma migrate dev`. If the `prisma-client-js` generator is defined in your schema, this will check if `@prisma/client` is installed and install it if it's missing.
+
+Great, you now created three tables in your database with Prisma Migrate 🚀
+
+</SwitchTech>
+
+<SwitchTech technologies={['*', 'sqlite']}>
+
+In this guide, you'll use [Prisma Migrate](/concepts/components/prisma-migrate) to create the tables in your database. Add the following Prisma data model to your [Prisma schema](/concepts/components/prisma-schema) in `prisma/schema.prisma`:
+
+```prisma file=prisma/schema.prisma copy
+model Post {
+  id        Int      @id
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  title     String
   content   String?
   published Boolean  @default(false)
   author    User     @relation(fields: [authorId], references: [id])
@@ -580,6 +629,79 @@ Great, you now created three tables in your database with Prisma Migrate 🚀
 
 </SwitchTech>
 
+<SwitchTech technologies={['*', 'sqlite']}>
+
+<TabbedContent tabs={[<FileWithIcon text="SQL" icon="code"/>, <FileWithIcon text="Tables" icon="database"/>]}>
+
+<tab>
+
+```sql
+CREATE TABLE "Post" (
+  "id" INTEGER NOT NULL PRIMARY KEY,
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" DATETIME NOT NULL,
+  "title" TEXT NOT NULL,
+  "content" TEXT,
+  "published" BOOLEAN NOT NULL DEFAULT false,
+  "authorId" INTEGER NOT NULL,
+  CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "Profile" (
+  "id" INTEGER NOT NULL PRIMARY KEY,
+  "bio" TEXT,
+  "userId" INTEGER NOT NULL,
+  CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "User" (
+  "id" INTEGER NOT NULL PRIMARY KEY,
+  "email" TEXT NOT NULL,
+  "name" TEXT
+);
+
+CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId")
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email")
+```
+
+</tab>
+
+<tab>
+
+**User**
+
+| Column name | Type      | Primary key | Foreign key | Required | Default            |
+| :---------- | :-------- | :---------- | :---------- | :------- | :----------------- |
+| `id`        | `INTEGER` | **✔️**       | No          | **✔️**    | _                  |
+| `name`      | `TEXT`    | No          | No          | No       | -                  |
+| `email`     | `TEXT`    | No          | No          | **✔️**    | -                  |
+
+**Post**
+
+| Column name | Type           | Primary key | Foreign key | Required | Default            |
+| :---------- | :------------- | :---------- | :---------- | :------- | :----------------- |
+| `id`        | `INTEGER`      | **✔️**      | No          | **✔️**   | _                    |
+| `createdAt` | `TIMESTAMP`    | No          | No          | **✔️**   | `now()`             |
+| `updatedAt` | `TIMESTAMP`    | No          | No          | **✔️**   |                     |
+| `title`     | `TEXT`         | No          | No          | **✔️**   | -                   |
+| `content`   | `TEXT`         | No          | No          | No       | -                  |
+| `published` | `BOOLEAN`      | No          | No          | **✔️**   | `false`             |
+| `authorId`  | `INTEGER`      | No          | **✔️**       | **✔️**   | -                   |
+
+**Profile**
+
+| Column name | Type      | Primary key | Foreign key | Required | Default            |
+| :---------- | :-------- | :---------- | :---------- | :------- | :----------------- |
+| `id`        | `INTEGER` | **✔️**      | No          | **✔️**     | _                  |
+| `bio`       | `TEXT`    | No          | No          | No       | -                  |
+| `userId`    | `INTEGER` | No          | **✔️**      | **✔️**     | -                  |
+
+</tab>
+
+</TabbedContent>
+
+</SwitchTech>
+
 <SwitchTech technologies={['node', 'postgresql']}>
 
 <NavigationLinksContainer>
@@ -710,6 +832,32 @@ Great, you now created three tables in your database with Prisma Migrate 🚀
 
 </SwitchTech>
 
+<SwitchTech technologies={['node', 'sqlite']}>
+
+<NavigationLinksContainer>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="./connect-your-database-node-sqlite"
+  arrowLeft
+>
+  Connect your database
+</ButtonLink>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="./install-prisma-client-node-sqlite"
+  arrow
+>
+  Install Prisma Client
+</ButtonLink>
+
+</NavigationLinksContainer>
+
+</SwitchTech>
+
 <SwitchTech technologies={['typescript', 'postgresql']}>
 
 <NavigationLinksContainer>
@@ -831,6 +979,32 @@ Great, you now created three tables in your database with Prisma Migrate 🚀
   color="dark"
   type="primary"
   href="./install-prisma-client-typescript-cockroachdb"
+  arrow
+>
+  Install Prisma Client
+</ButtonLink>
+
+</NavigationLinksContainer>
+
+</SwitchTech>
+
+<SwitchTech technologies={['typescript', 'sqlite']}>
+
+<NavigationLinksContainer>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="./connect-your-database-typescript-sqlite"
+  arrowLeft
+>
+  Connect your database
+</ButtonLink>
+
+<ButtonLink
+  color="dark"
+  type="primary"
+  href="./install-prisma-client-typescript-sqlite"
   arrow
 >
   Install Prisma Client

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/index.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/index.mdx
@@ -5,7 +5,7 @@ metaDescription: 'Learn how to create a new Node.js or TypeScript project from s
 duration: '15 min'
 toc: false
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'sqlite']
 ---
 
 <TopBlock>
@@ -58,6 +58,19 @@ This tutorial will also assume that you can push to the `main` branch of your da
 - A [Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/?view=sql-server-ver15) database
   - [Microsoft SQL Server on Linux for Docker](/concepts/database-connectors/sql-server/sql-server-docker)
   - [Microsoft SQL Server on Windows (local)](/concepts/database-connectors/sql-server/sql-server-local)
+
+</SwitchTech>
+
+<SwitchTech technologies={['*', 'sqlite']}>
+
+- [Node.js](https://nodejs.org/en/) installed on your machine
+- [SQLite 3](https://www.sqlite.org/download.html) installed locally.
+
+<Admonition type="info">
+
+SQLite is installed by default on most operating systems, including macOS, Linux, and Windows. You can check whether SQLite is installed by running `sqlite3` (macOS, Linux) or `sqlite3.exe` (Windows) in a terminal or command prompt.
+
+</Admonition>
 
 </SwitchTech>
 


### PR DESCRIPTION
**DRAFT: DO NOT MERGE**

## Describe this PR

This PR adds SQLite to the tutorials.

## Changes

- [x] Updates the `schema.prisma` definition for SQLite to remove `@default(autoincrement)` as the default `INTEGER PRIMARY KEY` is more performant (https://www.sqlite.org/autoinc.html)
- [ ] Adds SQLite throughout the "start from scratch" tutorial - Connect, Using Migrate, Install Prisma Client, Querying, Next Steps
- [ ] The same, but for the "add to existing project" tutorial

## Any other relevant information

None! 
