### PR TITLE
fix(accelerate): Rename "Testing" to "Evaluating"

### DIFF
--- a/content/800-data-platform/100-accelerate/550-evaluating.mdx
+++ b/content/800-data-platform/100-accelerate/550-evaluating.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Testing'
-metaTitle: 'Accelerate: Testing'
-metaDescription: 'Learn about testing Prisma Accelerate.'
+title: 'Evaluating'
+metaTitle: 'Accelerate: Evaluating'
+metaDescription: 'Learn about evaluating Prisma Accelerate.'
 tocDepth: 3
 toc: true
 ---
@@ -10,13 +10,13 @@ toc: true
 
 Prisma Accelerate optimizes database interactions through advanced connection pooling and global edge caching. Its connection pooler is available in 16 regions and helps applications load-balance and scale database requests based on demand.
 
-Considering the information above, we recommend testing Accelerate with high volume to see it perform under load.
+Considering the information above, we recommend evaluating Accelerate with high volume to see it perform under load.
 
 </TopBlock>
 
 ## How Accelerate's connection pool optimizes performance under load
 
-Prisma Accelerate employs a dynamic, serverless connection pooling infrastructure. When a request is made, a connection pool is quickly provisioned for the project in the region assigned while configuring Prisma Accelerate. This connection pool remains active, serving many additional requests while reusing established database connections. The connection pool will disconnect after a period of inactivity, so it’s important to test Prisma Accelerate with a consistent stream of traffic.
+Prisma Accelerate employs a dynamic, serverless connection pooling infrastructure. When a request is made, a connection pool is quickly provisioned for the project in the region assigned while configuring Prisma Accelerate. This connection pool remains active, serving many additional requests while reusing established database connections. The connection pool will disconnect after a period of inactivity, so it’s important to evaluate Prisma Accelerate with a consistent stream of traffic.
 
 **Key Benefits:**
 
@@ -28,9 +28,9 @@ Prisma Accelerate employs a dynamic, serverless connection pooling infrastructur
 
 By understanding and harnessing this mechanism, you can ensure that your database queries perform consistently and efficiently at scale.
 
-## Testing Prisma Accelerate connection pooling performance
+## Evaluating Prisma Accelerate connection pooling performance
 
-Below you will find an example of how to test Prisma Accelerate using a sample model:
+Below you will find an example of how to evaluate Prisma Accelerate using a sample model:
 
 ```prisma
 model Notes {
@@ -99,7 +99,7 @@ async function main() {
     take: 20,
   })
 
-  // we recommend testing Prisma Accelerate with a large loop
+  // we recommend evaluationg Prisma Accelerate with a large loop
   const LOOP_LENGTH = 10000
 
   for (let i = 0; i < LOOP_LENGTH; i++) {
@@ -128,11 +128,11 @@ main()
   })
 ```
 
-## Testing Prisma Accelerate caching performance
+## Evaluating Prisma Accelerate caching performance
 
 Prisma Accelerate’s edge cache is also optimized for a high volume of queries. The cache automatically optimizes for repeated queries. As a result, the cache hit rate will increase as the query frequency does. Adding a query result to the cache is also non-blocking, so a short burst of queries might not utilize the cache or a sustained load.
 
-To test Accelerate’s edge caching, you can modify the above script with the below:
+To evaluate Accelerate’s edge caching, you can modify the above script with the below:
 
 ```typescript
 import { PrismaClient } from '@prisma/client'
@@ -195,7 +195,7 @@ async function main() {
     },
   })
 
-  // we recommend testing Prisma Accelerate with a large loop
+  // we recommend evaluating Prisma Accelerate with a large loop
   const LOOP_LENGTH = 10000
 
   for (let i = 0; i < LOOP_LENGTH; i++) {

--- a/vercel.json
+++ b/vercel.json
@@ -1714,6 +1714,10 @@
     {
       "source": "/docs/data-platform/classic-projects/contact-support",
       "destination": "/docs/data-platform/platform-console/support"
+    },
+    {
+      "source": "/docs/data-platform/accelerate/testing",
+      "destination": "/docs/data-platform/accelerate/evaluating"
     }
   ]
 }


### PR DESCRIPTION
The content of this page has little to do with _testing_ as it is usually understood in software and Prisma context, which is about making sure that the software does the correct thing. 

Instead it is about _evaluating_ the performance and functionality of Prisma Accelerate.

Hence I renamed the page and replaced the term in the content.