### PR TITLE
docs: fix broken link in docs

### DIFF
--- a/content/300-guides/200-deployment/650-caveats-when-deploying-to-aws-platforms.mdx
+++ b/content/300-guides/200-deployment/650-caveats-when-deploying-to-aws-platforms.mdx
@@ -52,8 +52,8 @@ The [deployment package (.zip) size limit for lambdas is 50MB](https://docs.aws.
 
 Prisma CLI downloads additional engine binaries that are **not required** in production. You can delete the following files and folders:
 
-1. The entire `node_modules/@prisma/engines` folder (refer to the [sample bash script](https://github.com/prisma/e2e-tests/blob/dev/platforms-serverless/lambda/zip.sh) used by the Prisma end-to-end tests)
-1. The **local engine file** for your development platform from the `node_modules/.prisma/client` folder. For example, your schema might define the following `binaryTargets` if you develop on Debian (`native`) but deploy to AWS Lambda (`rhel-openssl-1.0.x`):
+1. The entire `node_modules/@prisma/engines` folder (refer to the [sample bash script](https://github.com/prisma/ecosystem-tests/blob/13e74dc47eababa5d3c8f488b73fe7fc8bffead7/platforms-serverless/lambda/run.sh#L16) used by the Prisma end-to-end tests)
+2. The **local engine file** for your development platform from the `node_modules/.prisma/client` folder. For example, your schema might define the following `binaryTargets` if you develop on Debian (`native`) but deploy to AWS Lambda (`rhel-openssl-1.0.x`):
 
    ```prisma
    binaryTargets = ["native", "rhel-openssl-1.0.x"]


### PR DESCRIPTION
## Changes

Fix broken link in 650-caveats-when-deploying-to-aws-platforms.mdx file.

## What issue does this fix?

Fixes #5333