### PR TITLE
change: page title for tech switcher paths to have `:` instead of `|`

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -35,7 +35,7 @@ const getTitle = (frontmatter: any, lang?: any, db?: any) => {
     const titleEntry = frontmatter.techMetaTitles
       ? frontmatter.techMetaTitles.find((item: any) => item.name === queryParam)
       : null
-    pageSeoTitle = titleEntry ? titleEntry.value : `${pageSeoTitle} | ${queryParam}`
+    pageSeoTitle = titleEntry ? titleEntry.value : `${pageSeoTitle} : ${queryParam}`
   }
   return pageSeoTitle
 }


### PR DESCRIPTION
Page title for tech switcher paths to have `:` instead of `|` since the title suffix is `| Prisma Docs`

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
