### PR TITLE
Add notion sync

### DIFF
--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -1,0 +1,36 @@
+name: Notion Board
+on:
+  issues:
+  issue_comment:
+  workflow_dispatch:
+    inputs:
+      setup:
+        description: 'Populate your notion database with all the requried properties'
+        type: boolean
+      syncIssues:
+        description: 'sync all other existing issues in this repo'
+        type: boolean
+      issueType:
+        type: choice
+        description: 'The issue type you want to sync'
+        options:
+          - all
+          - open
+          - closed
+        default: open
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Notion Board
+        uses: Souvikns/Notion-Board@2.2.0
+        with:
+          setup: ${{github.event.inputs.setup}}
+          syncIssues: ${{github.event.inputs.syncIssues}}
+          issueType: ${{github.event.inputs.issueType}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          NOTION_DATABASE: ${{ secrets.NOTION_DATABASE }}


### PR DESCRIPTION
## Description

This is setting up a notion sync so new issues are automatically posted to the internal Dev Connections notion DB.