### PR TITLE
chore(prisma-client-reference): Remove all Reference sections

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -150,20 +150,6 @@ Determines the type and level of logging. See also: [Logging](/concepts/componen
 | `stdout` | See: [stdout](https://en.wikipedia.org/wiki/Standard_streams) |
 | `event`  | Raises an event that you can subscribe to.                    |
 
-#### Reference
-
-```ts file=index.d.ts
-log?: Array<LogLevel | LogDefinition>
-```
-
-```ts file=index.d.ts
-export type LogLevel = 'info' | 'query' | 'warn' | 'error'
-export type LogDefinition = {
-  level: LogLevel
-  emit: 'stdout' | 'event'
-}
-```
-
 ##### Event types
 
 The `query` event type:
@@ -356,16 +342,6 @@ Determines the level and formatting of errors returned by Prisma.
 | `colorless` (default) | Enables colorless error formatting.            |
 | `minimal`             | Enables minimal error formatting.              |
 
-#### Reference
-
-```ts file=index.d.ts
-errorFormat?: ErrorFormat
-```
-
-```ts file=index.d.ts
-export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
-```
-
 #### Examples
 
 ##### No error formatting
@@ -422,12 +398,6 @@ Use the `rejectOnNotFound` parameter to configure `findUnique` and/or `findFirst
 | -------------------- | ------------------------------------------------------------------------------------------- |
 | `RejectOnNotFound`   | Enable globally (`true` / `false`) _or_ throw a custom error.                               |
 | `RejectPerOperation` | Enable per operation (`true` / `false`) _or_ throw a custom error per operation, per model. |
-
-#### Reference
-
-```ts file=index.d.ts
-rejectOnNotFound?: RejectOnNotFound | RejectPerOperation
-```
 
 #### Examples
 
@@ -502,18 +472,6 @@ Use model queries to perform CRUD operations on your models. See also: [CRUD](/c
 | JavaScript object (plain) | `{ title: "Hello world" }` | Use `select` and `include` to determine which fields to return.                                                                                                   |
 | `null`                    | `null`                     | Record not found                                                                                                                                                  |
 | Error                     |                            | If `rejectOnNotFound` is true, `findUnique` throws an error (`NotFoundError` by default, [customizable globally](#rejectonnotfound)) instead of returning `null`. |
-
-#### Reference
-
-`findUnique` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserFindUniqueArgs = {
-  where: UserWhereUniqueInput
-  select?: UserSelect | null
-  include?: UserInclude | null
-}
-```
 
 #### Examples
 
@@ -648,23 +606,6 @@ We introduced `findUniqueOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`
 - `findFirst` calls `findMany` behind the scenes and accepts the same query options.
 - Passing in a negative `take` value when you use a `findFirst` query reverses the order of the list.
 
-#### Reference
-
-`findFirst` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserFindFirstArgs = {
-  select?: XOR<UserSelect, null>
-  include?: XOR<UserInclude, null>
-  where?: UserWhereInput
-  orderBy?: XOR<Enumerable<UserOrderByInput>, UserOrderByInput>
-  cursor?: UserWhereUniqueInput
-  take?: number
-  skip?: number
-  distinct?: Enumerable<UserDistinctFieldEnum>
-}
-```
-
 #### Examples
 
 See [Filter conditions and operators](#filter-conditions-and-operators) for examples of how to filter results.
@@ -715,6 +656,8 @@ main()
 
 ### <inlinecode>findFirstOrThrow</inlinecode>
 
+<AlgoliaTerm name="apiReference" value="findFirstOrThrow" />
+
 <Admonition type="info">
 
 We introduced `findFirstOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`](#rejectonnotfound) option. `rejectOnNotFound` is deprecated in v4.0.0.
@@ -762,23 +705,6 @@ We introduced `findFirstOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`]
 | JavaScript array object (plain) | `[{ title: "Hello world" }]` | Use `select` and `include` to determine which fields to return. |
 | Empty array                     | `[]`                         | No matching records found.                                      |
 
-#### Reference
-
-`findMany` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserFindManyArgs = {
-  select?: XOR<UserSelect, null>
-  include?: XOR<UserInclude, null>
-  where?: UserWhereInput
-  orderBy?: XOR<Enumerable<UserOrderByInput>, UserOrderByInput>
-  cursor?: UserWhereUniqueInput
-  take?: number
-  skip?: number
-  distinct?: Enumerable<UserDistinctFieldEnum>
-}
-```
-
 #### Examples
 
 See [Filter conditions and operators](#filter-conditions-and-operators) for examples of how to filter results.
@@ -813,18 +739,6 @@ const user = await prisma.user.findMany({
 #### Remarks
 
 - You can also perform a nested [`create`](#create-1) - for example, add a `User` and two `Post` records at the same time.
-
-#### Reference
-
-`create` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserCreateArgs = {
-  select?: XOR<UserSelect, null>
-  include?: XOR<UserInclude, null>
-  data: XOR<UserCreateInput, UserUncheckedCreateInput>
-}
-```
 
 #### Examples
 
@@ -933,17 +847,6 @@ prisma:query COMMIT
 - To perform arithmetic operations on update (add, subtract, multiply, divide), use [atomic updates](#atomic-number-operations) to prevent race conditions.
 - You can also perform a nested [`update`](#update-1) - for example, update a user and that user's posts at the same time.
 
-#### Reference
-
-```ts file=index.d.ts
-export type UserUpdateArgs = {
-  select?: XOR<UserSelect, null>
-  include?: XOR<UserInclude, null>
-  data: XOR<UserUpdateInput, UserUncheckedUpdateInput>
-  where: UserWhereUniqueInput
-}
-```
-
 #### Examples
 
 ##### Update the `email` of the `User` record with `id` of `1` to `alice@prisma.io`
@@ -984,20 +887,6 @@ const user = await prisma.user.update({
 - To perform arithmetic operations on update (add, subtract, multiply, divide), use [atomic updates](#atomic-number-operations) to prevent race conditions.
 - If two or more upsert operations happen at the same time and the record doesn't already exist, then a race condition might happen. As a result, one or more of the upsert operations might throw a unique key constraint error. Your application code can catch this error and retry the operation. [Learn more](#unique-key-constraint-errors-on-upserts).
 - From version 4.6.0, Prisma hands over upsert queries to the database where possible. [Learn more](#database-upserts).
-
-#### Reference
-
-`upsert` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserUpsertArgs = {
-  select?: XOR<UserSelect, null>
-  include?: XOR<UserInclude, null>
-  where: UserWhereUniqueInput
-  create: XOR<UserCreateInput, UserUncheckedCreateInput>
-  update: XOR<UserUpdateInput, UserUncheckedUpdateInput>
-}
-```
 
 #### Examples
 
@@ -1202,18 +1091,6 @@ To delete records that match a certain criteria, use [`deleteMany`](#deletemany)
 
 - To delete multiple records based on some criteria (for example, all `User` records with a `prisma.io` email address, use `deleteMany`)
 
-#### Reference
-
-`delete` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserDeleteArgs = {
-  select?: XOR<UserSelect, null>
-  include?: XOR<UserInclude, null>
-  where: UserWhereUniqueInput
-}
-```
-
 #### Examples
 
 ##### Delete the `User` record with an `id` of `1`
@@ -1280,17 +1157,6 @@ const deleteUser = await prisma.user.delete({
 - You **cannot** create or connect relations - you cannot nest `create`, `createMany`, `connect`, `connectOrCreate` inside a top-level `createMany`
 - You can nest a [`createMany`](#createmany-1) inside an `update` or `create` query - for example, add a `User` and two `Post` records at the same time.
 
-#### Reference
-
-`createMany` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserCreateManyArgs = {
-  data: Enumerable<UserCreateManyInput>
-  skipDuplicates?: boolean
-}
-```
-
 #### Examples
 
 ##### Create several new users
@@ -1324,17 +1190,6 @@ const users = await prisma.user.createMany({
 ```ts
 export type BatchPayload = {
   count: number
-}
-```
-
-#### Reference
-
-`updateMany` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserUpdateManyArgs = {
-  data: XOR<UserUpdateManyMutationInput, UserUncheckedUpdateManyInput>
-  where?: UserWhereInput
 }
 ```
 
@@ -1393,16 +1248,6 @@ export type BatchPayload = {
 }
 ```
 
-#### Reference
-
-`deleteMany` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserDeleteManyArgs = {
-  where?: UserWhereInput
-}
-```
-
 #### Examples
 
 ##### Delete all `User` records
@@ -1439,34 +1284,6 @@ See [Filter conditions and operators](#filter-conditions-and-operators) for exam
 | ------------------------------ | ------------------------ | ----------------------------- |
 | `number`                       | `29`                     | The count of records.         |
 | `UserCountAggregateOutputType` | `{ _all: 27, name: 10 }` | Returned if `select` is used. |
-
-#### Reference
-
-`count` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserFindManyArgs = {
-  // select and include are excluded
-  where?: UserWhereInput
-  orderBy?: XOR<Enumerable<UserOrderByInput>, UserOrderByInput>
-  cursor?: UserWhereUniqueInput
-  take?: number
-  skip?: number
-}
-
-export type UserCountAggregateOutputType = {
-  id: number
-  name: number | null
-  email: number | null
-  profileViews: number
-  role: number | null
-  coinflips: number | null
-  testing: number | null
-  city: number | null
-  country: number | null
-  _all: number
-}
-```
 
 #### Examples
 
@@ -1526,25 +1343,6 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 | `_sum`    | `UserSumAggregateInputType`                                  | No       | Returns the sum of all values of the specified field.                                                                                                                                                     |
 | `_min`    | `UserMinAggregateInputType`                                  | No       | Returns the smallest available value of the specified field.                                                                                                                                              |
 | `_max`    | `UserMaxAggregateInputType`                                  | No       | Returns the largest available value of the specified field.                                                                                                                                               |
-
-#### Reference
-
-`aggregate` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserAggregateArgs = {
-  where?: UserWhereInput
-  orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
-  cursor?: UserWhereUniqueInput
-  take?: number
-  skip?: number
-  _count?: true | UserCountAggregateInputType
-  _avg?: UserAvgAggregateInputType
-  _sum?: UserSumAggregateInputType
-  _min?: UserMinAggregateInputType
-  _max?: UserMaxAggregateInputType
-}
-```
 
 #### Examples
 
@@ -1615,7 +1413,7 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 #### Options
 
 | Name      | Type                                                         | Required | Description                                                                                                                                                                                               |
-| --------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | 
+| --------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `where`   | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
 | `orderBy` | `XOR<Enumerable<UserOrderByInput>,`<br />`UserOrderByInput>` | No       | Lets you order the returned list by any property that is also present in `by`.                                                                                                                            |
 | `by`      | `Array<UserScalarFieldEnum>` \| `string`                     | No       | Specifies the field or combination of fields to group records by.                                                                                                                                         |
@@ -1627,26 +1425,6 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 | `_sum`    | `UserSumAggregateInputType`                                  | No       | Returns the sum of all values of the specified field.                                                                                                                                                     |
 | `_min`    | `UserMinAggregateInputType`                                  | No       | Returns the smallest available value of the specified field.                                                                                                                                              |
 | `_max`    | `UserMaxAggregateInputType`                                  | No       | Returns the largest available value of the specified field.                                                                                                                                               |
-
-#### Reference
-
-`groupBy` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserGroupByArgs = {
-  where?: UserWhereInput
-  orderBy?: Enumerable<UserOrderByInput>
-  by: Array<UserScalarFieldEnum>
-  having?: UserScalarWhereWithAggregatesInput
-  take?: number
-  skip?: number
-  _count?: true | UserCountAggregateInputType
-  _avg?: UserAvgAggregateInputType
-  _sum?: UserSumAggregateInputType
-  _min?: UserMinAggregateInputType
-  _max?: UserMaxAggregateInputType
-}
-```
 
 #### Examples
 
@@ -1719,21 +1497,6 @@ const groupUsers = await prisma.user.groupBy({
 
 - You cannot combine `select` and `include` on the same level.
 - In [3.0.1](https://github.com/prisma/prisma/releases/3.0.1) and later, you can [select a `_count` of relations](#select-a-_count-of-relations).
-
-#### Reference
-
-```ts file=index.d.ts
-export type UserSelect = {
-  id?: boolean
-  name?: boolean
-  email?: boolean
-  profileViews?: boolean
-  role?: boolean
-  coinflips?: boolean
-  posts?: boolean | PostFindManyArgs
-  _count?: boolean | UserCountOutputTypeArgs
-}
-```
 
 #### Examples
 
@@ -1967,15 +1730,6 @@ const selectNameEmailNotPosts = Prisma.validator<Prisma.UserSelect>()({
 
 - In [3.0.1](https://github.com/prisma/prisma/releases/3.0.1) and later, you can [`include` a `_count` of relations](#include-a-_count-of-relations)
 
-#### Reference
-
-```ts
-export type UserInclude = {
-  posts?: boolean | PostFindManyArgs
-  _count?: boolean | UserCountOutputTypeArgs
-}
-```
-
 #### Examples
 
 ##### Include the `posts` and `profile` relation when loading `User` records
@@ -2059,36 +1813,6 @@ const usersWithCount = await prisma.user.findMany({
 ### <inlinecode>where</inlinecode>
 
 `where` defines one or more [filters](#filter-conditions-and-operators), and can be used to filter on record properties (like a user's email address) or related record properties (like a user's top 10 most recent post titles).
-
-#### Reference
-
-For queries like `findMany` and `updateMany` that return multiple records, `where` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserWhereInput = {
-  AND?: Enumerable<UserWhereInput>
-  OR?: Enumerable<UserWhereInput>
-  NOT?: Enumerable<UserWhereInput>
-  id?: IntFilter | number
-  name?: StringNullableFilter | string | null
-  email?: StringFilter | string
-  profileViews?: IntFilter | number
-  role?: EnumRoleFilter | Role
-  coinflips?: BoolNullableListFilter
-  posts?: PostListRelationFilter
-}
-```
-
-> `findFirst` is a `findMany` query with a `take: 1`, and also accepts `UserWhereInput`.
-
-For queries like `findUnique`, which returns a single record by ID or unique identifier, `where` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserWhereUniqueInput = {
-  id?: number
-  email?: string
-}
-```
 
 #### Examples
 
@@ -2229,64 +1953,6 @@ Note:
 | ------- | ------------------------------ |
 | `first` | Sort with `null` values first. |
 | `last`  | Sort with `null` values last.  |
-
-#### Reference
-
-`orderBy` accepts the following input type:
-
-```ts file=index.d.ts
-export type UserOrderByInput = {
-  id?: SortOrder
-  name?: SortOrder | SortOrderInput
-  email?: SortOrder
-  profileViews?: SortOrder
-  role?: SortOrder
-  coinflips?: SortOrder
-  posts?: PostOrderByRelationAggregateInput
-  city?: SortOrder
-  country?: SortOrder
-  profile?: ExtendedProfileOrderByWithRelationAndSearchRelevanceInput
-  pets?: SortOrder
-  _relevance?: UserOrderByRelevanceInput
-}
-
-export type SortOrderInput = {
-  sort: SortOrder
-  nulls?: NullsOrder
-}
-```
-
-Related types:
-
-```ts
-export declare const SortOrder: {
-  asc: 'asc'
-  desc: 'desc'
-}
-
-export declare const NullsOrder: {
-  first: 'first'
-  last: 'last'
-}
-
-export type PostOrderByRelationAggregateInput = {
-  _count?: SortOrder
-}
-
-export type ExtendedProfileOrderByWithRelationAndSearchRelevanceInput = {
-  id?: SortOrder
-  userId?: SortOrder
-  bio?: SortOrder
-  User?: UserOrderByWithRelationAndSearchRelevanceInput
-  _relevance?: ExtendedProfileOrderByRelevanceInput
-}
-
-export type UserOrderByRelevanceInput = {
-  fields: Enumerable<UserOrderByRelevanceFieldEnum>
-  sort: SortOrder
-  search: string
-}
-```
 
 #### Examples
 
@@ -2758,24 +2424,7 @@ The following examples demonstrate how to use the [`validator`](/concepts/compon
 
 ### <inlinecode>distinct</inlinecode>
 
-See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-client/aggregation-grouping-summarizing#select-distinct) <span class="concept"></span>
-
-#### Reference
-
-```ts file=index.d.ts
-distinct?: Enumerable<UserDistinctFieldEnum>
-```
-
-```ts
-export declare const UserDistinctFieldEnum: {
-  id: 'id'
-  name: 'name'
-  email: 'email'
-  profileViews: 'profileViews'
-  role: 'role'
-  coinflips: 'coinflips'
-}
-```
+Deduplicate a list of records. See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-client/aggregation-grouping-summarizing#select-distinct) <span class="concept"></span>
 
 #### Examples
 
@@ -4143,16 +3792,6 @@ Returns all records where **one or more** ("some") _related_ records match filte
 
 - You can use `some` without parameters to return all records with at least one relation
 
-#### Reference
-
-```ts file=index.d.ts
-export type PostFilter = {
-  every?: PostWhereInput | null
-|  some?: PostWhereInput | null
-  none?: PostWhereInput | null
-}
-```
-
 #### Examples
 
 ##### Get all `User` records where _some_ posts mention `Prisma`
@@ -4174,16 +3813,6 @@ const result = await prisma.user.findMany({
 ### <inlinecode>every</inlinecode>
 
 Returns all records where **all** ("every") _related_ records match filtering criteria.
-
-#### Reference
-
-```ts file=index.d.ts
-export type PostFilter = {
-|  every?: PostWhereInput | null
-  some?: PostWhereInput | null
-  none?: PostWhereInput | null
-}
-```
 
 #### Examples
 
@@ -4208,16 +3837,6 @@ Returns all records where **zero** _related_ records match filtering criteria.
 #### Remarks
 
 - You can use `none` without parameters to [return all records with no relations](#get-all-user-records-with-zero-posts)
-
-#### Reference
-
-```ts file=index.d.ts
-export type PostFilter = {
-  every?: PostWhereInput | null
-  some?: PostWhereInput | null
-|  none?: PostWhereInput | null
-}
-```
 
 #### Examples
 
@@ -4251,15 +3870,6 @@ const result = await prisma.user.findMany({
 
 Returns all records where related record matches filtering criteria (for example, user's name `is` Bob).
 
-#### Reference
-
-```ts file=index.d.ts highlight=2;normal
-export type UserRelationFilter = {
-  is?: UserWhereInput | null
-  isNot?: UserWhereInput | null
-}
-```
-
 #### Examples
 
 ##### Get all `Post` records where user's name is `"Bob"`
@@ -4280,15 +3890,6 @@ const result = await prisma.post.findMany({
 
 Returns all records where related record matches filtering criteria (for example, user's name `isNot` Bob).
 
-#### Reference
-
-```ts file=index.d.ts highlight=3;normal
-export type UserRelationFilter = {
-  is?: UserWhereInput | null
-  isNot?: UserWhereInput | null
-}
-```
-
 #### Examples
 
 ##### Get all `Post` records where user's name is NOT `"Bob"`
@@ -4306,15 +3907,6 @@ const result = await prisma.post.findMany({
 ```
 
 ## Scalar list methods
-
-### Reference
-
-```ts
-export type PostUpdatetagsInput = {
-  set?: Enumerable<string>
-  push?: string
-}
-```
 
 ### <inlinecode>set</inlinecode>
 
@@ -4444,28 +4036,6 @@ Available for:
 ### Remarks
 
 - Scalar list / array filters [ignore `NULL` values](/concepts/components/prisma-client/working-with-fields/working-with-scalar-lists-arrays#null-values-in-arrays) <span class="concept"></span>. Using `isEmpty` or `NOT` does not return records with `NULL` value lists / arrays, and `{ equals: null }` results in an error.
-
-### Reference
-
-```ts file=index.d.ts
-export type StringNullableListFilter = {
-  equals?: Enumerable<string> | null
-  has?: string | null
-  hasEvery?: Enumerable<string>
-  hasSome?: Enumerable<string>
-  isEmpty?: boolean
-}
-```
-
-```ts file=index.d.ts
-export type BoolNullableListFilter = {
-  equals?: Enumerable<boolean> | null
-  has?: boolean | null
-  hasEvery?: Enumerable<boolean>
-  hasSome?: Enumerable<boolean>
-  isEmpty?: boolean
-}
-```
 
 ### <inlinecode>has</inlinecode>
 
@@ -4775,26 +4345,6 @@ Available for MongoDB only in Prisma `3.11.0` and later.
 
 Composite type filters allow you to filter the contents of [composite types](/concepts/components/prisma-client/composite-types).
 
-### Reference
-
-```ts file=index.d.ts
-export type AddressCompositeFilter = {
-  equals?: AddressObjectEqualityInput
-  is?: AddressWhereInput
-  isNot?: AddressWhereInput
-}
-```
-
-```ts file=index.d.ts
-export type PhotoCompositeListFilter = {
-  equals?: Enumerable<PhotoObjectEqualityInput>
-  every?: PhotoWhereInput
-  some?: PhotoWhereInput
-  none?: PhotoWhereInput
-  isEmpty?: boolean
-}
-```
-
 ### <inlinecode>equals</inlinecode>
 
 Use `equals` to filter results by matching a composite type or a list of composite types. Requires all required fields of the composite type to match.
@@ -4993,18 +4543,6 @@ The value _should_ be `23`, but the two clients did not read and write to the `p
 | `multiply`  | Multiplies the current value by `n`.                          |
 | `divide`    | Divides the current value by `n`.                             |
 | `set`       | Sets the current field value. Identical to `{ myField : n }`. |
-
-### Reference
-
-```ts file=index.d.ts
-export type IntFieldUpdateOperationsInput = {
-  set?: number
-  increment?: number
-  decrement?: number
-  multiply?: number
-  divide?: number
-}
-```
 
 ### Remarks
 
@@ -5464,12 +5002,6 @@ The `$disconnect()` method closes the database connections that were established
 
 - `$disconnect()` returns a `Promise`, so you should call it inside an `async` function with the `await` keyword.
 
-#### Reference
-
-```ts
-$disconnect(): Promise<void>
-```
-
 ### <inlinecode>$connect()</inlinecode>
 
 The `$connect()` method establishes a physical connection to the database via Prisma's query engine. See [Connection management](/concepts/components/prisma-client/working-with-prismaclient/connection-management) for an overview of `$connect()` and `$disconnect()`.
@@ -5477,12 +5009,6 @@ The `$connect()` method establishes a physical connection to the database via Pr
 #### Remarks
 
 - `$connect()` returns a `Promise`, so you should call it inside an `async` function with the `await` keyword.
-
-#### Reference
-
-```ts
-$connect(): Promise<void>
-```
 
 ### <inlinecode>$on()</inlinecode>
 
@@ -5545,27 +5071,6 @@ Example parameter values:
   action: 'findMany',
   model: 'Post'
 }
-```
-
-#### Reference
-
-`params` accepts the following type:
-
-```ts file=index.d.ts
-export type MiddlewareParams = {
-  model?: ModelName
-  action: PrismaAction
-  args: any
-  dataPath: string[]
-  runInTransaction: boolean
-}
-
-export declare const ModelName: {
-  User: 'User'
-  Post: 'Post'
-}
-
-export declare type ModelName = (typeof ModelName)[keyof typeof ModelName]
 ```
 
 #### Examples

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -412,7 +412,7 @@ const prisma = new PrismaClient({
 
 Use the `rejectOnNotFound` parameter to configure `findUnique` and/or `findFirst` to throw an error if the record was not found. By default, both operations return `null` if the record is not found.
 
-### Remarks
+#### Remarks
 
 - You can configure `rejectOnNotFound` on a per-request level for both [`findUnique`](#findunique) and [`findFirst`](#findfirst)
 
@@ -624,14 +624,14 @@ We introduced `findUniqueOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`
 
 | Name                            | Example type (`User`)                                        | Required | Description                                                                                                                                                                                                                                                     |
 | ------------------------------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| `distinct`                      | `Enumerable<UserDistinct`<br />`FieldEnum>`                  | No       | Lets you filter out duplicate rows by a specific field - for example, return only distinct `Post` titles.                                                                                                                                                       |
-| `where`                         | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                                                                            |
-| `cursor`                        | `UserWhereUniqueInput`                                       | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                                                                            |
-| `orderBy`                       | `XOR<Enumerable<User`<br />`OrderByInput>,UserOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                                                                               |
-| `include`                       | `XOR<UserInclude, null>`                                     | No       | [Specifies which relations should be eagerly loaded](/concepts/components/prisma-client/relation-queries) on the returned object.                                                                                                                               |
 | `select`                        | `XOR<UserSelect, null>`                                      | No       | [Specifies which properties to include](/concepts/components/prisma-client/select-fields) on the returned object.                                                                                                                                               |
-| `skip`                          | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                                                                       |
+| `include`                       | `XOR<UserInclude, null>`                                     | No       | [Specifies which relations should be eagerly loaded](/concepts/components/prisma-client/relation-queries) on the returned object.                                                                                                                               |
+| `where`                         | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                                                                            |
+| `orderBy`                       | `XOR<Enumerable<User`<br />`OrderByInput>,UserOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                                                                               |
+| `cursor`                        | `UserWhereUniqueInput`                                       | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                                                                            |
 | `take`                          | `number`                                                     | No       | Specifies how many objects should be returned in the list. When used with `findFirst`, `take` is implicitly `1` or `-1`. `findFirst` is only affected by whether the value is positive or negative - any negative value reverses the list.                      |
+| `skip`                          | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                                                                       |
+| `distinct`                      | `Enumerable<UserDistinct`<br />`FieldEnum>`                  | No       | Lets you filter out duplicate rows by a specific field - for example, return only distinct `Post` titles.                                                                                                                                                       |
 | `rejectOnNotFound` (deprecated) | `RejectOnNotFound`                                           | No       | If true, throw a `NotFoundError: No User found error`. You can also [configure `rejectOnNotFound` globally](#rejectonnotfound). <br></br>**Note:** `rejectOnNotFound`is deprecated in v4.0.0. From v4.0.0, use [`findFirstOrThrow`](#findfirstorthrow) instead. |     |
 
 #### Return type
@@ -745,13 +745,13 @@ We introduced `findFirstOrThrow` in v4.0.0. It replaces the [`rejectOnNotFound`]
 
 | Name       | Type                                                          | Required | Description                                                                                                                                                                                               |
 | ---------- | ------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `where`    | `UserWhereInput`                                              | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
-| `orderBy`  | `XOR<Enumerable<PostOrder`<br />`ByInput>, PostOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
-| `skip`     | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
-| `cursor`   | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
-| `take`     | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
 | `select`   | `XOR<PostSelect, null>`                                       | No       | [Specifies which properties to include](/concepts/components/prisma-client/select-fields) on the returned object.                                                                                         |
 | `include`  | `XOR<PostInclude, null>`                                      | No       | [Specifies which relations should be eagerly loaded](/concepts/components/prisma-client/relation-queries) on the returned object.                                                                         |
+| `where`    | `UserWhereInput`                                              | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
+| `orderBy`  | `XOR<Enumerable<PostOrder`<br />`ByInput>, PostOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
+| `cursor`   | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
+| `take`     | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`     | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `distinct` | `Enumerable<UserDistinctFieldEnum>`                           | No       | Lets you filter out duplicate rows by a specific field - for example, return only distinct `Post` titles.                                                                                                 |
 
 #### Return type
@@ -1428,11 +1428,10 @@ See [Filter conditions and operators](#filter-conditions-and-operators) for exam
 | Name      | Type                                                          | Required | Description                                                                                                                                                                                               |
 | --------- | ------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `where`   | `UserWhereInput`                                              | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
-| `cursor`  | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
-| `skip`    | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
-| `take`    | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
 | `orderBy` | `XOR<Enumerable<PostOrder`<br />`ByInput>, PostOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
-| `select`  | `UserCountAggregateInputType`                                 | No       | Select which fields to count (non-`null` values) - you can also count `_all`.                                                                                                                             |
+| `cursor`  | `UserWhereUniqueInput`                                        | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
+| `take`    | `number`                                                      | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`    | `number`                                                      | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 
 #### Return type
 
@@ -1453,7 +1452,6 @@ export type UserFindManyArgs = {
   cursor?: UserWhereUniqueInput
   take?: number
   skip?: number
-  distinct?: Enumerable<UserDistinctFieldEnum>
 }
 
 export type UserCountAggregateOutputType = {
@@ -1521,8 +1519,8 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 | `where`   | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
 | `orderBy` | `XOR<Enumerable<UserOrderByInput>,`<br />`UserOrderByInput>` | No       | Lets you order the returned list by any property.                                                                                                                                                         |
 | `cursor`  | `UserWhereUniqueInput`                                       | No       | Specifies the position for the list (the value typically specifies an `id` or another unique value).                                                                                                      |
-| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `take`    | `number`                                                     | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `_count`  | `true`                                                       | No       | Returns a count of matching records or non-`null` fields.                                                                                                                                                 |
 | `_avg`    | `UserAvgAggregateInputType`                                  | No       | Returns an average of all values of the specified field.                                                                                                                                                  |
 | `_sum`    | `UserSumAggregateInputType`                                  | No       | Returns the sum of all values of the specified field.                                                                                                                                                     |
@@ -1536,11 +1534,10 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 ```ts file=index.d.ts
 export type UserAggregateArgs = {
   where?: UserWhereInput
-  orderBy?: XOR<Enumerable<UserOrderByInput>, UserOrderByInput>
+  orderBy?: UserOrderByWithRelationInput | UserOrderByWithRelationInput[]
   cursor?: UserWhereUniqueInput
   take?: number
   skip?: number
-  distinct?: Enumerable<UserDistinctFieldEnum>
   _count?: true | UserCountAggregateInputType
   _avg?: UserAvgAggregateInputType
   _sum?: UserSumAggregateInputType
@@ -1618,13 +1615,13 @@ See also: [Aggregation, grouping, and summarizing](/concepts/components/prisma-c
 #### Options
 
 | Name      | Type                                                         | Required | Description                                                                                                                                                                                               |
-| --------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| --------- | ------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | 
 | `where`   | `UserWhereInput`                                             | No       | Wraps _all_ model fields in a type so that the list can be filtered by any property.                                                                                                                      |
 | `orderBy` | `XOR<Enumerable<UserOrderByInput>,`<br />`UserOrderByInput>` | No       | Lets you order the returned list by any property that is also present in `by`.                                                                                                                            |
-| `by`      | `Array<UserScalarFieldEnum>`                                 | `string` | No                                                                                                                                                                                                        | Specifies the field or combination of fields to group records by. |
+| `by`      | `Array<UserScalarFieldEnum>` \| `string`                     | No       | Specifies the field or combination of fields to group records by.                                                                                                                                         |
 | `having`  | `UserScalarWhereWithAggregatesInput`                         | No       | Allows you to filter groups by an aggregate value - for example, only return groups _having_ an average age less than 50.                                                                                 |
-| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `take`    | `number`                                                     | No       | Specifies how many objects should be returned in the list (as seen from the _beginning_ (positive value) or _end_ (negative value) **either** of the list **or** from the `cursor` position if mentioned) |
+| `skip`    | `number`                                                     | No       | Specifies how many of the returned objects in the list should be skipped.                                                                                                                                 |
 | `_count`  | `true` \| `UserCountAggregateInputType`                      | No       | Returns a count of matching records or non-`null` fields.                                                                                                                                                 |
 | `_avg`    | `UserAvgAggregateInputType`                                  | No       | Returns an average of all values of the specified field.                                                                                                                                                  |
 | `_sum`    | `UserSumAggregateInputType`                                  | No       | Returns the sum of all values of the specified field.                                                                                                                                                     |
@@ -2946,7 +2943,7 @@ const user = await prisma.user.create({
 
 Because it's a one-to-many relation, you can also create several `Post` records at once by passing an array to `create`:
 
-```ts highlight=5;normal
+```ts highlight=5-12;normal
 const user = await prisma.user.create({
   data: {
     email: 'alice@prisma.io',


### PR DESCRIPTION
This PR completely deletes all "Reference" sections from the Client API Reference.

These sections usually just repeat the `Options` table, often with outdated and misleading information.
Sometimes they also show fully example specific types that are hard or impossible to make sense of without the project context.

If there is any useful information in any of these, we should instead explain that in the introduction and make sure the examples show it properly.