### PR TITLE
Fix typo in Order of Fields section

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -343,7 +343,7 @@ Defines a Prisma [model](/concepts/components/prisma-schema/data-model#defining-
 
 #### Order of fields
 
-- In version 2.3.0 and later, introspection lists model fields same order as the corresponding columns in the database. Relation fields are listed after scalar fields.
+- In version 2.3.0 and later, introspection lists model fields in the same order as the corresponding columns in the database. Relation fields are listed after scalar fields.
 
 ### Examples
 


### PR DESCRIPTION
Fixes a minor typo in the `Order of Fields` section: https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#order-of-fields