### PR TITLE
fix(admonition-component): Prevent overlapping text

### DIFF
--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -60,7 +60,7 @@ const AdmonitionWrapper = styled.span<{ type?: string }>`
   padding-bottom: 8px;
   margin: 2rem 0px;
   position: relative;
-  display: flex;
+  display: block;
   max-width: 100%;
   pre {
     font-weight: normal;

--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -57,7 +57,6 @@ const AdmonitionWrapper = styled.span<{ type?: string }>`
   color: ${theme.colors.gray[600]} !important;
   padding-left: ${(p) => (p.type === 'alert' ? '3rem' : '1.5rem')};
   padding-bottom: 8px;
-  padding-bottom: 8px;
   margin: 2rem 0px;
   position: relative;
   display: block;


### PR DESCRIPTION
## Describe this PR

Elements within the Admonition component may overlap with adjacent elements.
Here is an example:
https://www.prisma.io/docs/concepts/database-connectors/sql-server#connection-details

![image](https://github.com/prisma/docs/assets/16272579/d063a229-6a62-40db-b374-41c90b36ba3a)

Switching the component's `display: flex` to `display: block` resolves this bug without altering the component's intended behavior:

![image](https://github.com/prisma/docs/assets/16272579/fca2a7e5-0be2-45b0-a5fd-c2ef8d256cbb)

## Changes

- Change display property from `flex` to `block`.
- Remove duplicate style property `padding-bottom: 8px`

## What issue does this fix?

Fixes #5163