### PR TITLE
feat: add explanation on default cache strategy #5203

### DIFF
--- a/content/800-data-platform/100-accelerate/300-concepts.mdx
+++ b/content/800-data-platform/100-accelerate/300-concepts.mdx
@@ -174,3 +174,13 @@ Update your application with the new Accelerate connection string. Then re-gener
 ```shell
 npx prisma generate --accelerate
 ```
+
+## Default cache strategy 
+
+Accelerate defaults to **no cache** to avoid counterintuitive issues. Caching can be a powerful tool for improving performance but can also be dangerous if not used correctly.
+
+For example, consider writing a query on a critical path without explicitly defining a cache strategy. If you run the code, you might receive incorrect data without explanation. This could be caused by someone forgetting to disable the default _implicit_ cache behavior. Implicit caching allows these counterintuitive issues to arise, leading to undesirable results.
+
+You must explicitly opt-in to caching if you want to use it. This makes it clear to developers that caching is not enabled by default and helps prevent counterintuitive issues from occurring.
+
+> When no cache strategy is specified or during a cache miss, a Prisma Client with the Accelerate extension routes all queries to the database through a connection pool instance near the database region.


### PR DESCRIPTION
closes [#5203](https://github.com/prisma/docs/issues/5203)