### PR TITLE
Offer clear field @map example

### DIFF
--- a/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
+++ b/content/400-reference/200-api-reference/100-prisma-schema-reference.mdx
@@ -385,7 +385,7 @@ model User {
 - Typically spelled in camelCase
 - Must adhere to the following regular expression: `[A-Za-z][A-Za-z0-9_]*`
 
-> **Note**: You can use the [`@map` attribute](#map) to map a field name (for example, `MyField`) to a column with a different name that does not match field naming conventions (for example, `myField`).
+> **Note**: You can use the [`@map` attribute](#map) to [map a field name to a column](/concepts/components/prisma-client/working-with-prismaclient/use-custom-model-and-field-names) with a different name that does not match field naming conventions: e.g. `myField @map("my_field")`.
 
 ## <inlinecode>model</inlinecode> field scalar types
 


### PR DESCRIPTION
There's no clear field-mapping example in the [Prisma schema reference documentation](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#model-fields).

Users have to find their way to the [Using custom model and field names](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/use-custom-model-and-field-names#using-map-and-map-to-rename-fields-and-models-in-the-prisma-client-api) to find a clear example. 

I added a direct link to this section in the note itself, to make it more discoverable. 