### PR TITLE
docs: add missing word

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -5673,7 +5673,7 @@ In the following situations, you must [use raw queries to compare columns in the
 
 </Admonition>
 
-To compare columns the same table, use the `<model>.fields` property. In the following example, the query returns all records where the value in the `prisma.product.quantity` field is less than or equal to the value in the `prisma.product.warnQuantity` field.
+To compare columns in the same table, use the `<model>.fields` property. In the following example, the query returns all records where the value in the `prisma.product.quantity` field is less than or equal to the value in the `prisma.product.warnQuantity` field.
 
 ```ts
 prisma.product.findMany({


### PR DESCRIPTION
## Describe this PR

I think there is a word drop in "To compare columns the same table"

## Changes

I've added the preposition "in" in the sentence.
