### PR TITLE
cloud to console link

### DIFF
--- a/content/100-getting-started/index.mdx
+++ b/content/100-getting-started/index.mdx
@@ -12,9 +12,9 @@ Welcome to the Prisma getting started section! 👋 Prisma is an [open source](h
 - [**Prisma Migrate**](/concepts/components/prisma-migrate): Migration tool to easily evolve your database schema from prototyping to production
 - [**Prisma Studio**](/concepts/components/prisma-studio): GUI to view and edit data in your database
 
-Prisma is also available on the [Prisma Data Platform](https://cloud.prisma.io), a cloud-based, collaborative environment for teams and organizations to develop type-safe applications. The platform focuses on developer productivity with GitHub integration for your code and schema, a visual data browser, an online query console, and an optional data proxy for handling database connections. For more information, refer to the Prisma Data Platform [documentation](/data-platform).
+Prisma is also available on the [Prisma Data Platform](https://console.prisma.io), a cloud-based, collaborative environment for teams and organizations to develop type-safe applications. The platform focuses on developer productivity with GitHub integration for your code and schema, a visual data browser, an online query console, and an optional data proxy for handling database connections. For more information, refer to the Prisma Data Platform [documentation](/data-platform).
 
-For a more detailed breakdown of what problems Prisma solves, and why it's **built to make you more productive**, see the [Why Prisma](/concepts/overview/why-prisma) section.
+For a more detailed breakdown of what problems Prisma solves and why it's **built to make you more productive**, see the [Why Prisma](/concepts/overview/why-prisma) section.
 
 </TopBlock>
 


### PR DESCRIPTION
### Describe this PR
Update[ Get Started page](https://www.prisma.io/docs/getting-started) to remove mention of Data Proxy, add mention of Prisma Accelerate & Prisma Pulse, and correctly link to console.prisma.io 

### Changes
- change link from cloud to console.prisma.io
- text updates


