### PR TITLE
Update 485-deploy-to-vercel.mdx to avoid build failed on vercel

### DIFF
--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
@@ -312,7 +312,7 @@ import { Client } from '@planetscale/database'
 
 export const runtime = 'edge'
 
-export async function GET(request) {
+export async function GET(request: Request) {
   const client = new Client({ url: process.env.DATABASE_URL })
   const adapter = new PrismaPlanetScale(client)
   const prisma = new PrismaClient({ adapter })
@@ -430,7 +430,7 @@ import { Pool } from '@neondatabase/serverless'
 
 export const runtime = 'edge'
 
-export async function GET(request) {
+export async function GET(request: Request) {
   const neon = new Pool({ connectionString: process.env.DATABASE_URL })
   const adapter = new PrismaNeon(neon)
   const prisma = new PrismaClient({ adapter })


### PR DESCRIPTION
## Describe this PR

Alter `export async function GET(request) {}` to `export async function GET(request: Request) {}`. Otherwise, the vercel build will report an error.

![image](https://github.com/prisma/docs/assets/52435083/c6ac39d4-05a0-451c-b945-21e16d316d18)


## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
