### PR TITLE
Update 06-features-without-psl-equivalent.mdx

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-features-without-psl-equivalent.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-features-without-psl-equivalent.mdx
@@ -83,7 +83,7 @@ Database error: Error querying the database: db error: ERROR: type "pgcrypto" do
 
 ## Unsupported field types
 
-Some database types of relational databases, such as `polygon` or `geometry`, do not have a Prisma Schema Language equivalent (Prisma supports all types of MongoDB). Use the [`Unsupported`](/reference/api-reference/prisma-schema-reference#unsupported) <span class="api"></span> field type to represent the field in your Prisma schema:
+Some database types of relational databases, such as `polygon` or `geometry`, do not have a Prisma Schema Language equivalent. Use the [`Unsupported`](/reference/api-reference/prisma-schema-reference#unsupported) <span class="api"></span> field type to represent the field in your Prisma schema:
 
 ```prisma highlight=3;normal
 model Star {


### PR DESCRIPTION
Removed statement that Prisma supports all MongoDB types, because it's not true for geo types like `Point`,...

- https://github.com/prisma/prisma/discussions/21046
- https://www.mongodb.com/docs/manual/reference/geojson/