### PR TITLE
Fix: Update 600-upgrading-to-prisma-5.mdx

### DIFF
--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/600-upgrading-to-prisma-5.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/600-upgrading-to-prisma-5.mdx
@@ -130,7 +130,7 @@ You will need to modify your code to handle the errors thrown by `...OrThrow` me
 
 ```js
 try {
-  prisma.user.findFirstOrThrow({
+  await prisma.user.findFirstOrThrow({
     where: { name: 'Alice' },
   })
 } catch (err) {


### PR DESCRIPTION
Add `await` to make try-catch works

## Describe this PR

An example in the guide demonstrates the usage of `findUniqueOrThrow` along with try-catch without "await" it.
The promise will be reject without triggering the try-catch in this case.

## Changes

Add `await` before the call

## What issue does this fix?

None

## Any other relevant information

None
