### PR TITLE
Add Cerbos ORM adapter link

### DIFF
--- a/content/200-orm/800-more/400-comparisons/04-prisma-and-drizzle.mdx
+++ b/content/200-orm/800-more/400-comparisons/04-prisma-and-drizzle.mdx
@@ -454,6 +454,7 @@ Thanks to its maturity, Prisma's community has developed a [plethora of useful t
 - [`jest-prisma`](https://github.com/Quramy/jest-prisma): Environment for Prisma integrated testing with [Jest](https://jestjs.io/).
 - [`prisma-pothos-types`](https://github.com/hayes/pothos/tree/main/packages/plugin-prisma): Creates GraphQL types based on Prisma models when using [GraphQL Pothos](https://github.com/hayes/pothos/tree/main).
 - [`prisma-trpc-generator`](https://github.com/omar-dulaimi/prisma-trpc-generator): Creates [tRPC](https://trpc.io/) routers from your Prisma schema.
+- [`@cerbos/orm-prisma`](https://github.com/cerbos/query-plan-adapters/tree/main/prisma): Filter data based on authorization policies from [Cerbos](https://cerbos.dev).
 
 ## Database support
 


### PR DESCRIPTION
Adds a reference to the Cerbos ORM adapter for Primsa 
