### PR TITLE
excluding-fields.mdx: add obfuscate fields to Going Further list

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/063-excluding-fields.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/063-excluding-fields.mdx
@@ -66,4 +66,5 @@ These generics flow through the logic, returning a `User` that omits the list of
 ## Going further
 
 - Learn how you can move the `exclude` function into [a custom model](/concepts/components/prisma-client/custom-models).
+- Instead of excluding fields, another option is to [obfuscate the field](https://github.com/prisma/prisma-client-extensions/tree/main/obfuscated-fields).
 - There's an [outstanding feature request](https://github.com/prisma/prisma/issues/5042) to add exclude support natively in Prisma Client. If you'd like to see that happen, make sure to upvote that issue and share your use case!


### PR DESCRIPTION
## Describe this PR

We wanted to exclude certain fields from our models. Information to obfuscate fields was only located within GitHub. Documentation should show this as an alternative to exclusion. 


## Changes

- Add obfuscate fields to Going Further list in Exclude Fields 
