### PR TITLE
docs: Make DIRECT_URL naming consistent with the previous pattern

### DIFF
--- a/content/200-orm/050-overview/500-databases/880-supabase.mdx
+++ b/content/200-orm/050-overview/500-databases/880-supabase.mdx
@@ -37,14 +37,14 @@ If you'd like to use the [connection pooling feature](https://supabase.com/docs/
 DATABASE_URL="postgres://postgres.[your-supabase-project]:[password]@aws-0-eu-central-1.pooler.supabase.com:6543/postgres?pgbouncer=true"
 ```
 
-If you would like to use the Prisma CLI in order to perform other actions on your database (e.g. migrations) you will need to add a `DIRECT_URL` environment variable to use in the `datasource.directUrl` property so that the CLI can bypass Supavisor:
+If you would like to use the Prisma CLI in order to perform other actions on your database (e.g. migrations) you will need to add a `DATABASE_DIRECT_URL` environment variable to use in the `datasource.directUrl` property so that the CLI can bypass Supavisor:
 
 ```env file=.env highlight=4-5;add
 # Connect to Supabase via connection pooling with Supavisor.
 DATABASE_URL="postgres://postgres.[your-supabase-project]:[password]@aws-0-eu-central-1.pooler.supabase.com:6543/postgres?pgbouncer=true"
 
 # Direct connection to the database. Used for migrations.
-DIRECT_URL="postgres://postgres:[password]@db.[your-supabase-project].supabase.co:5432/postgres"
+DATABASE_DIRECT_URL="postgres://postgres:[password]@db.[your-supabase-project].supabase.co:5432/postgres"
 ```
 
 You can then update your `schema.prisma` to use the new direct URL:
@@ -53,7 +53,7 @@ You can then update your `schema.prisma` to use the new direct URL:
 datasource db {
   provider  = "postgresql"
   url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
+  directUrl = env("DATABASE_DIRECT_URL")
 }
 ```
 
@@ -61,7 +61,7 @@ More information about the `directUrl` field can be found [here](/orm/reference/
 
 <Admonition type="info">
 
-We strongly recommend using connection pooling with Supavisor in addition to `DIRECT_URL`. You will gain the great developer experience of the Prisma CLI while also allowing for connections to be pooled regardless of your deployment strategy. While this is not strictly necessary for every app, serverless solutions will inevitably require connection pooling.
+We strongly recommend using connection pooling with Supavisor in addition to `DATABASE_DIRECT_URL`. You will gain the great developer experience of the Prisma CLI while also allowing for connections to be pooled regardless of your deployment strategy. While this is not strictly necessary for every app, serverless solutions will inevitably require connection pooling.
 
 </Admonition>
 


### PR DESCRIPTION

## Describe this PR

Current naming makes a mess in any env, because DIRECT_URL doesn't tell what that is, at the very least it has to stay consistent with the previous pattern, in ideal case both will be renamed because they are semantically wrong.

## Changes

More consistent env variable naming

## What issue does this fix?

Now people are copying bad naming and getting "DIRECT_URL" as a global env variable which says nothing about its usage and isn't consistent with Prisma's other url
