### PR TITLE
Corrected documentation hyperlink to use the updated domain

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/01-prisma-and-typeorm.mdx
+++ b/content/200-concepts/300-more/400-comparisons/01-prisma-and-typeorm.mdx
@@ -22,7 +22,7 @@ It uses the [Prisma schema](/concepts/components/prisma-schema) to define applic
 
 ## API design & Level of abstraction
 
-TypeORM and Prisma operate on different levels of abstraction. TypeORM is closer to mirroring SQL in its API while Prisma Client provides a higher-level abstraction that was carefully designed with the common tasks of application developers in mind. Prisma's API design heavily leans on the idea of [making the right thing easy](https://www.jason.af/right-thing-easy-thing/).
+TypeORM and Prisma operate on different levels of abstraction. TypeORM is closer to mirroring SQL in its API while Prisma Client provides a higher-level abstraction that was carefully designed with the common tasks of application developers in mind. Prisma's API design heavily leans on the idea of [making the right thing easy](https://jason.energy/right-thing-easy-thing/).
 
 While Prisma Client operates on a higher-level of abstraction, it strives to expose the full power of the underlying database and lets you drop down to [raw SQL](/concepts/components/prisma-client/raw-database-access) at any time if your use case requires it.
 


### PR DESCRIPTION

## Describe this PR

I believe the original author @jlengstorf has explicitly communicated the new location of their personal website [elsewhere](https://github.com/jlengstorf). 

## Changes

Corrected documentation hyperlink to use the updated resource location

## What issue does this fix?

Restores citation to key source of influence to Prisma design principle

## Any other relevant information

nada
