### PR TITLE
Adds note about the inability to use filter conditions to filter a JS…

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -461,6 +461,7 @@ Use model queries to perform CRUD operations on your models. See also: [CRUD](/c
 
 - Prisma's dataloader [automatically batches `findUnique` queries](/guides/performance-and-optimization/query-optimization-performance#solving-n1-in-graphql-with-findunique-and-prismas-dataloader) with the same `select` and `where` parameters.
 - If you want the query to throw an error if the record is not found, then consider using [`findUniqueOrThrow`](#finduniqueorthrow) instead.
+- You cannot use [filter conditions](/docs/reference/api-reference/prisma-client-reference#filter-conditions-and-operators) (e.g. `equals`, `contains`, `not`) to filter fields of the [JSON](/reference/api-reference/prisma-schema-reference#json) data type. Using filter conditions will likely result in a `null` response for that field.
 
 #### Options
 
@@ -5554,7 +5555,7 @@ export declare const ModelName: {
   Post: 'Post'
 }
 
-export declare type ModelName = typeof ModelName[keyof typeof ModelName]
+export declare type ModelName = (typeof ModelName)[keyof typeof ModelName]
 ```
 
 #### Examples


### PR DESCRIPTION
Adds note to the client API reference for `findUnique` letting readers know the cannot use filter conditions when filtering a JSON field.

Closes #5098 