### PR TITLE
fix: fix import path for deno

### DIFF
--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/005-introduction.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/005-introduction.mdx
@@ -135,7 +135,7 @@ const prisma = new PrismaClient()
 For Deno, you can import Prisma Client as follows:
 
 ```ts file=lib/prisma.ts
-import { PrismaClient } from '../prisma/generated/client/edge.ts'
+import { PrismaClient } from './generated/client/deno/edge.ts'
 
 const prisma = new PrismaClient()
 // use `prisma` in your application to read and write data in your DB


### PR DESCRIPTION
This import looks incorrect for Deno, it should be deno/edge.ts

[https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/introduction#3-importing-prisma-client:~:tex[…]isma/generated/client/edge.ts%27](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/introduction#3-importing-prisma-client:~:text=%27../prisma/generated/client/edge.ts%27)