### PR TITLE
fix: heading line height

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -57,6 +57,14 @@ const Content = styled.article<{ homePage?: boolean; wide?: boolean }>`
     margin: 0;
     ${(p) => (p.homePage ? 'max-width: 100%' : 'max-width: 570px')};
   }
+  section {
+    > h2,
+    h3,
+    h4,
+    h5 {
+      line-height: 35px;
+    }
+  }
 `
 
 const MaxWidth = styled.div<{ wide?: boolean }>`

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -65,7 +65,7 @@ const Content = styled.article<{ homePage?: boolean; wide?: boolean }>`
     h5,
     h6 {
       &:has(> inlinecode) {
-        line-height: 1.3;
+        line-height: 1.5;
       }
     }
   }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -65,7 +65,7 @@ const Content = styled.article<{ homePage?: boolean; wide?: boolean }>`
     h5,
     h6 {
       &:has(> inlinecode) {
-        line-height: 30px;
+        line-height: 1.3;
       }
     }
   }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -65,7 +65,7 @@ const Content = styled.article<{ homePage?: boolean; wide?: boolean }>`
     h5,
     h6 {
       &:has(> inlinecode) {
-        line-height: 35px;
+        line-height: 30px;
       }
     }
   }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -58,11 +58,15 @@ const Content = styled.article<{ homePage?: boolean; wide?: boolean }>`
     ${(p) => (p.homePage ? 'max-width: 100%' : 'max-width: 570px')};
   }
   section {
-    > h2,
+    > h1,
+    h2,
     h3,
     h4,
-    h5 {
-      line-height: 35px;
+    h5,
+    h6 {
+      &:has(> inlinecode) {
+        line-height: 35px;
+      }
     }
   }
 `

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -585,10 +585,6 @@ a.question::before {
   margin-left: inherit !important;
 }
 
-h2:has(inlinecode) {
-  line-height: 1.5;
-}
-
 /* Kapa.ai overrides */
 #kapa-widget-container .mantine-Button-root {
   z-index: 1000;


### PR DESCRIPTION
## Describe this PR

The headings inside the layout's content have a diminished line-height, which ends up overlapping text that contains `<inlinecode />` elements.

This PR also includes an update to the lens package that _**should not**_ affect the layout (as we don't use the `<WebsiteHeader />` from lens anymore. It is updated for consistency.

## Changes

Update `line-height` for headings elements inside the `<Content />` styled component to `35px` (this is tentative, so open to add other better fitting values)

## What issue does this fix?

Fixes #5026 

## Any other relevant information

N/a
