### PR TITLE
Update 120-query.mdx

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/053-client-extensions/120-query.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-client-extensions/120-query.mdx
@@ -57,8 +57,8 @@ const prisma = new PrismaClient().$extends({
   query: {
     user: {
       async findMany({ model, operation, args, query }) {
-        // set `age` and fill with the rest of `where`
-        args.where = { age: { gt: 18 }, ...args.where }
+        // take incoming `where` and set `age`
+        args.where = { ...args.where, age: { gt: 18 } }
 
         return query(args)
       },


### PR DESCRIPTION
applies age clause after object spread, prevents user overriding age rule

## Describe this PR

The current `age >= 18` example can be bypassed via the user supplying their own age:
```ts
const shouldntReturnButDoes = await prisma.user.findMany({ where: { age: { lt: 18 } } });
```
There could be a use case where you would want the ability to override the rule, but it's incongruent with the description:

> The following example modifies user.findMany to a use a customized query that finds only users who are older than 18 years

## Changes

Update the spread of the where clause to be before the age clause, so the age rule cannot be overridden by an incoming query

## What issue does this fix?

Prevents users from inadvertently shipping vulnerable extensions that they think are secure
