### PR TITLE
fix(accelerate): add a mention for edge runtimes

### DIFF
--- a/content/800-data-platform/100-accelerate/200-getting-started.mdx
+++ b/content/800-data-platform/100-accelerate/200-getting-started.mdx
@@ -124,6 +124,15 @@ import { withAccelerate } from '@prisma/extension-accelerate'
 const prisma = new PrismaClient().$extends(withAccelerate())
 ```
 
+If you are going to deploy to an edge runtime (like Cloudflare Workers, or Vercel Edge Functions, Deno Deploy, or Netlify Edge Functions), use our edge client instead:
+
+```ts
+import { PrismaClient } from '@prisma/client/edge'
+import { withAccelerate } from '@prisma/extension-accelerate'
+
+const prisma = new PrismaClient().$extends(withAccelerate())
+```
+
 If VS Code does not recognize the `$extends` method, refer to [this section](/data-platform/accelerate/faq#vs-code-does-not-recognize-the-extends-method) on how to resolve the issue.
 
 <Admonition type="info">

--- a/content/800-data-platform/100-accelerate/200-getting-started.mdx
+++ b/content/800-data-platform/100-accelerate/200-getting-started.mdx
@@ -124,7 +124,7 @@ import { withAccelerate } from '@prisma/extension-accelerate'
 const prisma = new PrismaClient().$extends(withAccelerate())
 ```
 
-If you are going to deploy to an edge runtime (like Cloudflare Workers, or Vercel Edge Functions, Deno Deploy, or Netlify Edge Functions), use our edge client instead:
+If you are going to deploy to an edge runtime (like Cloudflare Workers, Vercel Edge Functions, Deno Deploy, or Netlify Edge Functions), use our edge client instead:
 
 ```ts
 import { PrismaClient } from '@prisma/client/edge'


### PR DESCRIPTION
Quickly mention that Accelerate can be run in Cloudflare and other edge runtimes. In the ORM, when you run `prisma generate`, we will suggest in the successful generation message to use Accelerate for `@prisma/client/edge`. So I think my addition is required here at least. Ideally we could also point to guides once we revamped them.
