### PR TITLE
fix(using-multiple-env-files): Indentation and typos/grammar

### DIFF
--- a/content/300-guides/125-development-environment/050-environment-variables/200-using-multiple-env-files.mdx
+++ b/content/300-guides/125-development-environment/050-environment-variables/200-using-multiple-env-files.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Using multiple .env files'
 metaTitle: 'Using multiple .env files.'
-metaDescription: 'Learn how to setup a dedicated testing environment using multiple .env files.'
+metaDescription: 'Learn how to set up a dedicated testing environment using multiple .env files.'
 tocDepth: 3
 ---
 
@@ -9,14 +9,14 @@ tocDepth: 3
 
 There is a risk that your production database could be deleted if you store different connection URLs to each of your environments within a single `.env` file.
 
-One solution is to have multiple `.env` files which each represent different environments. In practice this means you create a file for each of your environments:
+One solution is to have multiple `.env` files which each represent different environments. In practice, this means you create a file for each of your environments:
 
 - `.env.development`
 - `.env.sample`
 
 <Admonition type="warning">
 
-`.env.production` is omitted from the above list as it's is not recommended to store your production credentials locally, even if they are git ignored.
+`.env.production` is omitted from the above list as it is not recommended to store your production credentials locally, even if they are git-ignored.
 
 </Admonition>
 
@@ -26,19 +26,19 @@ Then using a package like [`dotenv-cli`](https://www.npmjs.com/package/dotenv-cl
 
 ## Setup multiple `.env` files
 
-For the purpose of this guide it is assumed you have a dedicated development database which you use whilst developing your application.
+For the purpose of this guide, it is assumed you have a dedicated development database that you use whilst developing your application.
 
 1. Rename your `.env` file to `.env.development`
 
-```env file=.env.development
-DATABASE_URL="postgresql://prisma:prisma@localhost:5433/dev"
-```
+  ```env file=.env.development
+  DATABASE_URL="postgresql://prisma:prisma@localhost:5433/dev"
+  ```
 
 2. Create a new `.env.sample` file and change the database name to `sample` (or your preferred name)
 
-```env file=.env.sample
-DATABASE_URL="postgresql://prisma:prisma@localhost:5433/sample"
-```
+  ```env file=.env.sample
+  DATABASE_URL="postgresql://prisma:prisma@localhost:5433/sample"
+  ```
 
 3. Install [`dotenv-cli`](https://www.npmjs.com/package/dotenv-cli)
 
@@ -46,7 +46,7 @@ In order for Prisma and Jest to know which `.env` file to use, alter your packag
 
 <Admonition type="info">
 
-Any top level script that is running the tests and migrations needs the dotenv command before it. This makes sure that the env variables from `.env.sample` are passed to all commands including Jest.
+Any top-level script that is running the tests and migrations needs the `dotenv` command before it. This makes sure that the env variables from `.env.sample` are passed to all commands, including Jest.
 
 </Admonition>
 
@@ -66,9 +66,9 @@ The below script uses `dotenv-cli` to pass the `.env.sample` environment file (w
 
 ### Running tests on different environments
 
-When running tests we advise you to [mock Prisma Client](/guides/testing/unit-testing#mocking-the-prisma-client), in doing so you need to tell Jest which environment it should use when running its tests.
+When running tests, we advise you to [mock Prisma Client](/guides/testing/unit-testing#mocking-the-prisma-client). In doing so, you need to tell Jest which environment it should use when running its tests.
 
-By default Prisma Client will use the environment specified in the default `.env` file located at the projects root.
+By default, Prisma Client will use the environment specified in the default `.env` file located at the project's root.
 
 If you have created a separate `.env.sample` file to specify your testing database, then this environment will need to be passed to Jest.
 


### PR DESCRIPTION
Just wanted to fix the broken indentation, but then Grammarly pointed out all these typos and grammar problems - so I also fixed them.