### PR TITLE
fix(deploy-to-a-different-os): Use correct anchor

### DIFF
--- a/content/300-guides/200-deployment/700-deploy-to-a-different-os.mdx
+++ b/content/300-guides/200-deployment/700-deploy-to-a-different-os.mdx
@@ -12,7 +12,7 @@ The query engine is implemented in Rust and is used by Prisma in the form of exe
 
 If you have developed your application on a Windows machine for example, and wish to upload to AWS Lambda, which is a Linux environment, you may encounter issues and be presented with some warnings in your terminal.
 
-To solve this, if you know ahead of time that you will be deploying to a different environment, you can use the [binary targets](/concepts/components/prisma-schema/generators#the-native-binary-target) and specify which of the [supported operating systems](/reference/api-reference/prisma-schema-reference#binarytargets-options) binaries should be included.
+To solve this, if you know ahead of time that you will be deploying to a different environment, you can use the [binary targets](/concepts/components/prisma-schema/generators#binary-targets) and specify which of the [supported operating systems](/reference/api-reference/prisma-schema-reference#binarytargets-options) binaries should be included.
 
 > **Note**: If your OS isn't supported you can include a [custom binary](/concepts/components/prisma-engines#using-custom-engine-libraries-or-binaries).
 


### PR DESCRIPTION
No need to link to a subheadline, the main "binary targets" one is fine.