### PR TITLE
fix: PDP description grammer

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -98,7 +98,7 @@ const siteConfig = {
         title: 'Prisma Data Platform',
         icon: 'triangle',
         description:
-          'An ecosystem of tools empowering teams to build data-heavy, global-first applications',
+          'An ecosystem of tools empowering teams to build data-heavy, global-first applications.',
         links: [
           {
             url: 'data-platform/accelerate',


### PR DESCRIPTION
This PR fixes a small grammar issue.

Adding a full stop to;

```
An ecosystem of tools empowering teams to build data-heavy, global-first applications.
```

on url: https://www.prisma.io/docs