### PR TITLE
Use `terminal` instead of `sh` language annotation on terminal commands

### DIFF
--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection.mdx
@@ -31,7 +31,7 @@ Next, add some posts to our `Post` collection. It's important that the ObjectID 
 
 Now that you have a MongoDB database, the next step is to create a new project and initialize Prisma:
 
-```sh copy
+```terminal copy
 mkdir blog
 cd blog
 npm init -y
@@ -58,7 +58,7 @@ Next you'll need to adjust your `.env` file to point the `DATABASE_URL` to your 
 
 You're now ready to introspect. Run the following command to introspect your database:
 
-```sh copy
+```terminal copy
 npx prisma db pull
 ```
 

--- a/content/200-concepts/100-components/01-prisma-schema/08-views.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/08-views.mdx
@@ -236,7 +236,7 @@ If you have an existing view or views defined in your database, [introspection](
 
 Assuming the example `UserInfo` view exists in your underlying database, running the following command will generate a `view` block in your Prisma schema representing that view:
 
-```sh copy
+```terminal copy
 npx prisma db pull
 ```
 

--- a/content/200-concepts/100-components/08-prisma-engines/index.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/index.mdx
@@ -123,7 +123,7 @@ The output shows that the query engine path comes from the `PRISMA_QUERY_ENGINE_
 
    <tab>
 
-```sh highlight=2;normal
+```terminal highlight=2;normal
 Current platform     : darwin
 Query Engine         : query-engine d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /custom/my-query-engine-unix)
 Migration Engine     : migration-engine-cli d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at /myproject/node_modules/@prisma/engines/migration-engine-unix)
@@ -133,7 +133,7 @@ Introspection Engine : introspection-core d6ff7119649922b84e413b3b69660e2f49e2dd
    </tab>
    <tab>
 
-```sh highlight=2;normal
+```terminal highlight=2;normal
 Current platform     : windows
 Query Engine         : query-engine d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\custom\my-query-engine-windows.exe)
 Migration Engine     : migration-engine-cli d6ff7119649922b84e413b3b69660e2f49e2ddf3 (at c:\myproject\node_modules\@prisma\engines\migration-engine-windows.exe)

--- a/content/300-guides/125-development-environment/050-environment-variables/index.mdx
+++ b/content/300-guides/125-development-environment/050-environment-variables/index.mdx
@@ -113,8 +113,7 @@ datasource db {
 
 You can set the `DATABASE_URL` in your `.env` file:
 
-```
-# .env
+```env file=.env
 DATABASE_URL=postgresql://test:test@localhost:5432/test?schema=public
 ```
 

--- a/content/300-guides/200-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -43,7 +43,7 @@ Your functions will need the `DATABASE_URL` environment variable to access the d
 
 First, make sure that the plugin is installed:
 
-```sh
+```terminal
 npm install -D serverless-dotenv-plugin
 ```
 
@@ -59,14 +59,14 @@ The environment variables in your `.env` file will now be automatically loaded o
 <CodeWithResult expanded="{true}">
 <cmd>
 
-```sh
+```terminal
 serverless package
 ```
 
 </cmd>
 <cmdResult>
 
-```sh no-copy
+```terminal no-copy
 Running "serverless" from node_modules
 DOTENV: Loading environment variables from .env:
          - DATABASE_URL
@@ -122,7 +122,7 @@ If you use `serverless-webpack`, you will need additional configuration so that 
 
 First, ensure the following webpack dependencies are installed:
 
-```sh
+```terminal
 npm install --save-dev webpack webpack-node-externals copy-webpack-plugin serverless-webpack
 ```
 
@@ -195,7 +195,7 @@ custom:
         -- find . -name "libquery_engine-*" -not -name "libquery_engine-rhel-openssl-*" | xargs rm
 ```
 
-If you are deploying to [Lambda functions with ARM64 architecture](#lambda-functions-with-arm64-architectures) you should update the find command to the following:
+If you are deploying to [Lambda functions with ARM64 architecture](#lambda-functions-with-arm64-architectures) you should update the `find` command to the following:
 
 ```sh
 find . -name "libquery_engine-*" -not -name "libquery_engine-arm64-openssl-*" | xargs rm
@@ -208,14 +208,14 @@ You can now re-package and re-deploy your application. To do so, run `serverless
 <CodeWithResult expanded="{true}">
 <cmd>
 
-```sh
+```terminal
 serverless package
 ```
 
 </cmd>
 <cmdResult>
 
-```sh no-copy
+```terminal no-copy
 Running "serverless" from node_modules
 DOTENV: Loading environment variables from .env:
          - DATABASE_URL

--- a/content/300-guides/200-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -197,8 +197,13 @@ custom:
 
 If you are deploying to [Lambda functions with ARM64 architecture](#lambda-functions-with-arm64-architectures) you should update the `find` command to the following:
 
-```sh
-find . -name "libquery_engine-*" -not -name "libquery_engine-arm64-openssl-*" | xargs rm
+```yaml file=serverless.yml highlight=6;add
+custom:
+  webpack:
+    packagerOptions:
+      scripts:
+        - prisma generate
+        -- find . -name "libquery_engine-*" -not -name "libquery_engine-arm64-openssl-*" | xargs rm
 ```
 
 ### 4. Wrapping up

--- a/content/300-guides/200-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/300-guides/200-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -56,7 +56,7 @@ plugins:
 
 The environment variables in your `.env` file will now be automatically loaded on package or deployment.
 
-<CodeWithResult expanded="{true}">
+<CodeWithResult>
 <cmd>
 
 ```terminal
@@ -205,7 +205,7 @@ find . -name "libquery_engine-*" -not -name "libquery_engine-arm64-openssl-*" | 
 
 You can now re-package and re-deploy your application. To do so, run `serverless deploy`. Webpack output will show the schema file being moved with `copy-webpack-plugin`:
 
-<CodeWithResult expanded="{true}">
+<CodeWithResult>
 <cmd>
 
 ```terminal

--- a/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
+++ b/content/300-guides/400-migrate-to-prisma/01-migrate-from-typeorm.mdx
@@ -356,13 +356,13 @@ Assume you have the following database connection details in `ormconfig.json`:
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="postgresql://alice:myPassword42@localhost:5432/blog-typeorm"
 ```
 
 Note that you can optionally configure the PostgreSQL [schema](https://www.postgresql.org/docs/9.1/ddl-schemas.html) by appending the `schema` argument to the connection URL:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="postgresql://alice:myPassword42@localhost:5432/blog-typeorm?schema=myschema"
 ```
 
@@ -387,7 +387,7 @@ Assume you have the following database connection details in `ormconfig.json`:
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="mysql://alice:myPassword42@localhost:3306/blog-typeorm"
 ```
 
@@ -410,7 +410,7 @@ Assume you have the following database connection details in `ormconfig.json`:
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="sqlserver://localhost:1433;database=blog-typeorm;user=alice;password=myPassword42;trustServerCertificate=true"
 ```
 
@@ -429,7 +429,7 @@ Assume you have the following database connection details in `ormconfig.json`:
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="file:./blog-typeorm.db"
 ```
 

--- a/content/300-guides/400-migrate-to-prisma/02-migrate-from-sequelize.mdx
+++ b/content/300-guides/400-migrate-to-prisma/02-migrate-from-sequelize.mdx
@@ -284,13 +284,13 @@ const sequelize = new Sequelize('blog-sequelize', 'alice', 'myPassword42', {
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="postgresql://alice:myPassword42@localhost:5432/blog-sequelize"
 ```
 
 Note that you can optionally configure the PostgreSQL [schema](https://www.postgresql.org/docs/9.1/ddl-schemas.html) by appending the `schema` argument to the connection URL:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="postgresql://alice:myPassword42@localhost:5432/blog-sequelize?schema=myschema"
 ```
 
@@ -311,7 +311,7 @@ const sequelize = new Sequelize('blog-sequelize', 'alice', 'myPassword42', {
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="mysql://alice:myPassword42@localhost:3306/blog-sequelize"
 ```
 
@@ -330,7 +330,7 @@ const sequelize = new Sequelize('blog-sequelize', 'alice', 'myPassword42', {
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="sqlserver://localhost:1433;database=blog-sequelize;user=alice;password=myPassword42;trustServerCertificate=true"
 ```
 
@@ -349,7 +349,7 @@ const sequelize = new Sequelize({
 
 The respective connection URL would look as follows in Prisma:
 
-```sh file=.env
+```env file=.env
 DATABASE_URL="file:./blog-sequelize.db"
 ```
 

--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/425-nextjs-prisma-client-monorepo.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/425-nextjs-prisma-client-monorepo.mdx
@@ -64,7 +64,7 @@ To work around this issue, you can use a custom Webpack plugin we created that c
 
 To use this plugin, first install the package:
 
-```shell copy
+```terminal copy
 npm install -D @prisma/nextjs-monorepo-workaround-plugin
 ```
 

--- a/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/200-prisma-docs/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -259,7 +259,7 @@ When you need to provide a series of CLI commands as instructions to the reader,
 
 #### Better
 
-```shell
+```terminal
 cd path/to/server
 docker-compose up -d --build
 ./node_modules/.bin/sequelize db:migrate # or `npx sequelize db:migrate`

--- a/content/800-data-platform/100-accelerate/200-getting-started.mdx
+++ b/content/800-data-platform/100-accelerate/200-getting-started.mdx
@@ -48,7 +48,6 @@ Most likely, as shown above, your database connection string in defined in a `.e
 Update that variable to use the new Accelerate connection string:
 
 ```env file=.env
-# .env
 # __API_KEY__ is a unique API key that Accelerate generates and automatically assigns to a project.
 DATABASE_URL="prisma://accelerate.prisma-data.net/?api_key=__API_KEY__"
 
@@ -59,7 +58,6 @@ DATABASE_URL="prisma://accelerate.prisma-data.net/?api_key=__API_KEY__"
 Prisma Migrate and Prisma Studio do not work with a `prisma://` connection string. In order to continue using these features add a new variable to the `.env` file named `DIRECT_DATABASE_URL` whose value is the direct database connection string:
 
 ```env file=.env highlight=3;add
-# .env
 DATABASE_URL="prisma://accelerate.prisma-data.net/?api_key=__API_KEY__"
 DIRECT_DATABASE_URL="postgresql://user:password@host:port/db_name?schema=public"
 ```

--- a/content/800-data-platform/100-accelerate/200-getting-started.mdx
+++ b/content/800-data-platform/100-accelerate/200-getting-started.mdx
@@ -47,7 +47,7 @@ Most likely, as shown above, your database connection string in defined in a `.e
 
 Update that variable to use the new Accelerate connection string:
 
-```shell
+```env file=.env
 # .env
 # __API_KEY__ is a unique API key that Accelerate generates and automatically assigns to a project.
 DATABASE_URL="prisma://accelerate.prisma-data.net/?api_key=__API_KEY__"
@@ -58,7 +58,7 @@ DATABASE_URL="prisma://accelerate.prisma-data.net/?api_key=__API_KEY__"
 
 Prisma Migrate and Prisma Studio do not work with a `prisma://` connection string. In order to continue using these features add a new variable to the `.env` file named `DIRECT_DATABASE_URL` whose value is the direct database connection string:
 
-```shell highlight=3;add
+```env file=.env highlight=3;add
 # .env
 DATABASE_URL="prisma://accelerate.prisma-data.net/?api_key=__API_KEY__"
 DIRECT_DATABASE_URL="postgresql://user:password@host:port/db_name?schema=public"
@@ -80,7 +80,7 @@ Prisma Migrate and Prisma Studio will use the `directUrl` connection string rath
 
 Run the following command to install the Accelerate extension for Prisma Client:
 
-```shell
+```terminal
 npm install @prisma/extension-accelerate
 ```
 
@@ -98,7 +98,7 @@ generator client {
 
 Run the following command to generate Prisma Client for Accelerate:
 
-```shell
+```terminal
 npx prisma generate --accelerate
 ```
 
@@ -106,7 +106,7 @@ npx prisma generate --accelerate
 
 If your Prisma version is below `5.0.0`, generate Prisma Client with the `--data-proxy` option:
 
-```shell
+```terminal
 npx prisma generate --data-proxy
 ```
 

--- a/content/800-data-platform/200-pulse/200-getting-started.mdx
+++ b/content/800-data-platform/200-pulse/200-getting-started.mdx
@@ -132,7 +132,7 @@ The following will show how you can utilize Pulse in an existing application. We
 
 In a project using [Prisma Client](/concepts/components/prisma-client), run the following command to install the Pulse extension:
 
-```shell
+```terminal
 npm install @prisma/extension-pulse
 ```
 
@@ -148,8 +148,7 @@ You should have received an API key from the Cloud Projects dashboard when setti
 
 In `.env`, add a variable named `PULSE_API_KEY`:
 
-```shell
-# .env
+```env file=.env
 PULSE_API_KEY="YOUR-API-KEY"
 
 # Example:

--- a/content/800-data-platform/300-cloud-projects/200-platform/200-projects.mdx
+++ b/content/800-data-platform/300-cloud-projects/200-platform/200-projects.mdx
@@ -58,8 +58,7 @@ Accelerate requires your project API key to be passed via the `prisma://` connec
 
 To apply your project API key to an Accelerate connection string, add the `api_key` parameter with the API key as the value:
 
-```shell
-# .env
+```env file=.env
 ACCELERATE_URL=prisma://accelerate.prisma-data.net/?api_key=__API_KEY__
 ```
 
@@ -75,8 +74,7 @@ Pulse requires the project API key to be passed when extending Prisma Client wit
 
 To apply your project API key, create an environment variable that holds your API key:
 
-```shell
-# .env
+```env file=.env
 PRISMA_API_KEY=__API_KEY__
 ```
 


### PR DESCRIPTION
Fixes #5287

## Describe this PR

Updates most usage of `sh` to `terminal` for code snippets.