### PR TITLE
Prevent typescript not recommending actual prisma variable

### DIFF
--- a/content/200-orm/800-more/600-help-and-troubleshooting/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -28,14 +28,14 @@ const prismaClientSingleton = () => {
 }
 
 declare global {
-  var prisma: undefined | ReturnType<typeof prismaClientSingleton>
+  var prismaGlobal: undefined | ReturnType<typeof prismaClientSingleton>
 }
 
-const prisma = globalThis.prisma ?? prismaClientSingleton()
+const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
 
 export default prisma
 
-if (process.env.NODE_ENV !== 'production') globalThis.prisma = prisma
+if (process.env.NODE_ENV !== 'production') globalThis.prismaGlobal = prisma
 ```
 
 You can extend Prisma Client using a Prisma Client extension by appending the `$extends` client method when instantiating Prisma Client as follows:


### PR DESCRIPTION
## Describe this PR

### Best practice for instantiating Prisma Client with Next.js

By declaring global variable named prisma, typescript thinks it is an global variable and should not be imported from somewhere.

<img width="943" alt="image" src="https://github.com/prisma/docs/assets/48021917/861cd860-348e-4b97-9e00-60e9756a20f7">

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

Renaming global variable that contains the prisma object

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

Typescript now recommends actual prisma object separate to prismaGlobal variable we declared that is only needed to not instantiate prisma client again
<img width="1212" alt="image" src="https://github.com/prisma/docs/assets/48021917/862d1438-012e-4780-9d1a-fd36c0dfc8e1">


<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
