### PR TITLE
Update 400-deploy-to-aws-lambda.mdx

### DIFF
--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -168,6 +168,7 @@ package:
     - 'node_modules/.prisma/client/libquery_engine-rhel-*'
     - '!node_modules/prisma/libquery_engine-*'
     - '!node_modules/@prisma/engines/**'
+    - '!node_modules/.cache/prisma/**'
 ```
 
 If you are deploying to [Lambda functions with ARM64 architecture](#lambda-functions-with-arm64-architectures) you should update the Serverless configuration file to package the `arm64` engine file, as follows:


### PR DESCRIPTION
Additionally excluded node_modules/.cache/prisma/**

Which is present for Windows users