### PR TITLE
Update 050-prisma-client-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -1264,7 +1264,7 @@ const deleteUser = await prisma.user.delete({
 
 | Name              | Type                              | Required | Description                                                                                                                                                                                                                                                                   |
 | ----------------- | --------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data`            | `Enumerable<UserCreateManyInput>` | **Yes**  | Wraps all the model fields in a type so that they can be provided when creating new records. It also includes relation fields which lets you perform (transactional) nested inserts. Fields that are marked as optional or have default values in the datamodel are optional. |
+| `data`            | `Enumerable<UserCreateManyInput>` | **Yes**  | Wraps all the model fields in a type so that they can be provided when creating new records. Fields that are marked as optional or have default values in the datamodel are optional. |
 | `skipDuplicates?` | `boolean`                         | No       | Do not insert records with unique fields or ID fields that already exist. Only supported by databases that support [`ON CONFLICT DO NOTHING`](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT). This excludes MongoDB and SQLServer                       |
 
 #### Return type


### PR DESCRIPTION
## Describe this PR

Fix the reference which states that `createMany` allows nested writes: https://github.com/prisma/prisma/issues/8131

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
