### PR TITLE
MariaDB mentions

### DIFF
--- a/content/200-orm/050-overview/500-databases/400-mysql.mdx
+++ b/content/200-orm/050-overview/500-databases/400-mysql.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'MySQL'
+title: 'MySQL/MariaDB'
 metaTitle: 'MySQL database connector'
-metaDescription: 'This page explains how Prisma can connect to a MySQL database using the MySQL database connector.'
+metaDescription: 'This page explains how Prisma can connect to a MySQL or MariaDB database using the MySQL database connector.'
 tocDepth: 3
 ---
 
 <TopBlock>
 
-The MySQL data source connector connects Prisma ORM to a [MySQL](https://www.mysql.com/) database server.
+The MySQL data source connector connects Prisma ORM to a [MySQL](https://www.mysql.com/) or [MariaDB](https://mariadb.org/) database server.
 
 By default, the MySQL connector contains a database driver responsible for connecting to your database. You can use a [driver adapter](/orm/overview/databases/database-drivers#driver-adapters) (Preview) to connect to your database using a JavaScript database driver from Prisma Client.
 
@@ -26,7 +26,7 @@ datasource db {
 
 The fields passed to the `datasource` block are:
 
-- `provider`: Specifies the `mysql` data source connector.
+- `provider`: Specifies the `mysql` data source connector, which is used both for MySQL and MariaDB.
 - `url`: Specifies the [connection URL](#connection-url) for the MySQL database server. In this case, an [environment variable is used](/orm/prisma-schema/overview#accessing-environment-variables-from-the-schema) to provide the connection URL.
 
 ## Connection details
@@ -50,7 +50,7 @@ The following components make up the _base URL_ of your database, they are alway
 | Name     | Placeholder | Description                                                                                                         |
 | :------- | :---------- | :------------------------------------------------------------------------------------------------------------------ |
 | Host     | `HOST`      | IP address/domain of your database server, e.g. `localhost`                                                         |
-| Port     | `PORT`      | Port on which your database server is running, e.g. `5432`                                                          |
+| Port     | `PORT`      | Port on which your database server is running, e.g. `5432`  (default is `3306`, or no port when using Unix socket)  |
 | User     | `USER`      | Name of your database user, e.g. `janedoe`                                                                          |
 | Password | `PASSWORD`  | Password for your database user                                                                                     |
 | Database | `DATABASE`  | Name of the [database](https://dev.mysql.com/doc/refman/8.0/en/creating-database.html) you want to use, e.g. `mydb` |
@@ -112,8 +112,8 @@ mysql://USER:PASSWORD@HOST:PORT/DATABASE?sslidentity=client-identity.p12&sslpass
 
 ### Connecting via sockets
 
-To connect to your MySQL database via sockets, you must add a `socket` field as a _query parameter_ to the connection URL (instead of setting it as the `host` part of the URI).
-The value of this parameter then must point to the directory that contains the socket, e.g.: `mysql://USER:POST@localhost/database?socket=/var/run/mysql/`
+To connect to your MySQL/MariaDB database via a socket, you must add a `socket` field as a _query parameter_ to the connection URL (instead of setting it as the `host` part of the URI).
+The value of this parameter then must point to the directory that contains the socket, e.g. on a default installation of MySQL/MariaDB on Ubuntu or Debian use: `mysql://USER:POST@localhost/database?socket=/run/mysqld/mysqld.sock`
 
 Note that `localhost` is required, the value itself is ignored and can be anything.
 
@@ -138,6 +138,20 @@ The MySQL connector maps the [scalar types](/orm/prisma-schema/data-model/models
 | `DateTime` | `DATETIME(3)`    |                                                  |
 | `Json`     | `JSON`           | Supported in MySQL 5.7+ only                     |
 | `Bytes`    | `LONGBLOB`       |
+
+### Native type mapping from Prisma ORM to MariaDB
+
+| Prisma ORM | MariaDB            | Notes                                            |
+| ---------- | ---------------- | -------------------------------------------------- |
+| `String`   | `VARCHAR(191)`   |                                                    |
+| `Boolean`  | `BOOLEAN`        | In MariaDB `BOOLEAN` is a synonym for `TINYINT(1)` |
+| `Int`      | `INT`            |                                                    |
+| `BigInt`   | `BIGINT`         |                                                    |
+| `Float`    | `DOUBLE`         |                                                    |
+| `Decimal`  | `DECIMAL(65,30)` |                                                    |
+| `DateTime` | `DATETIME(3)`    |                                                    |
+| `Json`     | `LONGTEXT        | See https://mariadb.com/kb/en/json-data-type/      |
+| `Bytes`    | `LONGBLOB`       |                                                    |
 
 ### Native type mappings
 
@@ -204,3 +218,18 @@ model Device {
 ## Engine
 
 If you are using a version of MySQL where MyISAM is the default engine, you must specify `ENGINE = InnoDB;` when you create a table. If you introspect a database that uses a different engine, relations in the Prisma Schema are not created (or lost, if the relation already existed).
+
+## Permissions
+
+A fresh new installation of MySQL/MariaDB has by default only a `root` database user. Do not use `root` user in your Prisma configuration, but instead create a database and database user for each application. On most Linux hosts (e.g. Ubuntu) you can simply run this as the Linux `root` user (which automatically has database `root` access as well):
+
+```
+mysql -e "CREATE DATABASE IF NOT EXISTS $DB_PRISMA;"
+mysql -e "GRANT ALL PRIVILEGES ON $DB_PRISMA.* TO $DB_USER@'%' IDENTIFIED BY '$DB_PASSWORD';"
+```
+
+The above is enough to run the `prisma db pull` and `prisma db push` commands. In order to also run `prisma migrate` commands these permissions need to be granted:
+
+```
+mysql -e "GRANT CREATE, DROP, REFERENCES, ALTER ON *.* TO $DB_USER@'%';"
+```

--- a/content/200-orm/100-prisma-schema/20-data-model/20-relations/410-referential-actions/index.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/20-relations/410-referential-actions/index.mdx
@@ -150,14 +150,14 @@ The following caveats apply:
 
 The following table shows which referential action each database supports.
 
-| Database    | Cascade | Restrict | NoAction | SetNull | SetDefault |
-| :---------- | :------ | :------- | :------- | :------ | :--------- |
-| PostgreSQL  | ✔️      | ✔️       | ✔️       | ✔️⌘     | ✔️         |
-| MySQL       | ✔️      | ✔️       | ✔️       | ✔️      | ❌ (✔️†)   |
-| SQLite      | ✔️      | ✔️       | ✔️       | ✔️      | ✔️         |
-| SQL Server  | ✔️      | ❌‡      | ✔️       | ✔️      | ✔️         |
-| CockroachDB | ✔️      | ✔️       | ✔️       | ✔️      | ✔️         |
-| MongoDB††   | ✔️      | ✔️       | ✔️       | ✔️      | ❌         |
+| Database      | Cascade | Restrict | NoAction | SetNull | SetDefault |
+| :------------ | :------ | :------- | :------- | :------ | :--------- |
+| PostgreSQL    | ✔️      | ✔️         | ✔️        | ✔️⌘      | ✔️          |
+| MySQL/MariaDB | ✔️      | ✔️         | ✔️        | ✔️       | ❌ (✔️†)    |
+| SQLite        | ✔️      | ✔️         | ✔️        | ✔️       | ✔️          |
+| SQL Server    | ✔️      | ❌‡       | ✔️        | ✔️       | ✔️          |
+| CockroachDB   | ✔️      | ✔️         | ✔️        | ✔️       | ✔️          |
+| MongoDB††     | ✔️      | ✔️         | ✔️        | ✔️       | ❌         |
 
 - † See [special cases for MySQL](#mysql).
 - ⌘ See [special cases for PostgreSQL](#postgresql).
@@ -168,9 +168,9 @@ The following table shows which referential action each database supports.
 
 Referential actions are part of the ANSI SQL standard. However, there are special cases where some relational databases diverge from the standard.
 
-#### MySQL
+#### MySQL/MariaDB
 
-MySQL, and the underlying InnoDB storage engine, does not support `SetDefault`. The exact behavior depends on the database version:
+MySQL/MariaDB, and the underlying InnoDB storage engine, does not support `SetDefault`. The exact behavior depends on the database version:
 
 - In MySQL versions 8 and later, and MariaDB versions 10.5 and later, `SetDefault` effectively acts as an alias for `NoAction`. You can define tables using the `SET DEFAULT` referential action, but a foreign key constraint error is triggered at runtime.
 - In MySQL versions 5.6 and later, and MariaDB versions before 10.5, attempting to create a table definition with the `SET DEFAULT` referential action fails with a syntax error.

--- a/content/200-orm/300-prisma-migrate/200-understanding-prisma-migrate/200-shadow-database.mdx
+++ b/content/200-orm/300-prisma-migrate/200-understanding-prisma-migrate/200-shadow-database.mdx
@@ -113,7 +113,7 @@ In order to create and delete the shadow database when using `migrate dev`, Pris
 | Database             | Database user requirements                                                                                                                                                                                            |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SQLite               | No special requirements.                                                                                                                                                                                              |
-| MySQL                | Database user must have `CREATE, ALTER, DROP, REFERENCES ON *.*` privileges                                                                                                                                           |
+| MySQL/MariaDB        | Database user must have `CREATE, ALTER, DROP, REFERENCES ON *.*` privileges                                                                                                                                           |
 | PostgreSQL           | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createrole.html))                                           |
 | Microsoft SQL Server | The user must be a site admin or have the `SERVER` securable. See the [official documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine?view=sql-server-ver15). |
 

--- a/content/200-orm/500-reference/375-supported-databases.mdx
+++ b/content/200-orm/500-reference/375-supported-databases.mdx
@@ -19,14 +19,15 @@ An asterisk (\*) indicates that the version number is not relevant; either all v
 | Database             | Version |
 | -------------------- | ------- |
 | CockroachDB          | 21.2.4+ |
-| MariaDB              | 10      |
+| MariaDB              | 10.0+   |
+| MariaDB              | 11.0+   |
 | Microsoft SQL Server | 2017    |
 | Microsoft SQL Server | 2019    |
 | Microsoft SQL Server | 2022    |
 | MongoDB              | 4.2+    |
 | MySQL                | 5.6     |
 | MySQL                | 5.7     |
-| MySQL                | 8       |
+| MySQL                | 8.0     |
 | PostgreSQL           | 9.6     |
 | PostgreSQL           | 10      |
 | PostgreSQL           | 11      |

--- a/content/300-accelerate/200-getting-started.mdx
+++ b/content/300-accelerate/200-getting-started.mdx
@@ -16,7 +16,7 @@ To get started with Accelerate, you will need the following:
 
 - A GitHub account.
 - A project that uses [Prisma Client](/orm/prisma-client) `4.16.1` or higher. If your project is using interactive transactions, you need to use `5.1.1` or higher. (We always recommend using the latest version of Prisma.)
-- A hosted PostgreSQL, MySQL, PlanetScale, CockroachDB, or MongoDB database.
+- A hosted PostgreSQL, MySQL/MariaDB, PlanetScale, CockroachDB, or MongoDB database.
 
 ## 1. Enable Accelerate in a project
 

--- a/src/components/shortcodes/index.tsx
+++ b/src/components/shortcodes/index.tsx
@@ -32,6 +32,7 @@ import {
   Tab,
 } from './gettingstarted'
 import PostgresSQLSimple from '../../icons/technologies/PostgresSQLSimple'
+import MariaDBDark from '../../icons/technologies/MariaDBDark'
 import MySQLSimple from '../../icons/technologies/MySQLSimple'
 import SQLServer from '../../icons/technologies/SQLServer'
 import PlanetScale from '../../icons/technologies/PlanetScale'
@@ -93,6 +94,7 @@ const shortcodes = {
   Tab,
   SquareLogo,
   PostgresSQLSimple,
+  MariaDBDark,
   MySQLSimple,
   SQLServer,
   PlanetScale,


### PR DESCRIPTION
## Describe this PR

I have never used Prisma before, and it took me quite a lot of extra effort to figure out if Prisma supports MariaDB at all because the documentation was only mentioning MySQL. After some digging, I found that indeed Prisma uses both https://www.npmjs.com/package/mariadb for the connector and https://hub.docker.com/_/mariadb as part of the CI, and MariaDB support is actually excellent.

## What issue does this fix?

The docs hide the fact that Prisma actually supports MariaDB. [Sequalize has very clear MariaDB documentation](https://sequelize.org/docs/v7/other-topics/dialect-specific-things/#mariadb), and if you merge this PR then Prisma will be much more clear about the MariaDB support situation.

## Changes

Each commit is [atomic](https://optimizedbyotto.com/post/good-git-commit/#1-commits-should-be-atomic) and carefully documented - please review this PR by looking commit-by-commit looking at the message and the change at the same time. 

Looking at [git log in 500-databases](https://github.com/prisma/docs/commits/main/content/200-orm/050-overview/500-databases) and e.g. 4358a4169ef3ff042d70b825a9cf3e16bf71e48e seems you prefer to squash when merging. Please merge this PR as-is **without** squashing to avoid loosing the per-commit documentation.

## Any other relevant information

I am also happy to iterate on the contents of this PR based on your feedback. I am also happy to rebase frequently.
