### PR TITLE
Fix case on `pgbouncer=true` param

### DIFF
--- a/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
+++ b/content/300-guides/100-performance-and-optimization/150-connection-management/index.mdx
@@ -304,7 +304,7 @@ If you would like to use the Prisma CLI in order to perform other actions on you
 
 ```env file=.env highlight=4,5;add
 # Connection URL to your database using PgBouncer.
-DATABASE_URL="postgres://root:password@127.0.0.1:54321/postgres?pgBouncer=true"
+DATABASE_URL="postgres://root:password@127.0.0.1:54321/postgres?pgbouncer=true"
 
 # Direct connection URL to the database used for migrations
 DIRECT_URL="postgres://root:password@127.0.0.1:5432/postgres"


### PR DESCRIPTION
## Describe this PR

Fix the case of the param `pgbouncer` in page "Connection management".
It must be lowercased, this page currently has it with a uppercased `B`.
All other pages have already the correct lowercased version.

## Changes

- Fix case on param `pgbouncer` in page "Connection management"
