### PR TITLE
fix: Use default .env location in out examples

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database.mdx
@@ -220,7 +220,7 @@ In this case, the `url` is [set via an environment variable](/concepts/component
 
 The following example connection URL [uses SQL authentication](/concepts/database-connectors/sql-server), but there are [other ways to format your connection URL](/concepts/database-connectors/sql-server)
 
-```bash file=prisma/.env
+```bash file=.env
   DATABASE_URL="sqlserver://localhost:1433;database=mydb;user=sa;password=r@ndomP@$$w0rd;trustServerCertificate=true"
 ```
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database.mdx
@@ -199,7 +199,7 @@ datasource db {
 
 The `url` is [set via an environment variable](/concepts/components/prisma-schema#accessing-environment-variables-from-the-schema), the following example connection URL [uses SQL authentication](/concepts/database-connectors/sql-server), but there are [other ways to format your connection URL](/concepts/database-connectors/sql-server)
 
-```bash file=prisma/.env
+```bash file=.env
 DATABASE_URL="sqlserver://localhost:1433;database=mydb;user=sa;password=r@ndomP@$$w0rd;trustServerCertificate=true"
 ```
 

--- a/content/200-concepts/100-components/01-prisma-schema/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/index.mdx
@@ -170,7 +170,7 @@ The Prisma CLI looks for the Prisma schema file in the following locations, in t
 The Prisma CLI outputs the path of the schema file that will be used. The following example shows the terminal output for `prisma db pull`:
 
 ```no-lines
-Environment variables loaded from prisma/.env
+Environment variables loaded from .env
 |Prisma Schema loaded from prisma/schema.prisma
 
 Introspecting based on datasource defined in prisma/schema.prisma …

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -199,7 +199,7 @@ prisma version
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from ./.env
+Environment variables loaded from .env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
 Current platform     : windows
@@ -229,7 +229,7 @@ prisma -v
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from ./.env
+Environment variables loaded from .env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
 Current platform     : windows
@@ -259,7 +259,7 @@ prisma version --json
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from prisma\.env
+Environment variables loaded from .env
 {
   "prisma": "2.21.0-dev.4",
   "@prisma/client": "2.21.0-dev.4",

--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -199,7 +199,7 @@ prisma version
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from ./prisma/.env
+Environment variables loaded from ./.env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
 Current platform     : windows
@@ -229,7 +229,7 @@ prisma -v
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from ./prisma/.env
+Environment variables loaded from ./.env
 prisma               : 2.21.0-dev.4
 @prisma/client       : 2.21.0-dev.4
 Current platform     : windows
@@ -351,7 +351,7 @@ generator client {
 }
 ```
 
-**`prisma/.env`**
+**`.env`**
 
 A file to define environment variables for your project:
 
@@ -393,7 +393,7 @@ generator client {
 }
 ```
 
-**`prisma/.env`**
+**`.env`**
 
 A file to define environment variables for your project:
 
@@ -564,7 +564,7 @@ prisma validate
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from prisma/.env
+Environment variables loaded from .env
 Prisma schema loaded from prisma/schema.prisma
 The schema at /absolute/path/prisma/schema.prisma is valid 🚀
 ```
@@ -585,7 +585,7 @@ prisma validate
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from prisma/.env
+Environment variables loaded from .env
 Prisma schema loaded from prisma/schema.prisma
 Error: Schema validation error - Error (query-engine-node-api library)
 Error code: P1012
@@ -630,7 +630,7 @@ prisma format
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from prisma/.env
+Environment variables loaded from .env
 Prisma schema loaded from prisma/schema.prisma
 Formatted prisma/schema.prisma in 116ms �
 ```
@@ -651,7 +651,7 @@ prisma format
 <cmdResult>
 
 ```code no-copy
-Environment variables loaded from prisma/.env
+Environment variables loaded from .env
 Prisma schema loaded from prisma/schema.prisma
 Error: Schema validation error - Error (query-engine-node-api library)
 Error code: P1012


### PR DESCRIPTION
Fix location to avoid confusion