### PR TITLE
Fixed update event filter example

### DIFF
--- a/content/800-data-platform/200-pulse/400-api-reference.mdx
+++ b/content/800-data-platform/200-pulse/400-api-reference.mdx
@@ -217,7 +217,7 @@ Get `update` events where the value of name is equal to `Jim` after the event ha
 
 ```ts
 const subscription = await prisma.user.subscribe({
-  create: {
+  update: {
     after: {
       name: 'Jim',
     },


### PR DESCRIPTION
Changed `create` to `update` in the update filter event example.

## Describe this PR

The update event filter example was using `create` instead of `update`, which I corrected.

## Changes

Changed `create` to `update` in the example showing how to use the filter when subscribing to update events.

## What issue does this fix?
## Any other relevant information