### PR TITLE
fix: update links to bug report template for prisma/prisma repository

### DIFF
--- a/content/300-guides/500-other/880-troubleshooting-orm/050-creating-bug-reports.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/050-creating-bug-reports.mdx
@@ -24,7 +24,7 @@ This [StackOverflow guide](https://stackoverflow.com/help/minimal-reproducible-e
 
 ## Best practices for writing a bug report
 
-If you don't have the time to create a full reproduction of the issue, please include as much information as possible about the problem. The [bug report template](https://github.com/prisma/prisma/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yml) helps you with that.
+If you don't have the time to create a full reproduction of the issue, please include as much information as possible about the problem. The [bug report template](https://pris.ly/prisma-prisma-bug-report) helps you with that.
 
 ### Include logging and debugging output
 

--- a/content/300-guides/500-other/880-troubleshooting-orm/050-creating-bug-reports.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/050-creating-bug-reports.mdx
@@ -24,7 +24,7 @@ This [StackOverflow guide](https://stackoverflow.com/help/minimal-reproducible-e
 
 ## Best practices for writing a bug report
 
-If you don't have the time to create a full reproduction of the issue, please include as much information as possible about the problem. The [bug report template](https://github.com/prisma/prisma/issues/new?assignees=&labels=&template=bug_report.md&title=) helps you with that.
+If you don't have the time to create a full reproduction of the issue, please include as much information as possible about the problem. The [bug report template](https://github.com/prisma/prisma/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yml) helps you with that.
 
 ### Include logging and debugging output
 

--- a/content/300-guides/500-other/880-troubleshooting-orm/index.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/index.mdx
@@ -34,7 +34,7 @@ If you see problems or room for improvement in the ORM product, you can create a
 <ButtonLink
   color="dark"
   type="primary"
-  href="https://github.com/prisma/prisma/issues/new?assignees=&labels=&template=bug_report.md&title='Create bug report'"
+  href="https://github.com/prisma/prisma/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yml&title='Create bug report'"
 >
   Create bug report
 </ButtonLink>

--- a/content/300-guides/500-other/880-troubleshooting-orm/index.mdx
+++ b/content/300-guides/500-other/880-troubleshooting-orm/index.mdx
@@ -34,7 +34,7 @@ If you see problems or room for improvement in the ORM product, you can create a
 <ButtonLink
   color="dark"
   type="primary"
-  href="https://github.com/prisma/prisma/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yml&title='Create bug report'"
+  href="https://pris.ly/prisma-prisma-bug-report"
 >
   Create bug report
 </ButtonLink>


### PR DESCRIPTION
Fix link to bug report, previous link does not load the bug template.

Because the bug template changed from `.md` to `.yml` at some point.