### PR TITLE
Update 050-prisma-client-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1036,6 +1036,7 @@ Prisma Client uses a database upsert for an `upsert` query when the query meets 
 - The query modifies only one model
 - There is only one unique field in the `upsert`'s `where` option
 - The unique field in the `where` option and the unique field in the `create` option have the same value
+- The update field is not an empty object
 
 If your query does not meet these criteria, then Prisma Client handles the upsert itself.
 


### PR DESCRIPTION


## Describe this PR

I ran into this where the upsert query will be a SELECT + INSERT if the update field is an empty object. This is a bit unintuitive, maybe even a bug?

## Changes

Add another condition to when an upsert is used

## What issue does this fix?

Unexpected SELECT + INSERT instead of a UPDATE ON CONFLICT
