### PR TITLE
fix: add appropriate labels before titles and metatags

### DIFF
--- a/content/800-data-platform/100-accelerate/300-concepts.mdx
+++ b/content/800-data-platform/100-accelerate/300-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Accelerate: Concepts'
+title: 'Concepts'
 metaTitle: 'Accelerate: Concepts'
 metaDescription: 'Learn about the concepts that are important to understand when using Accelerate.'
 tocDepth: 3

--- a/content/800-data-platform/100-accelerate/300-concepts.mdx
+++ b/content/800-data-platform/100-accelerate/300-concepts.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Concepts'
-metaTitle: 'Concepts'
+title: 'Accelerate: Concepts'
+metaTitle: 'Accelerate: Concepts'
 metaDescription: 'Learn about the concepts that are important to understand when using Accelerate.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/100-accelerate/400-api-reference.mdx
+++ b/content/800-data-platform/100-accelerate/400-api-reference.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'API Reference'
-metaTitle: 'API Reference'
+title: 'Accelerate: API Reference'
+metaTitle: 'Accelerate: API Reference'
 metaDescription: 'API reference documentation for Accelerate.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/100-accelerate/400-api-reference.mdx
+++ b/content/800-data-platform/100-accelerate/400-api-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Accelerate: API Reference'
+title: 'API Reference'
 metaTitle: 'Accelerate: API Reference'
 metaDescription: 'API reference documentation for Accelerate.'
 tocDepth: 3

--- a/content/800-data-platform/100-accelerate/500-current-limitations.mdx
+++ b/content/800-data-platform/100-accelerate/500-current-limitations.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Accelerate: Current limitations'
+title: 'Current limitations'
 metaTitle: 'Accelerate: Current limitations'
 metaDescription: 'Learn about current limitations of Accelerate.'
 tocDepth: 3

--- a/content/800-data-platform/100-accelerate/500-current-limitations.mdx
+++ b/content/800-data-platform/100-accelerate/500-current-limitations.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Current limitations'
-metaTitle: 'Current limitations'
+title: 'Accelerate: Current limitations'
+metaTitle: 'Accelerate: Current limitations'
 metaDescription: 'Learn about current limitations of Accelerate.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/100-accelerate/600-faq.mdx
+++ b/content/800-data-platform/100-accelerate/600-faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Accelerate: FAQ'
+title: 'FAQ'
 metaTitle: 'Accelerate: FAQ'
 metaDescription: 'Frequently asked questions about Accelerate.'
 tocDepth: 3

--- a/content/800-data-platform/100-accelerate/600-faq.mdx
+++ b/content/800-data-platform/100-accelerate/600-faq.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'FAQ'
-metaTitle: 'FAQ'
+title: 'Accelerate: FAQ'
+metaTitle: 'Accelerate: FAQ'
 metaDescription: 'Frequently asked questions about Accelerate.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/100-accelerate/700-feedback.mdx
+++ b/content/800-data-platform/100-accelerate/700-feedback.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Accelerate: Feedback'
+title: 'Feedback'
 metaTitle: 'Accelerate: Feedback'
 metaDescription: 'Learn where to submit feedback about Accelerate.'
 tocDepth: 3

--- a/content/800-data-platform/100-accelerate/700-feedback.mdx
+++ b/content/800-data-platform/100-accelerate/700-feedback.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Feedback'
-metaTitle: 'Feedback'
+title: 'Accelerate: Feedback'
+metaTitle: 'Accelerate: Feedback'
 metaDescription: 'Learn where to submit feedback about Accelerate.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/200-pulse/300-concepts.mdx
+++ b/content/800-data-platform/200-pulse/300-concepts.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Concepts'
-metaTitle: 'Concepts'
+title: 'Pulse: Concepts'
+metaTitle: 'Pulse: Concepts'
 metaDescription: 'Learn about the concepts that are important to understand when using Pulse.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/200-pulse/300-concepts.mdx
+++ b/content/800-data-platform/200-pulse/300-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Pulse: Concepts'
+title: 'Concepts'
 metaTitle: 'Pulse: Concepts'
 metaDescription: 'Learn about the concepts that are important to understand when using Pulse.'
 tocDepth: 3

--- a/content/800-data-platform/200-pulse/400-api-reference.mdx
+++ b/content/800-data-platform/200-pulse/400-api-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Pulse: API Reference'
+title: 'API Reference'
 metaTitle: 'Pulse: API Reference'
 metaDescription: 'API reference documentation for Pulse.'
 tocDepth: 4

--- a/content/800-data-platform/200-pulse/400-api-reference.mdx
+++ b/content/800-data-platform/200-pulse/400-api-reference.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'API Reference'
-metaTitle: 'API Reference'
+title: 'Pulse: API Reference'
+metaTitle: 'Pulse: API Reference'
 metaDescription: 'API reference documentation for Pulse.'
 tocDepth: 4
 toc: true

--- a/content/800-data-platform/200-pulse/500-current-limitations.mdx
+++ b/content/800-data-platform/200-pulse/500-current-limitations.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Current limitations'
-metaTitle: 'Current limitations'
+title: 'Pulse: Current limitations'
+metaTitle: 'Pulse: Current limitations'
 metaDescription: 'Learn about current limitations of Pulse.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/200-pulse/500-current-limitations.mdx
+++ b/content/800-data-platform/200-pulse/500-current-limitations.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Pulse: Current limitations'
+title: 'Current limitations'
 metaTitle: 'Pulse: Current limitations'
 metaDescription: 'Learn about current limitations of Pulse.'
 tocDepth: 3

--- a/content/800-data-platform/200-pulse/600-faq.mdx
+++ b/content/800-data-platform/200-pulse/600-faq.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'FAQ'
-metaTitle: 'FAQ'
+title: 'Pulse: FAQ'
+metaTitle: 'Pulse: FAQ'
 metaDescription: 'Frequently asked questions about Pulse.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/200-pulse/600-faq.mdx
+++ b/content/800-data-platform/200-pulse/600-faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Pulse: FAQ'
+title: 'FAQ'
 metaTitle: 'Pulse: FAQ'
 metaDescription: 'Frequently asked questions about Pulse.'
 tocDepth: 3

--- a/content/800-data-platform/200-pulse/700-feedback.mdx
+++ b/content/800-data-platform/200-pulse/700-feedback.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Feedback'
-metaTitle: 'Feedback'
+title: 'Pulse: Feedback'
+metaTitle: 'Pulse: Feedback'
 metaDescription: 'Learn where to submit feedback about Pulse.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/200-pulse/700-feedback.mdx
+++ b/content/800-data-platform/200-pulse/700-feedback.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Pulse: Feedback'
+title: 'Feedback'
 metaTitle: 'Pulse: Feedback'
 metaDescription: 'Learn where to submit feedback about Pulse.'
 tocDepth: 3

--- a/content/800-data-platform/300-cloud-projects/300-faq.mdx
+++ b/content/800-data-platform/300-cloud-projects/300-faq.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'FAQ'
-metaTitle: 'FAQ'
+title: 'Cloud Projects: FAQ'
+metaTitle: 'Cloud Projects: FAQ'
 metaDescription: 'Frequently asked questions about the Cloud Projects platform.'
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/300-cloud-projects/300-faq.mdx
+++ b/content/800-data-platform/300-cloud-projects/300-faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Cloud Projects: FAQ'
+title: 'FAQ'
 metaTitle: 'Cloud Projects: FAQ'
 metaDescription: 'Frequently asked questions about the Cloud Projects platform.'
 tocDepth: 3

--- a/content/800-data-platform/300-cloud-projects/400-support.mdx
+++ b/content/800-data-platform/300-cloud-projects/400-support.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Support'
-metaTitle: 'Support'
+title: 'Cloud Projects: Support'
+metaTitle: 'Cloud Projects: Support'
 metaDescription: ''
 tocDepth: 3
 toc: true

--- a/content/800-data-platform/300-cloud-projects/400-support.mdx
+++ b/content/800-data-platform/300-cloud-projects/400-support.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Cloud Projects: Support'
+title: 'Support'
 metaTitle: 'Cloud Projects: Support'
 metaDescription: ''
 tocDepth: 3


### PR DESCRIPTION
closes #5267 