### PR TITLE
pnpx is deprecated, update docs to reference pnpm dlx

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -93,7 +93,7 @@ yarn prisma
 ### pnpm
 
 ```
-pnpx prisma
+pnpm dlx prisma
 ```
 
 ## Synopsis


### PR DESCRIPTION
## Describe this PR

docs are still referencing pnpx it's been deprecated for a few years

## Changes

updated code example to use `pnpm dlx` instead of `pnpx`
