### PR TITLE
Custom output with `driverAdapters`

### DIFF
--- a/content/200-orm/050-overview/500-databases/200-database-drivers.mdx
+++ b/content/200-orm/050-overview/500-databases/200-database-drivers.mdx
@@ -50,7 +50,7 @@ You can also build your own driver adapter for the database you're using. The fo
 
 To use this feature:
 
-1. Update the `previewFeatures` block in your schema to include the the `driverAdapters` preview feature:
+1. Update the `previewFeatures` block in your schema to include the the `driverAdapters` Preview feature:
 
    ```prisma
    generator client {
@@ -70,3 +70,63 @@ To use this feature:
    - [Neon](/orm/overview/databases/neon#how-to-use-neons-serverless-driver-with-prisma-preview)
    - [PlanetScale](/orm/overview/databases/planetscale#how-to-use-the-planetscale-serverless-driver-with-prisma-preview)
    - [Turso](/orm/overview/databases/turso#how-to-connect-and-query-a-turso-database)
+
+### Driver adapters and custom output paths
+
+When using the driver adapters Preview feature along with a [custom output path for Prisma Client](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path), you cannot reference Prisma Client using a relative path.
+
+Let's assume you had `output` in your Prisma schema set to `../src/generated/client`:
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+  output   = "../src/generated/client"
+}
+```
+
+What you should **not** do is reference that path relatively:
+
+```ts no-copy
+// what not to do!
+import { PrismaClient } from './src/generated/client'
+
+const client = new PrismaClient()
+```
+
+Instead, you will need to use a linked dependency.
+
+<TabbedContent tabs={[<FileWithIcon text="npm" icon="file"/>, <FileWithIcon text="pnpm" icon="file"/>, <FileWithIcon text="yarn" icon="file"/>]}>
+
+<tab>
+
+```terminal
+npm add db@./src/generated/client
+```
+
+</tab>
+
+<tab>
+
+```terminal
+pnpm add db@link:./src/generated/client
+```
+
+</tab>
+
+<tab>
+
+```terminal
+yarn add db@link:./src/generated/client
+```
+
+</tab>
+
+</TabbedContent>
+
+Now you should be able to reference your generated client using `db`!
+
+```ts
+import { PrismaClient } from 'db'
+
+const client = new PrismaClient()
+```

--- a/content/200-orm/050-overview/500-databases/200-database-drivers.mdx
+++ b/content/200-orm/050-overview/500-databases/200-database-drivers.mdx
@@ -73,7 +73,7 @@ To use this feature:
 
 ### Driver adapters and custom output paths
 
-When using the driver adapters Preview feature along with a [custom output path for Prisma Client](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path), you cannot reference Prisma Client using a relative path.
+Since Prisma 5.9.0, when using the driver adapters Preview feature along with a [custom output path for Prisma Client](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path), you cannot reference Prisma Client using a relative path.
 
 Let's assume you had `output` in your Prisma schema set to `../src/generated/client`:
 


### PR DESCRIPTION
Fixes #5609

## Description

Added a few changes for a specific 5.9.0+ interaction between custom output paths and the driver adapters Preview feature.