### PR TITLE
bugfix(search): inner search input focused on query string

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -159,8 +159,6 @@ export default function Layout({
   const [mobileNavOpen, setMobileNav] = useState(false)
   const [showDocsBtn, setShowDocsBtn] = React.useState(true)
   const queryString = new URLSearchParams(location?.search).get('query')
-
-  console.log(queryString)
   const [value, setValue] = useState(queryString || '')
 
   const closeSidenavSearch = () => setShowDocsBtn(true)

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -158,8 +158,10 @@ export default function Layout({
   const { header, footer } = site.siteMetadata
   const [mobileNavOpen, setMobileNav] = useState(false)
   const [showDocsBtn, setShowDocsBtn] = React.useState(true)
+  const queryString = new URLSearchParams(location?.search).get('query')
 
-  const [value, setValue] = useState('')
+  console.log(queryString)
+  const [value, setValue] = useState(queryString || '')
 
   const closeSidenavSearch = () => setShowDocsBtn(true)
 

--- a/src/components/search/minimalInput.tsx
+++ b/src/components/search/minimalInput.tsx
@@ -162,7 +162,6 @@ const SearchSlashIcon = styled(SearchSlash)`
 const focusShortcuts = ['s', 191]
 
 const SearchBox = ({ showHeaderSearch, value }: any) => {
-  console.log('value:', value)
   const inputEl = React.useRef(null)
   const onKeyDown = (e: any) => {
     const shortcuts = focusShortcuts.map((key) =>

--- a/src/components/search/minimalInput.tsx
+++ b/src/components/search/minimalInput.tsx
@@ -162,6 +162,7 @@ const SearchSlashIcon = styled(SearchSlash)`
 const focusShortcuts = ['s', 191]
 
 const SearchBox = ({ showHeaderSearch, value }: any) => {
+  console.log('value:', value)
   const inputEl = React.useRef(null)
   const onKeyDown = (e: any) => {
     const shortcuts = focusShortcuts.map((key) =>
@@ -197,6 +198,12 @@ const SearchBox = ({ showHeaderSearch, value }: any) => {
       document.removeEventListener('keydown', onKeyDown)
     }
   }, [])
+
+  React.useEffect(() => {
+    if (value) {
+      inputEl.current.focus()
+    }
+  }, [value])
 
   return (
     <SearchBoxDiv>


### PR DESCRIPTION
## Describe this PR

Inner search input does not open the input by default on query string

## Changes

Made input element focus on query string

## What issue does this fix?

Fixes #5212 


