### PR TITLE
Cross-reference nested upsert and upsert()

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -896,7 +896,7 @@ const user = await prisma.user.update({
 ```
 
 ### <inlinecode>upsert()</inlinecode>
-
+*This section covers the usage of the general upsert() operation. To learn about using nested upsert queries within update(), reference the documentation [here](#upsert-1).*
 `upsert` does the following:
 
 - If an existing database record satisfies the `where` condition, it updates that record
@@ -3149,7 +3149,7 @@ const user = await prisma.user.update({
 ### <inlinecode>upsert</inlinecode>
 
 <AlgoliaTerm name="apiReference" value="upsert" />
-
+*This section covers the usage of nested upsert within update(). To learn about the [`upsert()`](#upsert) operation, reference the linked documentation.*
 A nested `upsert` query updates a related record if it exists, or creates a new related record.
 
 #### Examples

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -902,6 +902,7 @@ const user = await prisma.user.update({
 This section covers the usage of the `upsert()` operation. To learn about using [nested upsert queries](#upsert-1) within `update()`, reference the linked documentation.
 
 </Admonition>
+
 `upsert` does the following:
 
 - If an existing database record satisfies the `where` condition, it updates that record
@@ -3155,7 +3156,11 @@ const user = await prisma.user.update({
 
 <AlgoliaTerm name="apiReference" value="upsert" />
 
-*This section covers the usage of nested upsert within `update()`. To learn about the [`upsert()`](#upsert) operation, reference the linked documentation.*
+<Admonition type="info">
+
+This section covers the usage of nested upsert within `update()`. To learn about the [`upsert()`](#upsert) operation, reference the linked documentation.
+
+</Admonition>
 
 A nested `upsert` query updates a related record if it exists, or creates a new related record.
 

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -896,7 +896,12 @@ const user = await prisma.user.update({
 ```
 
 ### <inlinecode>upsert()</inlinecode>
-*This section covers the usage of the general upsert() operation. To learn about using nested upsert queries within update(), reference the documentation [here](#upsert-1).*
+
+<Admonition type="info">
+
+This section covers the usage of the `upsert()` operation. To learn about using [nested upsert queries](#upsert-1) within `update()`, reference the linked documentation.
+
+</Admonition>
 `upsert` does the following:
 
 - If an existing database record satisfies the `where` condition, it updates that record

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -3149,7 +3149,9 @@ const user = await prisma.user.update({
 ### <inlinecode>upsert</inlinecode>
 
 <AlgoliaTerm name="apiReference" value="upsert" />
-*This section covers the usage of nested upsert within update(). To learn about the [`upsert()`](#upsert) operation, reference the linked documentation.*
+
+*This section covers the usage of nested upsert within `update()`. To learn about the [`upsert()`](#upsert) operation, reference the linked documentation.*
+
 A nested `upsert` query updates a related record if it exists, or creates a new related record.
 
 #### Examples


### PR DESCRIPTION
Fixes #5614 

- [ ] Cross reference two upsert sections