### PR TITLE
fix(full-text-search): Remove PostgreSQL specific query operator link on generic introduction

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/060-full-text-search.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/060-full-text-search.mdx
@@ -54,7 +54,7 @@ const result = await prisma.posts.findMany({
 
 ## Querying the database
 
-The `search` field uses the database's native querying capabilities under the hood. This means that the exact [query operators](https://www.postgresql.org/docs/14/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES) available are also database-specific.
+The `search` field uses the database's native querying capabilities under the hood. This means that the exact query operators available are also database-specific.
 
 ### PostgreSQL
 


### PR DESCRIPTION
… 
