### PR TITLE
(upgrade guides) yarn upgrade alias -> yarn up

### DIFF
--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/600-upgrading-to-prisma-5/index.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/600-upgrading-to-prisma-5/index.mdx
@@ -32,7 +32,7 @@ npm install -D prisma@5
 <tab>
 
 ```terminal
-yarn upgrade prisma@5 @prisma/client@5
+yarn up prisma@5 @prisma/client@5
 ```
 
 </tab>

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/700-upgrading-to-prisma-4.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/700-upgrading-to-prisma-4.mdx
@@ -468,7 +468,7 @@ npm install prisma@4 @prisma/client@4
 <tab>
 
 ```terminal
-yarn upgrade prisma@4 @prisma/client@4
+yarn up prisma@4 @prisma/client@4
 ```
 
 </tab>

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/800-upgrading-to-prisma-3/index.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/800-upgrading-to-prisma-3/index.mdx
@@ -153,7 +153,7 @@ npm install prisma@3 @prisma/client@3
 <tab>
 
 ```terminal
-yarn upgrade prisma@3 @prisma/client@3
+yarn up prisma@3 @prisma/client@3
 ```
 
 </tab>


### PR DESCRIPTION
## Describe this PR

`yarn up` will work with both yarn 1 and yarn 2.

## Changes

yarn upgrade -> yarn up

## What issue does this fix?

guides doesn't work for yarn 2

##

opened instead of 3-week older PR against your older codebase that went out of sync