### PR TITLE
Update 050-prisma-client-reference.mdx

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -4312,7 +4312,7 @@ const result = await prisma.post.findMany({
 ```ts
 export type PostUpdatetagsInput = {
   set?: Enumerable<string>
-  push?: string
+  push?: string | string[]
 }
 ```
 
@@ -4375,12 +4375,12 @@ const setTags = await prisma.post.update({
 
 ### <inlinecode>push</inlinecode>
 
-`push` is available in version [2.20.0](https://github.com/prisma/prisma/releases/2.20.0) and later. Use `push` to add _one_ value to a scalar list field.
+`push` is available in version [2.20.0](https://github.com/prisma/prisma/releases/2.20.0) and later. Use `push` to add _one_ value or _multiple_ values to a scalar list field.
 
 #### Remarks
 
 - Available for PostgreSQL and MongoDB only.
-- You cannot push a list of values - only a single value.
+- You can push a list of values or only a single value.
 
 #### Examples
 
@@ -4394,6 +4394,19 @@ const addTag = await prisma.post.update({
   data: {
     tags: {
       push: 'computing',
+    },
+  },
+})
+```
+
+```ts
+const addTag = await prisma.post.update({
+  where: {
+    id: 9,
+  },
+  data: {
+    tags: {
+      push: ['computing', 'genetics'],
     },
   },
 })


### PR DESCRIPTION


## Describe this PR

A user reported that `push` can be used to push not just a single value but also a list of values in this [github discussion](https://github.com/prisma/prisma/discussions/21464). I also confirmed this behaviour from the original [issue](https://github.com/prisma/prisma-engines/pull/1805) that was implemented for `push`

## Changes

I updated the wordings to reflect that `push` can also be used for adding multiple values to a scalar list and added an example as well

