### PR TITLE
fix docs for migrate diff

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -13,7 +13,7 @@ Some development-focused commands for relational databases of Prisma Migrate use
 
 The shadow database is **created and deleted automatically**\* each time you run a development-focused command and is primarily used to **detect problems** such as schema drift.
 
-[`migrate diff` command](/reference/api-reference/command-reference#migrate-diff) also requires a shadow database when diffing against a local `migrations` directory.
+[`migrate diff` command](/reference/api-reference/command-reference#migrate-diff) also requires a shadow database when diffing against a local `migrations` directory with `--from-migrations` or `--to-migrations`.
 
 <FootNote>
 

--- a/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/200-shadow-database.mdx
@@ -13,6 +13,8 @@ Some development-focused commands for relational databases of Prisma Migrate use
 
 The shadow database is **created and deleted automatically**\* each time you run a development-focused command and is primarily used to **detect problems** such as schema drift.
 
+[`migrate diff` command](/reference/api-reference/command-reference#migrate-diff) also requires a shadow database when diffing against a local `migrations` directory.
+
 <FootNote>
 
 \* If you use a cloud-hosted database for development, you need to [create the shadow database manually](#cloud-hosted-shadow-databases-must-be-created-manually).

--- a/content/300-guides/025-migrate/100-developing-with-prisma-migrate/180-generating-down-migrations.mdx
+++ b/content/300-guides/025-migrate/100-developing-with-prisma-migrate/180-generating-down-migrations.mdx
@@ -107,7 +107,8 @@ You will need to create the down migration first, before creating the correspond
      ```terminal wrap
      npx prisma migrate diff \
       --from-schema-datamodel prisma/schema.prisma \
-      --to-migrations prisma/migrations --shadow-database-url $SHADOW_DATABASE_URL \
+      --to-migrations prisma/migrations \
+      --shadow-database-url $SHADOW_DATABASE_URL \
       --script > down.sql
      ```
 

--- a/content/300-guides/025-migrate/800-production-troubleshooting.mdx
+++ b/content/300-guides/025-migrate/800-production-troubleshooting.mdx
@@ -135,11 +135,16 @@ In this case, you need to create a migration that takes your production database
 
   - Run the following `prisma migrate diff` command:
 
-    ```bash
-     npx prisma migrate diff --from-url "$DATABASE_URL_PROD" --to-migrations ./migrations --script > backward.sql
+    ```terminal wrap
+     npx prisma migrate diff \
+      --from-url "$DATABASE_URL_PROD" \
+      --to-migrations ./prisma/migrations \ 
+      --shadow-database-url $SHADOW_DATABASE_URL \
+      --script > backward.sql
     ```
-
+    
     This will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
+    Note that because we're using `--to-migrations`, the command requires a [shadow database](/concepts/components/prisma-migrate/shadow-database).
 
   - Run the following `prisma db execute` command:
 

--- a/content/300-guides/025-migrate/800-production-troubleshooting.mdx
+++ b/content/300-guides/025-migrate/800-production-troubleshooting.mdx
@@ -142,7 +142,6 @@ In this case, you need to create a migration that takes your production database
       --shadow-database-url $SHADOW_DATABASE_URL \
       --script > backward.sql
     ```
-    
     This will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
     Note that because we're using `--to-migrations`, the command requires a [shadow database](/concepts/components/prisma-migrate/shadow-database).
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -1155,7 +1155,7 @@ prisma migrate resolve --rolled-back 20201231000000_add_users_table
 
 ### <inlinecode>migrate status</inlinecode>
 
-The `prisma migrate status` command looks up the migrations in `/prisma/migrations/*` folder and the entries in the `_prisma_migrations` table and compiles information about the state of the migrations in your database.
+The `prisma migrate status` command looks up the migrations in `./prisma/migrations/*` folder and the entries in the `_prisma_migrations` table and compiles information about the state of the migrations in your database.
 
 <Admonition type="warning">
 

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -1303,12 +1303,13 @@ Other options:
     --to-url "postgresql://login:password@localhost:5432/db2"
   ```
 
-- Compare the state of a database with a URL of `$DATABASE_URL` to the schema defined by the migrations in the `./migrations` directory, and output the differences to a script `script.sql`:
+- Compare the state of a database with a URL of `$DATABASE_URL` to the schema defined by the migrations in the `./prisma/migrations` directory, and output the differences to a script `script.sql`:
 
   ```terminal
   prisma migrate diff \
    --from-url "$DATABASE_URL" \
-   --to-migrations ./migrations \
+   --to-migrations ./prisma/migrations \
+   --shadow-database-url $SHADOW_DATABASE_URL \
    --script > script.sql
   ```
 


### PR DESCRIPTION
I found 2 problems while looking at this issue, https://github.com/prisma/prisma/issues/14950#issuecomment-1691203291, and then looking at the docs

- the path to the migrations' directory should be `./prisma/migrations` or it would error with a misleading message at the moment.
- the missing required `--shadow-database-url` in that case
