### PR TITLE
add an extension to the community extensions list

### DIFF
--- a/content/200-orm/200-prisma-client/300-client-extensions/200-extension-examples.mdx
+++ b/content/200-orm/200-prisma-client/300-client-extensions/200-extension-examples.mdx
@@ -28,6 +28,7 @@ The following is a list of extensions created by the community. If you want to c
 | [`prisma-extension-cache-manager`](https://github.com/random42/prisma-extension-cache-manager) | Caches model queries with any [cache-manager](https://www.npmjs.com/package/cache-manager) compatible cache           |
 | [`prisma-extension-random`](https://github.com/nkeil/prisma-extension-random)                  | Lets you query for random rows in your database                                                                       |
 | [`prisma-paginate`](https://github.com/sandrewTx08/prisma-paginate)                            | Adds support for paginating read queries                                                                              |
+| [`prisma-extension-streamdal`](https://github.com/streamdal/prisma-extension-streamdal) | Adds support for Code-Native data pipelines using Streamdal |
 
 If you have built an extension and would like to see it featured, feel free to add it to the list by opening a pull request.
 


### PR DESCRIPTION
## Describe this PR

Adding the Prisma extension we created to the list of community extensions.

## Changes

Adds an extension we created to the list. The extension is here: https://github.com/streamdal/prisma-extension-streamdal and in npm. 

## What issue does this fix?

Adds a community extension to the list.

## Any other relevant information

