### PR TITLE
fix(docs): remove extra parenthesis

### DIFF
--- a/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
@@ -15,7 +15,7 @@ npx prisma migrate deploy
 <Admonition type="info">
 
 This guide **does not apply for MongoDB**.<br />
-Instead of `migrate deploy`, [`db push`](/orm/prisma-migrate/workflows/prototyping-your-schema) is used for [MongoDB](/orm/overview/databases/mongodb)).
+Instead of `migrate deploy`, [`db push`](/orm/prisma-migrate/workflows/prototyping-your-schema) is used for [MongoDB](/orm/overview/databases/mongodb).
 
 </Admonition>
 


### PR DESCRIPTION
## Describe this PR

At the top of ["Deploying database changes with Prisma Migrate"], a warning ends with an extra `)`:

> This guide **does not apply for MongoDB**.  
> Instead of `migrate deploy`, `db push` is used for MongoDB).

["Deploying database changes with Prisma Migrate"]: https://www.prisma.io/docs/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate

## Changes

Removed the extra `)`.

## What issue does this fix?

N/A, this is a minor fix.

## Any other relevant information

N/A
