### PR TITLE
Prisma ORM release cadence

### DIFF
--- a/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
+++ b/content/200-concepts/050-overview/250-should-you-use-prisma.mdx
@@ -94,7 +94,7 @@ Development of Prisma's open source tools is happening in the open. Most of it h
 
 - issues and PRs in our repos are triaged and prioritized (usually within 1-2 days)
 - there is a public [roadmap](https://pris.ly/roadmap) that is kept up to date with our plans
-- new [releases](https://github.com/prisma/prisma/releases) with new features and improvements are issued every two weeks
+- new [releases](https://github.com/prisma/prisma/releases) with new features and improvements are issued every three weeks
 - we have a dedicated support team that responds to questions in [GitHub Discussions](https://github.com/prisma/prisma/discussions)
 - our product team is always eager to talk to you in the `#product-feedback` channel on Slack to get your feedback about Prisma
 

--- a/content/600-about/100-prisma/10-releases.mdx
+++ b/content/600-about/100-prisma/10-releases.mdx
@@ -13,7 +13,7 @@ This page explains the release process of the Prisma ORM, how it's versioned and
 
 ## Releases
 
-Prisma releases typically happen every two weeks. Note that this is _not_ a hard rule – releases might be postponed for internal reasons.
+Prisma releases typically happen every three weeks. Note that this is _not_ a hard rule – releases might be postponed for internal reasons.
 
 [Check out all the releases notes in GitHub](https://github.com/prisma/prisma/releases).
 


### PR DESCRIPTION

## Describe this PR

Changed the release cadence for the Prisma ORM from two to three weeks as the latter is our current sprint duration.

## Changes

- Changed `250-should-you-use-prisma.mdx` and  `10-releases.mdx` where it refers to the two-week release cycle and made it three weeks.
