### PR TITLE
docs(db-push): clarify the migration table note

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/150-db-push.mdx
@@ -20,7 +20,7 @@ The Prisma CLI has a dedicated command for prototyping schemas: [`db push`](/ref
 
 > **Notes**:
 >
-> - `db push` does not interact with or rely on migrations. The migrations table will not be updated, and no migration files will be generated.
+> - `db push` does not interact with or rely on migrations. The migrations table `_prisma_migrations` will not be created or updated, and no migration files will be generated.
 > - When working with PlanetScale, we recommend that you use `db push` instead of `migrate`. For details refer to our Getting Started documentation, either [Start from scratch](/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale) or [Add to existing project](/getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale) depending on your situation.
 
 </TopBlock>


### PR DESCRIPTION
## Describe this PR

The note wasn't very clear to me, a beginner, that the `_prisma_migrations` table won't be created, and seemed to contradict with the behavior described in other knowledge sources (namely blog posts and issue threads). I feel a more clear note will leave no room for ambiguity

## Changes

- Made a reference to `_prisma_migration` table
- Made it super clear that the table will not be created

## What issue does this fix?

No issue, we had a brief discussion with @ludralph  in https://github.com/prisma/prisma/discussions/20523 which has more details

## Any other relevant information

* https://selimb.hashnode.dev/speedy-prisma-pg-tests
* https://github.com/prisma/prisma/discussions/20523
* https://github.com/selimb/fast-prisma-tests/blob/main/tests/helpers/fast-prisma-tests/fast-migrations.ts