### PR TITLE
Chore: Fix typo in multiple files

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/09-indexes.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/09-indexes.mdx
@@ -330,7 +330,7 @@ As an example, the following model adds a `Brin` index to the `value` field with
 model Example {
   id    Int @id
   value Int
-  //    ^ field type macthing the operator class
+  //    ^ field type matching the operator class
 
   @@index([value(ops: Int4BloomOps)], type: Brin)
   //                  ^ operator class      ^ index type

--- a/content/200-concepts/100-components/02-prisma-client/054-middleware/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/054-middleware/index.mdx
@@ -42,7 +42,7 @@ prisma.$use(async (params, next) => {
 
 <Admonition type="warning">
 
-Do not invoke <inlinecode>next</inlinecode> multiple times within a middleware when using [batch transactions](/concepts/components/prisma-client/transactions#sequential-prisma-client-operations). This will cause you to break out of the transaction and lead to unexepected results.
+Do not invoke <inlinecode>next</inlinecode> multiple times within a middleware when using [batch transactions](/concepts/components/prisma-client/transactions#sequential-prisma-client-operations). This will cause you to break out of the transaction and lead to unexpected results.
 
 </Admonition>
 

--- a/content/300-guides/300-upgrade-guides/200-upgrading-versions/800-upgrading-to-prisma-3/index.mdx
+++ b/content/300-guides/300-upgrade-guides/200-upgrading-versions/800-upgrading-to-prisma-3/index.mdx
@@ -120,7 +120,7 @@ prisma.log.create({
 
 This API change does not apply to the MongoDB connector where there is not a difference between a JSON null and a database NULL.
 
-They also do not apply to the `array_contains` operator becuase there can only be a JSON null within an JSON array. Since there cannot be a database NULL within a JSON array, `{ array_contains: null }` is not ambiguous.
+They also do not apply to the `array_contains` operator because there can only be a JSON null within an JSON array. Since there cannot be a database NULL within a JSON array, `{ array_contains: null }` is not ambiguous.
 
 </Admonition>
 

--- a/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/425-nextjs-prisma-client-monorepo.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/100-help-articles/425-nextjs-prisma-client-monorepo.mdx
@@ -13,7 +13,7 @@ Error: Your schema.prisma could not be found, and we detected that you are using
 Find out why and learn how to fix this: https://pris.ly/d/schema-not-found-nextjs
 ```
 
-If you are using a Prisma version earlier than 4.11.0, the error message you will recieve will look similar to the message below:
+If you are using a Prisma version earlier than 4.11.0, the error message you will receive will look similar to the message below:
 
 ```
 Error: ENOENT: no such file or directory, open '/prisma-next-mono-reproduction/packages/service/.next/cache/webpack/client-development/schema.prisma'

--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -913,7 +913,7 @@ When Prisma does an upsert, it first checks whether that record already exists i
 - If the record does not exist, then Prisma creates that record.
 - If the record exists, then Prisma updates it.
 
-When your application tries to perform two or more concurrent upsert operations, then a race condition might happen where two or more operations do not find the record and therefore try to create that record. In this situation, one of the operations succesfully creates the new record but the other operations fail and return a unique key constraint error.
+When your application tries to perform two or more concurrent upsert operations, then a race condition might happen where two or more operations do not find the record and therefore try to create that record. In this situation, one of the operations successfully creates the new record but the other operations fail and return a unique key constraint error.
 
 ##### Solution
 

--- a/content/800-data-platform/200-pulse/400-api-reference.mdx
+++ b/content/800-data-platform/200-pulse/400-api-reference.mdx
@@ -162,7 +162,7 @@ Pulse allows you to subscribe to change events based on filter conditions and op
 You must wrap your filter criteria inside a `before` or `after` object depending on the type of event your subscription is listening for:
 
 - `before`: `delete` events
-- `after`: `create` and `udpate` events
+- `after`: `create` and `update` events
 
 This makes it explicit that the specified filter criteria apply to the `before` or `after` state of the change event.
 

--- a/content/800-data-platform/600-classic-projects/100-platform/900-troubleshooting/050-connection-to-db-timed-out.mdx
+++ b/content/800-data-platform/600-classic-projects/100-platform/900-troubleshooting/050-connection-to-db-timed-out.mdx
@@ -27,7 +27,7 @@ Several reasons related to the Data Proxy or database configuration might cause 
 
 - The time it took the database to process the query pushed it over the timeout limit
 - The payload response is large and could not be processed within the timeout limit
-- The depth of the query is large (it includes mutliple relational fields)
+- The depth of the query is large (it includes multiple relational fields)
 
 ## **Solution**
 


### PR DESCRIPTION
## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

This PR fix the typos seen in multiple files

## Changes

```pseudo
macthing > matching
unexepected > unexpected
becuase > because
recieve > receive
mutliple > multiple
```
