### PR TITLE
fix: import statement for prisma in example code

### DIFF
--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -65,7 +65,7 @@ After creating this file, you can now import the extended `PrismaClient` instanc
 
 ```ts
 // e.g. in `pages/index.tsx`
-import { prisma } from './db'
+import prisma from './db'
 
 export const getServerSideProps = async () => {
   const posts = await prisma.post.findMany()


### PR DESCRIPTION
## Describe this PR

Received this following the instructions on this page: https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices

Attempted import error: 'prisma' is not exported from './db' (imported as 'prisma').

## Changes

Correct import statement to make the issue go away.

## What issue does this fix?

Fixes #5262

## Any other relevant information

N/A
