### PR TITLE
03-primsa-and-mongoose.mdx fix typo

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/03-prisma-and-mongoose.mdx
+++ b/content/200-concepts/300-more/400-comparisons/03-prisma-and-mongoose.mdx
@@ -101,7 +101,7 @@ const posts = await prisma.post.findMany({
 **Mongoose**
 
 ```ts
-const user = await Post.find({
+const posts = await Post.find({
   title: 'Hello World',
 })
 ```


### PR DESCRIPTION
## Changes

Fix typo from 'users' to 'posts'.

## What issue does this fix?

Fixes #5302 
