### PR TITLE
fix: link to `exists-method` repo

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/053-client-extensions/200-extension-examples.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-client-extensions/200-extension-examples.mdx
@@ -29,7 +29,7 @@ The extensions are provided as examples only, and without warranty. We recommend
 | [`row-level-security`](https://github.com/prisma/prisma-client-extensions/tree/main/row-level-security)     | Uses Postgres row-level security policies to isolate data a multi-tenant application        |
 | [`static-methods`](https://github.com/prisma/prisma-client-extensions/tree/main/static-methods)             | Adds custom query methods to Prisma Client models                                           |
 | [`transformed-fields`](https://github.com/prisma/prisma-client-extensions/tree/main/transformed-fields)     | Demonstrates how to use result extensions to transform query results and add i18n to an app |
-| [`exists-method`](https://github.com/prisma/prisma-client-extensions/tree/main/exists-method)               | Demonstrates how to add an `exists` method to all your models                               |
+| [`exists-method`](https://github.com/prisma/prisma-client-extensions/tree/main/exists-fn)               | Demonstrates how to add an `exists` method to all your models                               |
 
 ## Going further
 


### PR DESCRIPTION
## Describe this PR

The link to the [`exists-method`](https://github.com/prisma/prisma-client-extensions/tree/main/exists-fn) repo was pointing to a non-existent repo. 

## Changes

Updated the URL from `https://github.com/prisma/prisma-client-extensions/tree/main/exists-method` to `https://github.com/prisma/prisma-client-extensions/tree/main/exists-fn`

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
