### PR TITLE
Add Reo script tag

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -34,6 +34,15 @@ const HTML = (props: any) => {
         {props.preBodyComponents}
         <div key={`body`} id="___gatsby" dangerouslySetInnerHTML={{ __html: props.body }} />
         {props.postBodyComponents}
+
+        {/* Start of Reo Javascript */}
+        <script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{
+            __html: '!function(){var e,t,n;e="dea12ffb2578f27",t=function(){Reo.init({ clientID: "dea12ffb2578f27" })},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.async=!0,n.onload=t,document.head.appendChild(n)}();',
+          }}
+        ></script>
+        {/* End of Reo Javascript */}
       </body>
     </html>
   )


### PR DESCRIPTION
Introducing a script tag to run an experiment with reo.dev.

Here are the original installation instructions: https://roverly.notion.site/JavaScript-Installation-Guide-for-documentation-webpages-f28305213fa543778e27a5b8baeadeee

Reo is a tool that Nitin and I are looking into, very initial phases, so for now I'd simply like to integrate this into our docs page to see how it works.

Once I have a PR approval that the code is okay, I'll be happy to merge this myself at the right time, so I can double-check that the setup is correct.