### PR TITLE
fix(client-extensions): Remove `(Preview)` from page titles

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/053-client-extensions/100-model.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-client-extensions/100-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Add custom methods to your models'
-metaTitle: 'Prisma Client extensions: model component (Preview)'
+metaTitle: 'Prisma Client extensions: model component'
 metaDescription: 'Extend the functionality of Prisma Client, model component'
 tocDepth: 4
 ---

--- a/content/200-concepts/100-components/02-prisma-client/053-client-extensions/110-client.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-client-extensions/110-client.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Add methods to Prisma Client'
-metaTitle: 'Prisma Client extensions: client component (Preview)'
+metaTitle: 'Prisma Client extensions: client component'
 metaDescription: 'Extend the functionality of Prisma Client, client component'
 tocDepth: 4
 ---

--- a/content/200-concepts/100-components/02-prisma-client/053-client-extensions/120-query.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-client-extensions/120-query.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create custom Prisma Client queries'
-metaTitle: 'Prisma Client extensions: query component (Preview)'
+metaTitle: 'Prisma Client extensions: query component'
 metaDescription: 'Extend the functionality of Prisma Client, query component'
 tocDepth: 4
 ---

--- a/content/200-concepts/100-components/02-prisma-client/053-client-extensions/130-result.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-client-extensions/130-result.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Add custom fields and methods to query results'
-metaTitle: 'Prisma Client extensions: result component (Preview)'
+metaTitle: 'Prisma Client extensions: result component'
 metaDescription: 'Extend the functionality of Prisma Client, result component'
 tocDepth: 4
 ---

--- a/content/200-concepts/100-components/02-prisma-client/053-client-extensions/200-extension-examples.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-client-extensions/200-extension-examples.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Examples'
-metaTitle: 'Prisma Client Extension | Examples'
+metaTitle: 'Prisma Client Extensions | Examples'
 metaDescription: 'Extend the functionality of Prisma Client: Examples'
 ---
 


### PR DESCRIPTION
Remove leftover `(Preview)`