### PR TITLE
fix: List under admonition indentation

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -275,7 +275,7 @@ model Category {
 
 This schema is the same as the [example data model](/concepts/components/prisma-schema/data-model) but has all [scalar fields](/concepts/components/prisma-schema/data-model#scalar-fields) removed (except for the required [relation scalars](/concepts/components/prisma-schema/relations#relation-scalar-fields)) so you can focus on the [relation fields](#relation-fields).
 
-  </Admonition>
+</Admonition>
 
 <Admonition type="info">
 

--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -28,7 +28,7 @@ const Admonition = ({ children, type, ...props }: AdmonitionProps) => {
         <FlexContainer>
           {children.map((child: any, index: number) =>
             child.props.originalType === 'ul' ? (
-              <ul key={index}>{child && child.props && child.props.children}</ul>
+              <ChildList key={index}>{child && child.props && child.props.children}</ChildList>
             ) : (
               <ChildDiv key={index}>{child && child.props && child.props.children}</ChildDiv>
             )
@@ -50,6 +50,10 @@ const FlexContainer = styled.div`
 
 const ChildDiv = styled.div`
   margin: 0;
+`
+
+const ChildList = styled.ul`
+  padding-left: 16px;
 `
 
 const AdmonitionWrapper = styled.span<{ type?: string }>`

--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -25,11 +25,13 @@ const Admonition = ({ children, type, ...props }: AdmonitionProps) => {
       )}
       {children && Array.isArray(children) ? (
         <FlexContainer>
-          {children.map((child: any, index: number) => (
-            <ChildContainer key={index}>
-              {child && child.props && child.props.children}
-            </ChildContainer>
-          ))}
+          {children.map((child: any, index: number) =>
+            child.props.originalType === 'ul' ? (
+              <ul key={index}>{child && child.props && child.props.children}</ul>
+            ) : (
+              <ChildDiv key={index}>{child && child.props && child.props.children}</ChildDiv>
+            )
+          )}
         </FlexContainer>
       ) : (
         children
@@ -45,19 +47,8 @@ const FlexContainer = styled.div`
   flex-direction: column;
 `
 
-const ChildContainer = styled.div`
+const ChildDiv = styled.div`
   margin: 0;
-
-  li {
-    margin-left: 24px;
-    margin-top: 10px;
-    &:first-of-type {
-      margin-top: 16px;
-    }
-    &:last-of-type {
-      margin-bottom: 16px;
-    }
-  }
 `
 
 const AdmonitionWrapper = styled.span<{ type?: string }>`

--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -50,6 +50,7 @@ const ChildContainer = styled.div`
 
   li {
     margin-left: 24px;
+    margin-top: 10px;
     &:first-of-type {
       margin-top: 16px;
     }

--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -1,7 +1,8 @@
-import { defaultTheme as theme } from '@prisma/lens/dist/web'
 import React from 'react'
 import { AlertCircle } from 'react-feather'
 import styled from 'styled-components'
+
+import { defaultTheme as theme } from '../../theme'
 
 interface AdmonitionType {
   type?: string

--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -1,7 +1,7 @@
+import { defaultTheme as theme } from '@prisma/lens/dist/web'
 import React from 'react'
-import styled from 'styled-components'
-import { defaultTheme as theme } from '../../theme'
 import { AlertCircle } from 'react-feather'
+import styled from 'styled-components'
 
 interface AdmonitionType {
   type?: string
@@ -47,6 +47,16 @@ const FlexContainer = styled.div`
 
 const ChildContainer = styled.div`
   margin: 0;
+
+  li {
+    margin-left: 24px;
+    &:first-of-type {
+      margin-top: 16px;
+    }
+    &:last-of-type {
+      margin-bottom: 16px;
+    }
+  }
 `
 
 const AdmonitionWrapper = styled.span<{ type?: string }>`


### PR DESCRIPTION
## Describe this PR

Lists inside Admonition components do not get the same margins as a regular list on the body.

## Changes

Added `margin-left`, `margin-top`, and `margin-bottom` to lists rendered under the `Admonition` component.

## What issue does this fix?

Fixes #4891 

## Any other relevant information

N/a