### PR TITLE
add --dev flag to bun install command

### DIFF
--- a/content/400-reference/200-api-reference/200-command-reference.mdx
+++ b/content/400-reference/200-api-reference/200-command-reference.mdx
@@ -50,7 +50,7 @@ pnpm install prisma --save-dev
 Install with [Bun](https://bun.sh/):
 
 ```
-bun add prisma
+bun add prisma --dev
 ```
 
 <details>


### PR DESCRIPTION
## Describe this PR

In the installation instructions, the `bun add` command was missing the `--dev` flag, unlike the equivelent commands for `npm`, `yarn`, and `pnpm`.

## Changes

I appended `--bun` to `bun add prisma`