### PR TITLE
Update 400-nextjs-prisma-client-dev-practices.mdx

### DIFF
--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -20,7 +20,7 @@ In development, the command `next dev` clears Node.js cache on run. This in turn
 
 The solution in this case is to instantiate a single instance `PrismaClient` and save it on the [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) object. Then we keep a check to only instantiate `PrismaClient` if it's not on the `globalThis` object otherwise use the same instance again if already present to prevent instantiating extra `PrismaClient` instances.
 
-```ts file=./db
+```ts file=./db.ts
 import { PrismaClient } from '@prisma/client'
 
 const prismaClientSingleton = () => {

--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -20,7 +20,7 @@ In development, the command `next dev` clears Node.js cache on run. This in turn
 
 The solution in this case is to instantiate a single instance `PrismaClient` and save it on the [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) object. Then we keep a check to only instantiate `PrismaClient` if it's not on the `globalThis` object otherwise use the same instance again if already present to prevent instantiating extra `PrismaClient` instances.
 
-```ts file=./db.ts
+```ts file=db.ts
 import { PrismaClient } from '@prisma/client'
 
 const prismaClientSingleton = () => {


### PR DESCRIPTION
- Add extension to the `db` file as file=./db was a bit misleading Result: file=./db.ts

## Describe this PR

- The explanation for connection bets practices - [Best practice for instantiating PrismaClient with Next.js](https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices) has an exmpale file `db` with missing extension. This seemed a bit misleading because other parts on the docs have the extension. The screenshots as reference:
- WIth extiension
![Screen Shot 2023-10-17 at 3 12 10 PM](https://github.com/prisma/docs/assets/77268705/fa614ce4-d8d5-4e10-9a74-d07b168bb2aa)
- without extension 
![Screen Shot 2023-10-17 at 3 12 15 PM](https://github.com/prisma/docs/assets/77268705/f7b6c6cf-aa70-4ab5-88c4-01d727163c27)

## Changes

- Added extension to the file in the docs