### PR TITLE
fix: update prisma schema env section

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -184,7 +184,7 @@ Run prisma generate to generate Prisma Client.
 
 You can use environment variables to provide configuration options when a CLI command is invoked, or a Prisma Client query is run.
 
-Using environment variables in the schema allows you to **keep secrets out of the schema file** which in turn **improves the portability of the schema** by allowing you to use it in different environments
+Hardcoding URLs directly in your schema is possible but is discouraged because it poses a security risk. Using environment variables in the schema allows you to **keep secrets out of the schema file** which in turn **improves the portability of the schema** by allowing you to use it in different environments.
 
 Environment variables can be accessed using the `env()` function:
 


### PR DESCRIPTION
This PR updates the env section to emphasize on the security risk that comes with hardcoding URLs.

A link to this page will be displayed by the Prisma CLI when a URL is hardcoded.