### PR TITLE
docs: remove incorrect link

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -3228,7 +3228,7 @@ Set a timestamp of the time when a record is created.
   | PostgreSQL  | [`CURRENT_TIMESTAMP`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT) and aliases like `now()`      |
   | MySQL       | [`CURRENT_TIMESTAMP`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_current-timestamp) and aliases like `now()` |
   | SQLite      | `CURRENT_TIMESTAMP` and aliases like `date('now')`                                                                                              |
-  | CockroachDB | [`CURRENT_TIMESTAMP`](https://www.cockroachlabs.com/docs/stable/functions-and-operators#special-syntax-forms) and aliases like `now()`                                                                                                    |
+  | CockroachDB | [`CURRENT_TIMESTAMP`](https://www.cockroachlabs.com/docs/stable/functions-and-operators#special-syntax-forms) and aliases like `now()`          |
 
 ##### MongoDB
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -3228,7 +3228,7 @@ Set a timestamp of the time when a record is created.
   | PostgreSQL  | [`CURRENT_TIMESTAMP`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT) and aliases like `now()`      |
   | MySQL       | [`CURRENT_TIMESTAMP`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_current-timestamp) and aliases like `now()` |
   | SQLite      | `CURRENT_TIMESTAMP` and aliases like `date('now')`                                                                                              |
-  | CockroachDB | `CURRENT_TIMESTAMP` and aliases like `now()`                                                                                                    |
+  | CockroachDB | [`CURRENT_TIMESTAMP`](https://www.cockroachlabs.com/docs/stable/functions-and-operators#special-syntax-forms) and aliases like `now()`                                                                                                    |
 
 ##### MongoDB
 

--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -3228,7 +3228,7 @@ Set a timestamp of the time when a record is created.
   | PostgreSQL  | [`CURRENT_TIMESTAMP`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT) and aliases like `now()`      |
   | MySQL       | [`CURRENT_TIMESTAMP`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_current-timestamp) and aliases like `now()` |
   | SQLite      | `CURRENT_TIMESTAMP` and aliases like `date('now')`                                                                                              |
-  | CockroachDB | [`CURRENT_TIMESTAMP`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT) and aliases like `now()`      |
+  | CockroachDB | `CURRENT_TIMESTAMP` and aliases like `now()`                                                                                                    |
 
 ##### MongoDB
 


### PR DESCRIPTION
## Describe this PR

Link mentioned for cockroach db redirects to postgresql documentation. 

## Changes

Remove incorrect link **prisma-schema-reference**

## Any other relevant information

n/a
