### PR TITLE
fix(metrics): 2 "Global labels" examples should be enough

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/240-metrics.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/240-metrics.mdx
@@ -454,7 +454,7 @@ console.log(metrics)
 
 This returns information in the following format:
 
-```json highlight=5,11,19,25,31,37,45;add
+```json highlight=5,11;add
 {
   "counters": [
     {
@@ -470,54 +470,6 @@ This returns information in the following format:
       "description": "The total number of queries executed"
     }
   ],
-  "gauges": [
-    {
-      "key": "prisma_pool_connections_busy",
-      "labels": { "server": "us_server1", "app_version": "one" },
-      "value": 0,
-      "description": "The number of active connections in use"
-    },
-    {
-      "key": "prisma_pool_connections_idle",
-      "labels": { "server": "us_server1", "app_version": "one" },
-      "value": 21,
-      "description": "The number of connections that are not being used"
-    },
-    {
-      "key": "prisma_client_queries_wait",
-      "labels": { "server": "us_server1", "app_version": "one" },
-      "value": 0,
-      "description": "The number of workers waiting for a connection"
-    },
-    {
-      "key": "prisma_client_queries_active",
-      "labels": { "server": "us_server1", "app_version": "one" },
-      "value": 0,
-      "description": "The number of active transactions"
-    }
-  ],
-  "histograms": [
-    {
-      "key": "prisma_client_queries_wait_histogram_ms",
-      "labels": { "server": "us_server1", "app_version": "one" },
-      "value": {
-        "buckets": [
-          [0, 0],
-          [1, 0],
-          [5, 0],
-          [10, 0],
-          [50, 0],
-          [100, 0],
-          [500, 0],
-          [1000, 0],
-          [5000, 0],
-          [50000, 0]
-        ],
-        "sum": 0,
-        "count": 0
-      },
-      "description": "The wait time for a worker to get a connection."
-    }
-  ]
+  ...
 }
 ```

--- a/content/200-concepts/100-components/02-prisma-client/240-metrics.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/240-metrics.mdx
@@ -468,8 +468,14 @@ This returns information in the following format:
       "labels": { "server": "us_server1", "app_version": "one" },
       "value": 0,
       "description": "The total number of queries executed"
-    }
+    },
+    ...
   ],
-  ...
+  "gauges": [
+    ...
+  ],
+  "histograms": [
+    ...
+  ]
 }
 ```


### PR DESCRIPTION
Right now the full diff is super distracting and does not add much.