### PR TITLE
Fix yarn add --dev command

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -34,7 +34,7 @@ npm install prisma --save-dev
 Install with [yarn](https://yarnpkg.dev/):
 
 ```
-yarn add prisma --save-dev
+yarn add prisma --dev
 ```
 
 ### pnpm


### PR DESCRIPTION
Yarn uses `--dev` to add devDependencies, not `--save-dev`

## Describe this PR

This yarn command was incorrectly using npm's `--save-dev` flag. Just fixing that little issue.

## Changes

Easy fix!

## What issue does this fix?

Now anybody who copies this command and runs it will add prisma cli to their devDependencies.
