### PR TITLE
fix(relation-queries): Add missing link for API references

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/037-relation-queries.mdx
@@ -669,7 +669,7 @@ const createMany = await prisma.user.createMany({
 
 ### Connect multiple records
 
-The following query creates ([`create`](/reference/api-reference/prisma-client-reference#create) <span class="api"></span>) a new `User` record and connects that record (`connect` <span class="api"></span>) to three existing posts:
+The following query creates ([`create`](/reference/api-reference/prisma-client-reference#create) <span class="api"></span>) a new `User` record and connects that record ([`connect`](/reference/api-reference/prisma-client-reference#connect) <span class="api"></span>) to three existing posts:
 
 <CodeWithResult outputResultText="query">
 <cmd>
@@ -720,7 +720,7 @@ const result = await prisma.user.create({
 
 ### Connect a single record
 
-You can `connect` <span class="api"></span> an existing record to a new or existing user. The following query connects an existing post (`id: 11`) to an existing user (`id: 9`)
+You can [`connect`](/reference/api-reference/prisma-client-reference#connect) <span class="api"></span> an existing record to a new or existing user. The following query connects an existing post (`id: 11`) to an existing user (`id: 9`)
 
 ```ts highlight=6-9;normal
 const result = await prisma.user.update({
@@ -742,7 +742,7 @@ const result = await prisma.user.update({
 
 ### Connect _or_ create a record
 
-If a related record may or may not already exist, use `connectOrCreate` <span class="api"></span> to connect the related record:
+If a related record may or may not already exist, use [`connectOrCreate`](/reference/api-reference/prisma-client-reference#connectorcreate) <span class="api"></span> to connect the related record:
 
 - Connect a `User` with the email address `viola@prisma.io` _or_
 - Create a new `User` with the email address `viola@prisma.io` if the user does not already exist
@@ -880,7 +880,7 @@ const result = await prisma.post.update({
 
 ### Disconnect all related records
 
-To `disconnect` <span class="api"></span> _all_ related records in a one-to-many relation (a user has many posts), `set` the relation to an empty list as shown:
+To [`disconnect`](/reference/api-reference/prisma-client-reference#disconnect) <span class="api"></span> _all_ related records in a one-to-many relation (a user has many posts), `set` the relation to an empty list as shown:
 
 <CodeWithResult outputResultText="query">
 <cmd>


### PR DESCRIPTION
API annotation only makes sense if there is also a link to the API.