### PR TITLE
Update 80-table-inheritance.mdx wrong comment corrected at line 257

### DIFF
--- a/content/200-orm/100-prisma-schema/20-data-model/80-table-inheritance.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/80-table-inheritance.mdx
@@ -254,7 +254,7 @@ const articles = await prisma.article.findMany({
 Depending on your needs, you may also query the other way around by filtering on the `type` discriminator column:
 
 ```ts
-// Query all articles
+// Query all videos
 const videoActivities = await prisma.activity.findMany({
   where: { type: 'Video' }
   include: { video: true }


### PR DESCRIPTION
Corrected comment at line 257 to accurately reflect functionality: "Query all videos" instead of "Query all articles"

## Describe this PR

Corrected comment at line 257 to accurately reflect functionality: "Query all videos" instead of "Query all articles"

## Changes

Corrected comment at line 257 to accurately reflect functionality: "Query all videos" instead of "Query all articles"

- Refactored example with a correct comment instead of wrong one (Query all articles)
```ts
// Query all videos
const videoActivities = await prisma.activity.findMany({
  where: { type: 'Video' }
  include: { video: true }
})
```

## What issue does this fix?

A wrong comment at line 257 of doc file (Table inheritance)

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
