### PR TITLE
fix: remove distributed from accelerate definition

### DIFF
--- a/content/800-data-platform/100-accelerate/100-what-is-accelerate.mdx
+++ b/content/800-data-platform/100-accelerate/100-what-is-accelerate.mdx
@@ -14,7 +14,7 @@ Its main features are:
 
 - a global cache
 - scalable connection pool for serverless and edge applications
-- usage of Prisma Client at the Edge (e.g. in Cloudflare Workers or Vercel Edge Functions)
+- usage of Prisma Client at the edge (e.g. in Cloudflare Workers or Vercel Edge Functions)
 
 The goal of Accelerate is to improve response times and reduce database load. It works by caching data at the edge using established caching patterns that you control.
 

--- a/content/800-data-platform/100-accelerate/100-what-is-accelerate.mdx
+++ b/content/800-data-platform/100-accelerate/100-what-is-accelerate.mdx
@@ -12,8 +12,8 @@ toc: true
 
 Its main features are:
 
-- a globally distributed cache
-- scalable connection pool for serverless applications
+- a global cache
+- scalable connection pool for serverless and edge applications
 - usage of Prisma Client at the Edge (e.g. in Cloudflare Workers or Vercel Edge Functions)
 
 The goal of Accelerate is to improve response times and reduce database load. It works by caching data at the edge using established caching patterns that you control.


### PR DESCRIPTION
- Accelerate is not a distributed cache; it's globally available.
- It's connection pooling features also benefit edge applications