### PR TITLE
Prepping Pulse Docs for removal of EA

### DIFF
--- a/content/800-data-platform/300-cloud-projects/200-platform/200-projects.mdx
+++ b/content/800-data-platform/300-cloud-projects/200-platform/200-projects.mdx
@@ -188,69 +188,52 @@ See [Usage](/data-platform/cloud-projects/platform/organizations#usage) for deta
 
 ## Pulse
 
-Within each Cloud Project you can set up and configure Pulse, Prisma's manage [change data capture](https://en.wikipedia.org/wiki/Change_data_capture) (CDC) service.
+Within each Cloud Project, you can set up and configure Pulse, Prisma's manage [change data capture](https://en.wikipedia.org/wiki/Change_data_capture) (CDC) service.
 
-### Configure Pulse
+### Enable Pulse
 
-To set up Pulse in your project, enter the **Pulse** tab on your project's details page.
+From your Cloud Project dashboard select **Enable Pulse**
 
-<Admonition type="info">
-
-This option will look slightly different if you have not yet been given Early Access to Pulse. In that scenario the link's text will change and will take you to the Pulse webpage.
-
-</Admonition>
-
-Alternatively, if you have been given access to Pulse, you can click **Configure Pulse** under the **Get Started** section of your project's **Dashboard** page.
+> This option will look slightly different if you have not yet been given Early Access to Pulse. In that scenario the link will prompt you to join the waitlist.
 
 On this page, there are two important sections with instructions to follow to set up Pulse:
 
-#### Prepare your database
+### Prepare your database
 
 First is the **Prepare your database** section. Here, a set of instructions are defined that guide you on preparing your database for supporting real-time functionality.
 
-These configurations are not Prisma-specific, but rather are database configurations Pulse relies on. For more detailed instructions, see the [Pulse documentation](/data-platform/pulse/what-is-pulse).
+These configurations are not Prisma-specific, but rather are database configurations Pulse relies on. For more detailed instructions, see the [Pulse documentation](https://docs-git-mhess-pulse-docs-updates-prisma.vercel.app/data-platform/pulse/what-is-pulse).
 
-<Admonition type="info">
+> Pulse currently works with PostgreSQL databases and MySQL support is coming soon.
 
-Pulse currently works with PostgreSQL databases and MySQL support is coming soon.
-
-</Admonition>
-
-#### Configure Pulse
+#### Enable Pulse
 
 This section will prompt you for two pieces of information needed to set up Pulse:
 
 1. Your database connection string
 2. The region where you would like to host Pulse
 
-<Admonition type="info">
+> It is recommended to choose a region nearest your database as this will minimize latency between Pulse and the database itself.
+>
+> Once those fields are filled in, click **Enable Pulse** at the bottom of the form. This will configure Pulse to be used by your project.
 
-It is recommended to choose a region closest to your database as this will minimize latency between Pulse and the database itself.
-
-</Admonition>
-
-Once those fields are filled in, click **Configure Pulse** at the bottom of the form. This will configure Pulse to be used by your project.
-
-After this completes, the view will display [instructions](/data-platform/pulse/what-is-pulse) on how to begin using Pulse in your application.
+After this completes, the view will display [instructions](/data-platform/pulse/what-is-pulse) on how to add Pulse to your application and start your first subscription.
 
 Specifically, you will be prompted to:
 
-1. Get a [Project API Key](/data-platform/cloud-projects/platform/projects#project-api-keys) if you do not already have one to use in the Pulse extension
-2. Set up Pulse in your application
+1. Add a [Project API Key](/data-platform/cloud-projects/platform/projects#project-api-keys) if you do not already have one to use in the Pulse extension
+2. Add Pulse to your application
 
-### Disable Pulse
+#### Disable Pulse
 
 At any time, you may disable Pulse and no longer use it in your project. To do this, head to the **Pulse** tab of your project's **Dashboard** page.
 
-On this tab, if Pulse is already enabled you will see a **Disable Pulse** button on the top right of the page. Clicking this button will open a panel with instructions on the changes that should be made to your database to drop the replication slot Pulse was configured to use.
+From this view, if Pulse is already enabled, navigate to **Settings** where you will be able to **Disable Pulse**. Clicking this button will open a dialog with instructions on the changes that should be made to your database to drop the replication slot Pulse was configured to use.
 
 Once that change is made, clicking the **Disable Pulse** button on that panel will disable Pulse, making it unusable by the associated project.
 
 ### View Pulse usage
 
-<Admonition type="info">
+Usage for Pulse is coming soon.
 
-**Usage for Pulse is coming soon.**<br/>
-We are currently working on providing usage statistics for Pulse.
-
-</Admonition>
+> We are currently working on providing usage statistics for Pulse.


### PR DESCRIPTION
Removed a link in the getting started page of the Pulse Docs that referenced signing up for early access. 