### PR TITLE
fix: tab titles not showing ` | Prisma`

### DIFF
--- a/src/templates/docs.tsx
+++ b/src/templates/docs.tsx
@@ -55,7 +55,7 @@ const ArticleLayout = ({ data, ...props }: ArticleLayoutProps) => {
 export default ArticleLayout
 
 export const Head = ({ pageContext: { seoTitle, seoDescription } }: ArticleLayoutProps) => {
-  return <SEO title={seoTitle} description={seoDescription} homepage />
+  return <SEO title={seoTitle} homepage={false} description={seoDescription} />
 }
 
 export const query = graphql`

--- a/src/templates/docs.tsx
+++ b/src/templates/docs.tsx
@@ -1,13 +1,12 @@
-import { RouterProps } from '@reach/router'
+import { RouterProps, navigate } from '@reach/router'
+import { graphql } from 'gatsby'
+import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer'
 import * as React from 'react'
-import { ArticleQueryData } from '../interfaces/Article.interface'
 import Layout from '../components/layout'
-import TopSection from '../components/topSection'
 import PageBottom from '../components/pageBottom'
 import SEO from '../components/seo'
-import { graphql, useStaticQuery } from 'gatsby'
-import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer'
-import { navigate } from '@reach/router'
+import TopSection from '../components/topSection'
+import { ArticleQueryData } from '../interfaces/Article.interface'
 import { CreatePageContext } from '../interfaces/Layout.interface'
 
 type ArticleLayoutProps = ArticleQueryData & RouterProps & CreatePageContext


### PR DESCRIPTION
## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

Tab titles don't show ` | Prisma`, but I think they should. If I favorite a Prisma docs page, I'd like to be able to find it easily by typing `prisma` into my browser's address bar, as opposed to trying to remember the specific title of the page I favorited.

## Changes

This hardcodes `homepage` to `false` in `src/templates/docs.tsx`.

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

This change fixes #5315.

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->