### PR TITLE
fix(prisma-client-reference): Remove misleading `distinct` options for count and aggreagate (+ all kinds of things along the way)

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -412,7 +412,7 @@ const prisma = new PrismaClient({
 
 Use the `rejectOnNotFound` parameter to configure `findUnique` and/or `findFirst` to throw an error if the record was not found. By default, both operations return `null` if the record is not found.
 
-### Remarks
+#### Remarks
 
 - You can configure `rejectOnNotFound` on a per-request level for both [`findUnique`](#findunique) and [`findFirst`](#findfirst)
 
@@ -624,14 +624,14 @@ We introduced `findUniqueOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`
 
 | Name                            | Example type (`User`)                                        | Required | Description                                                                                                                                                                                                                                                     |
 | ------------------------------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| `distinct`                      | `Enumerable<UserDistinct`<br />`FieldEnum>`                  | No       | Lets you filter out duplicate rows by a specific field - for example, return only distinct `Post` titles.                                                                                                                                                       |
-| `where`                         | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                                                                            |
-| `cursor`                        | `UserWhereUniqueInput`                                       | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                                                                            |
-| `orderBy`                       | `XOR<Enumerable<User`<br />`OrderByInput>,UserOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                                                                               |
-| `include`                       | `XOR<UserInclude, null>`                                     | No       | [Specifies which relations should be eagerly loaded](/concepts/components/prisma-client/relation-queries) on the returned object.                                                                                                                               |
 | `select`                        | `XOR<UserSelect, null>`                                      | No       | [Specifies which properties to include](/concepts/components/prisma-client/select-fields) on the returned object.                                                                                                                                               |
-| `skip`                          | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                                                                       |
+| `include`                       | `XOR<UserInclude, null>`                                     | No       | [Specifies which relations should be eagerly loaded](/concepts/components/prisma-client/relation-queries) on the returned object.                                                                                                                               |
+| `where`                         | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                                                                            |
+| `orderBy`                       | `XOR<Enumerable<User`<br />`OrderByInput>,UserOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                                                                               |
+| `cursor`                        | `UserWhereUniqueInput`                                       | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                                                                            |
 | `take`                          | `number`                                                     | No       | Specifies how many objects should be returned in the list. When used with `findFirst`, `take` is implicitly `1` or `-1`. `findFirst` is only affected by whether the value is positive or negative - any negative value reverses the list.                      |
+| `skip`                          | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                                                                       |
+| `distinct`                      | `Enumerable<UserDistinct`<br />`FieldEnum>`                  | No       | Lets you filter out duplicate rows by a specific field - for example, return only distinct `Post` titles.                                                                                                                                                       |
 | `rejectOnNotFound` (deprecated) | `RejectOnNotFound`                                           | No       | If true, throw a `NotFoundError: No User found error`. You can also [configure `rejectOnNotFound` globally](#rejectonnotfound). <br></br>**Note:** `rejectOnNotFound`is deprecated in v4.0.0. From v4.0.0, use [`findFirstOrThrow`](#findfirstorthrow) instead. |     |
 
 #### Return type
@@ -745,13 +745,13 @@ We introduced `findFirstOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`]
 
 | Name       | Type                                                          | Required | Description                                                                                                                                                                                               |
 | ---------- | ------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `where`    | `UserWhereInput`                                              | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
-| `orderBy`  | `XOR<Enumerable<PostOrder`<br />`ByInput>, PostOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
-| `skip`     | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
-| `cursor`   | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
-| `take`     | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
 | `select`   | `XOR<PostSelect, null>`                                       | No       | [Specifies which properties to include](/concepts/components/prisma-client/select-fields) on the returned object.                                                                                         |
 | `include`  | `XOR<PostInclude, null>`                                      | No       | [Specifies which relations should be eagerly loaded](/concepts/components/prisma-client/relation-queries) on the returned object.                                                                         |
+| `where`    | `UserWhereInput`                                              | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
+| `orderBy`  | `XOR<Enumerable<PostOrder`<br />`ByInput>, PostOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
+| `cursor`   | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
+| `take`     | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`     | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `distinct` | `Enumerable<UserDistinctFieldEnum>`                           | No       | Lets you filter out duplicate rows by a specific field - for example, return only distinct `Post` titles.                                                                                                 |
 
 #### Return type
@@ -1428,11 +1428,10 @@ See [Filter conditions and operators](#filter-conditions-and-operators) for exam
 | Name      | Type                                                          | Required | Description                                                                                                                                                                                               |
 | --------- | ------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `where`   | `UserWhereInput`                                              | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
-| `cursor`  | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
-| `skip`    | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
-| `take`    | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
 | `orderBy` | `XOR<Enumerable<PostOrder`<br />`ByInput>, PostOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
-| `select`  | `UserCountAggregateInputType`                                 | No       | Select which fields to count (non-`null` values) - you can also count `_all`.                                                                                                                             |
+| `cursor`  | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
+| `take`    | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`    | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 
 #### Return type
 
@@ -1453,7 +1452,6 @@ export type UserFindManyArgs = {
   cursor?: UserWhereUniqueInput
   take?: number
   skip?: number
-  distinct?: Enumerable<UserDistinctFieldEnum>
 }
 
 export type UserCountAggregateOutputType = {
@@ -1521,8 +1519,8 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 | `where`   | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
 | `orderBy` | `XOR<Enumerable<UserOrderByInput>,`<br />`UserOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
 | `cursor`  | `UserWhereUniqueInput`                                       | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
-| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `take`    | `number`                                                     | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `_count`  | `true`                                                       | No       | Returns a count of matching records or non-`null` fields.                                                                                                                                                 |
 | `_avg`    | `UserAvgAggregateInputType`                                  | No       | Returns an average of all values of the specified field.                                                                                                                                                  |
 | `_sum`    | `UserSumAggregateInputType`                                  | No       | Returns the sum of all values of the specified field.                                                                                                                                                     |
@@ -1536,11 +1534,10 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 ```ts file=index.d.ts
 export type UserAggregateArgs = {
   where?: UserWhereInput
-  orderBy?: XOR<Enumerable<UserOrderByInput>, UserOrderByInput>
+  orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
   cursor?: UserWhereUniqueInput
   take?: number
   skip?: number
-  distinct?: Enumerable<UserDistinctFieldEnum>
   _count?: true | UserCountAggregateInputType
   _avg?: UserAvgAggregateInputType
   _sum?: UserSumAggregateInputType
@@ -1618,13 +1615,13 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 #### Options
 
 | Name      | Type                                                         | Required | Description                                                                                                                                                                                               |
-| --------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| --------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | 
 | `where`   | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
 | `orderBy` | `XOR<Enumerable<UserOrderByInput>,`<br />`UserOrderByInput>` | No       | Lets you order the returned list by any property that is also present in `by`.                                                                                                                            |
-| `by`      | `Array<UserScalarFieldEnum>`                                 | `string` | No                                                                                                                                                                                                        | Specifies the field or combination of fields to group records by. |
+| `by`      | `Array<UserScalarFieldEnum>` \| `string`                     | No       | Specifies the field or combination of fields to group records by.                                                                                                                                         |
 | `having`  | `UserScalarWhereWithAggregatesInput`                         | No       | Allows you to filter groups by an aggregate value - for example, only return groups _having_ an average age less than 50.                                                                                 |
-| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `take`    | `number`                                                     | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `_count`  | `true` \| `UserCountAggregateInputType`                      | No       | Returns a count of matching records or non-`null` fields.                                                                                                                                                 |
 | `_avg`    | `UserAvgAggregateInputType`                                  | No       | Returns an average of all values of the specified field.                                                                                                                                                  |
 | `_sum`    | `UserSumAggregateInputType`                                  | No       | Returns the sum of all values of the specified field.                                                                                                                                                     |
@@ -2946,7 +2943,7 @@ const user = await prisma.user.create({
 
 Because it's a one-to-many relation, you can also create several `Post` records at once by passing an array to `create`:
 
-```ts highlight=5;normal
+```ts highlight=5-12;normal
 const user = await prisma.user.create({
   data: {
     email: 'alice@prisma.io',


### PR DESCRIPTION
- Remove `disctinct` from `count` and `aggregate` options/reference

Also:
- Remove `select` from `count` options/reference
- Resort tables of options to match types (select,include,where => orderBy => cursor/take/skip => disctinct usually) and logical priority (= required before optional)
- Fix "Remarks" headline level of "rejectOnNotFound"
- Fix broken Options table for `groupBy`
- Fix code highlighting for `create` example