### PR TITLE
Refactor Docs Page: Remove Unnecessary Code Snippet Update 07-mongodb…

### DIFF
--- a/content/200-concepts/200-database-connectors/07-mongodb.mdx
+++ b/content/200-concepts/200-database-connectors/07-mongodb.mdx
@@ -114,13 +114,6 @@ model User {
 }
 ```
 
-```prisma
-model User {
-  id Bytes @id @default(auto()) @map("_id") @db.ObjectId
-  // Other fields
-}
-```
-
 See also: [Defining ID fields in MongoDB](/concepts/components/prisma-schema/data-model#defining-ids-in-mongodb)
 
 ### Generating `ObjectId`


### PR DESCRIPTION
….mdx

This pull request addresses an issue in the documentation page where an unnecessary code snippet was present. The code snippet has been identified and removed to enhance the clarity and conciseness of the documentation.  there is a one example of user schema in mongodb section that is written two times

## Describe this PR
This pull request addresses an issue in the documentation page where an unnecessary code snippet was present. Specifically, there is a duplicate example of the user schema in the MongoDB section, which has been identified and removed to improve the clarity and conciseness of the documentation.
## Changes

<!-- What changes have you made? Keep it brief!

Removed duplicate user schema example in the MongoDB section.
- ... -->



## Any other relevant information

The redundant user schema example was causing confusion for readers, as it appeared twice in the MongoDB section. This removal aims to provide a more streamlined and error-free learning experience for users. The documentation now accurately reflects the intended content without unnecessary repetition.
![fix](https://github.com/prisma/docs/assets/96821893/23d9e9d8-1dde-43c3-9d96-3daae0a6d48c)
