### PR TITLE
document validator alternative `Prisma.validator` usage

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/99-prisma-validator.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/052-advanced-type-safety/99-prisma-validator.mdx
@@ -72,6 +72,22 @@ const user = await prisma.user.findUnique({
 })
 ```
 
+Alternatively, you can use the following syntax that uses a "selector" pattern using an existing instance of Prisma Client:
+
+```ts
+import { Prisma } from '@prisma/client'
+import prisma from './lib/prisma'
+
+const userEmail = Prisma.validator(
+  prisma,
+  'user',
+  'findUnique',
+  'select'
+)({
+  email: true,
+})
+```
+
 The big difference is that the `userEmail` object is now type-safe. If you hover your mouse over it TypeScript will tell you the object's key/value pair. If you use dot notation to access the object's properties you will only be able to access the `email` property of the object.
 
 This functionality is handy when combined with user defined input, like form data.

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -5609,7 +5609,7 @@ Prisma.validator<GeneratedType>({ args })
 
 #### Using a "selector"
 
-Provides a validator that uses an existing Prisma Client instance. This pattern allows you to select the model, operation, and query option to validate against.
+When using the selector pattern, you use an existing Prisma Client instance to create a validator. This pattern allows you to select the model, operation, and query option to validate against.
 
 You can also use an instance of Prisma Client that has been extended using a [Prisma Client extension](/concepts/components/prisma-client/client-extensions)<span class="concept"></span>.
 

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -5601,7 +5601,7 @@ There are two ways you can use the `validator`:
 
 #### Using generated Prisma Client types
 
-Provides a type-level approach to validate data:
+Using types provides a type-level approach to validate data:
 
 ```ts
 Prisma.validator<GeneratedType>({ args })

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -5597,40 +5597,39 @@ Utility types are helper functions and types that live on the Prisma namespace. 
 
 The `validator` helps you create re-usable query parameters based on your schema models while making sure that the objects you create are valid. See also: [Using `Prisma.validator`](/concepts/components/prisma-client/advanced-type-safety/prisma-validator) <span class="concept"></span>
 
-#### Reference
+There are two ways you can use the `validator`:
+
+#### Using generated Prisma Client types
+
+Provides a type-level approach to validate data:
 
 ```ts
-export function validator<V>(): <S>(select: Exact<S, V>) => S
+Prisma.validator<GeneratedType>({ args })
+```
 
-type Exact<A, W = unknown> = W extends unknown
-  ? A extends Narrowable
-    ? Cast<A, W>
-    : Cast<
-        { [K in keyof A]: K extends keyof W ? Exact<A[K], W[K]> : never },
-        { [K in keyof W]: K extends keyof A ? Exact<A[K], W[K]> : W[K] }
-      >
-  : never
+#### Using a "selector"
 
-type Narrowable = string | number | boolean | bigint
+Provides a validator that uses an existing Prisma Client instance. This pattern allows you to select the model, operation, and query option to validate against.
 
-type Cast<A, B> = A extends B ? A : B
+You can also use an instance of Prisma Client that has been extended using a [Prisma Client extension](/concepts/components/prisma-client/client-extensions)<span class="concept"></span>.
 
-export const type: unique symbol
+```ts
+Prisma.validator(
+  PrismaClientInstance,
+  '<model>',
+  '<operation>',
+  '<query option>'
+)({ args })
 ```
 
 #### Examples
 
-The following example shows how you can extract a `create` operation into a custom function for re-use and accepting form data:
+The following example shows how you can extract and validate the input for the `create` operation you can reuse within your app:
 
 ```ts
 import { Prisma } from '@prisma/client'
 
-const createUserAndPost = (
-  name: string,
-  email: string,
-  postTitle: string,
-  profileBio: string
-) => {
+const validateUserAndPostInput = (name, email, postTitle) => {
   return Prisma.validator<Prisma.UserCreateInput>()({
     name,
     email,
@@ -5639,9 +5638,28 @@ const createUserAndPost = (
         title: postTitle,
       },
     },
-    profile: {
+  })
+}
+```
+
+Here is an alternative syntax for the same operation:
+
+```ts
+import { Prisma } from '@prisma/client'
+import prisma from './prisma'
+
+const validateUserAndPostInput = (name, email, postTitle) => {
+  return Prisma.validator(
+    prisma,
+    'user',
+    'create',
+    'data'
+  )({
+    name,
+    email,
+    posts: {
       create: {
-        bio: profileBio,
+        title: postTitle,
       },
     },
   })


### PR DESCRIPTION
Closes #5076

This PR doesn't necessarily document how to use it with Prisma Client extensions but documents the alternative syntax for `Prisma.validator` in the Reference and Concepts sections.

Example usage that was previously undocumented:

```ts
Prisma.validator(PrismaClientInstance, '<model>', '<operation>', '<query option>')({ args })
```