### PR TITLE
Correcting Escaped Code Example

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/050-filtering-and-sorting.mdx
@@ -267,7 +267,7 @@ The above query will match any user whose name starts with a character followed 
 const users = await prisma.user.findMany({
   where: {
     name: {
-      startsWith: '\_benny', // note that the `_` character is escaped
+      startsWith: '\\_benny', // note that the `_` character is escaped, preceding `\` with `\` when included in a string
     },
   },
 })


### PR DESCRIPTION
In js, according to the normal string escape rules, need to add `\` before `\`