### PR TITLE
Fixes link caption in Prisma Migration docs

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -18,7 +18,7 @@ Prisma Migrate is an **declarative database schema migration tool** that enables
 - Keep your database schema in sync with your [Prisma schema](/concepts/components/prisma-schema) as it evolves _and_
 - Maintain existing data in your database
 
-Prisma Migrate generates [a history of `.sql` migration files](/concepts/components/prisma-migrate/migration-histories), and plays a role in both [development and deployment](/concepts/components/prisma-migrate/migrate-development-production).
+Prisma Migrate generates [a history of `.sql` migration files](/concepts/components/prisma-migrate/migration-histories), and plays a role in both [development and production](/concepts/components/prisma-migrate/migrate-development-production).
 
 <Tip>
 


### PR DESCRIPTION
## Describe this PR

This PR fixes a link caption in the docs that describe the use cases for Prisma migrations.

## Changes

Before:
```
... and plays a role in both [development and deployment](https://www.prisma.io/docs/concepts/components/prisma-migrate/migrate-development-production).
```

After:
```
... and plays a role in both [development and production](https://www.prisma.io/docs/concepts/components/prisma-migrate/migrate-development-production).
```

## What issue does this fix?

No issue available. The page in question is this: https://www.prisma.io/docs/concepts/components/prisma-migrate

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
