### PR TITLE
fix(aggregate): reference type

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1518,7 +1518,6 @@ export type UserAggregateArgs = {
   cursor?: UserWhereUniqueInput
   take?: number
   skip?: number
-  distinct?: Enumerable<UserDistinctFieldEnum>
   _count?: true | UserCountAggregateInputType
   _avg?: UserAvgAggregateInputType
   _sum?: UserSumAggregateInputType


### PR DESCRIPTION
## Describe this PR

I noticed a mismatch between the [Aggregate method options list and its reference type](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#aggregate) so I fixed the problem

## Changes

Deleted unmatching type property from the reference type

## What issue does this fix?

Fixes #5194 
