### PR TITLE
docs(guide/connection-management): remove unused prisma import

### DIFF
--- a/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
@@ -208,7 +208,7 @@ If the `connection_limit` is 1, this function is forced to send queries **serial
 Instantiate `PrismaClient` [outside the scope of the function handler](https://github.com/prisma/e2e-tests/blob/5d1041d3f19245d3d237d959eca94d1d796e3a52/platforms/serverless-lambda/index.ts#L3) to increase the chances of reuse. As long as the handler remains 'warm' (in use), the connection is potentially reusable:
 
 ```ts highlight=3;normal
-import { PrismaClient, Prisma } from '@prisma/client'
+import { PrismaClient } from '@prisma/client'
 
 const client = new PrismaClient()
 


### PR DESCRIPTION
## Describe this PR

Remove unused import `Prisma`

