### PR TITLE
Update documentation related to SQL injection with raw queries

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -630,7 +630,7 @@ The following example uses a MySQL query and is safe ✅ from SQL Injection:
 
 ```ts
 // Safe if the text query below is completely trusted content
-const query = Prisma.sql`SELECT id, name FROM "User" WHERE name = $1`
+const query = Prisma.sql`SELECT id, name FROM "User" WHERE name = ?`
 
 // inputString can be untrusted input
 const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -58,9 +58,7 @@ const result = await prisma.$queryRaw(
 
 <Admonition type="warning">
 
-If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
-
-For more information on this risk, see the [SQL Injection](#sql-injection) section below.
+If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion. For more information on this risk, see the [SQL Injection](#sql-injection) section below.
 
 </Admonition>
 
@@ -562,7 +560,7 @@ One way is by artificially generating a tagged template that unsafely concatenat
 The following example is vulnerable ❌ to SQL Injection:
 
 ```ts
-//Unsafely generate query text
+// Unsafely generate query text
 const inputString = `'Sarah' UNION SELECT id, title FROM "Post"` // SQL Injection
 const query = `SELECT id, name FROM "User" WHERE name = ${inputString}`
 
@@ -697,7 +695,7 @@ const result = await prisma.$queryRaw(query)
 console.log(result)
 ```
 
-### The "Unsafe" methods
+### In <inlinecode>$queryRawUnsafe</inlinecode> and <inlinecode>$executeRawUnsafe</inlinecode>
 
 #### Using <inlinecode>$queryRawUnsafe</inlinecode> and <inlinecode>$executeRawUnsafe</inlinecode> unsafely
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -557,7 +557,7 @@ console.log(result)
 
 However, it is also possible to use these methods in unsafe ways.
 
-One way is by generating a tagged template that unsafely concatenates user input.
+One way is by artificially generating a tagged template that unsafely concatenates user input.
 
 The following example is vulnerable ❌ to SQL Injection:
 
@@ -566,8 +566,13 @@ The following example is vulnerable ❌ to SQL Injection:
 const inputString = `'Sarah' UNION SELECT id, title FROM "Post"` // SQL Injection
 const query = `SELECT id, name FROM "User" WHERE name = ${inputString}`
 
-// Make into a tagged template
+// Version for Typescript
+const stringsArray: any = [...[query]]
+
+// Version for Javascript
 const stringsArray = [...[query]]
+
+// Use the `raw` property to impersonate a tagged template
 stringsArray.raw = [query]
 
 // Use queryRaw
@@ -629,8 +634,14 @@ In these examples, the `sql` helper method is used to build the query text inclu
 The following example uses a MySQL query and is safe ✅ from SQL Injection:
 
 ```ts
+// Version for Typescript
+const query: any
+
+// Version for Javascript
+const query
+
 // Safe if the text query below is completely trusted content
-const query = Prisma.sql`SELECT id, name FROM "User" WHERE name = ?`
+query = Prisma.sql`SELECT id, name FROM "User" WHERE name = ?`
 
 // inputString can be untrusted input
 const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
@@ -645,8 +656,14 @@ console.log(result)
 The following example uses a PostgreSQL query and is safe ✅ from SQL Injection:
 
 ```ts
+// Version for Typescript
+const query: any
+
+// Version for Javascript
+const query
+
 // Safe if the text query below is completely trusted content
-const query = Prisma.sql`SELECT id, name FROM "User" WHERE name = $1`
+query = Prisma.sql`SELECT id, name FROM "User" WHERE name = $1`
 
 // inputString can be untrusted input
 const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
@@ -686,15 +703,17 @@ If you want to build your raw queries into one large string, this is still possi
 The following example is safe ✅ from SQL Injection as long as the query strings being passed to `Prisma.raw` only contain trusted content:
 
 ```ts
+// Version for Typescript
+const query: any
+
+// Version for Javascript
+const query
+
 // Example is safe if the text query below is completely trusted content
 const query1 = `SELECT id, name FROM "User" `
 const query2 = `WHERE name = $1 `
 
-// Version for Javascript
-const query = Prisma.raw(`${query1}${query2}`)
-
-// Version for Typescript
-const query: any = Prisma.raw(`${query1}${query2}`)
+query = Prisma.raw(`${query1}${query2}`)
 
 // inputString can be untrusted input
 const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -21,14 +21,16 @@ Raw queries are available for all relational databases Prisma ORM supports. In a
 
 ## Raw queries with relational databases
 
-For relational databases, Prisma Client exposes four methods that allow you to send raw queries. The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**. The other two methods are safe to use with a simple template tag, no string building, and no concatenation. However, caution is required for more complex use cases as it is still possible to introduce SQL injection if these methods are used in certain ways. For more details, see the [SQL Injection](#sql-injection) section below.
-
-You can use:
+For relational databases, Prisma Client exposes four methods that allow you to send raw queries. You can use:
 
 - `$queryRaw` to return actual records (for example, using `SELECT`).
 - `$executeRaw` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`).
 - `$queryRawUnsafe` to return actual records (for example, using `SELECT`) using a raw string.
 - `$executeRawUnsafe` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`) using a raw string.
+
+ The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**.
+ 
+ The other two methods are safe to use with a simple template tag, no string building, and no concatenation. **However**, caution is required for more complex use cases as it is still possible to introduce SQL injection if these methods are used in certain ways. For more details, see the [SQL injection prevention](#sql-injection-prevention) section below.
 
 > **Note**: All methods in the above list can only run **one** query at a time. You cannot append a second query - for example, calling any of them with `select 1; select 2;` will not work.
 
@@ -58,7 +60,7 @@ const result = await prisma.$queryRaw(
 
 <Admonition type="warning">
 
-If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion. For more information on this risk, see the [SQL Injection](#sql-injection) section below.
+If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion. The prefered mechanism would be to include the text of the query at the point that you run this method. For more information on this risk and also examples of how to prevent it, see the [SQL injection prevention](#sql-injection-prevention) section below.
 
 </Admonition>
 
@@ -184,7 +186,7 @@ The `$queryRawUnsafe` method allows you to pass a raw string (or template string
 
 If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
-Wherever possible you should use the `$queryRaw` query instead, taking into account that this method can also be made vulnerable in certain circumstances. For more information, see the [SQL Injection](#sql-injection) section below.
+Wherever possible you should use the `$queryRaw` method instead. When used correctly `$queryRaw` method is significantly safer but note that the `$queryRaw` method can also be made vulnerable in certain circumstances. For more information, see the [SQL injection prevention](#sql-injection-prevention) section below.
 
 </Admonition>
 
@@ -237,9 +239,7 @@ const result: number =
 
 <Admonition type="warning">
 
-If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
-
-For more information on this risk, see the [SQL Injection](#sql-injection) section below.
+If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion. The prefered mechanism would be to include the text of the query at the point that you run this method. For more information on this risk and also examples of how to prevent it, see the [SQL injection prevention](#sql-injection-prevention) section below.
 
 </Admonition>
 
@@ -299,7 +299,7 @@ The `$executeRawUnsafe` method allows you to pass a raw string (or template stri
 
 If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
-Wherever possible you should use the `$executeRaw` query instead, taking into account that this method can also be made vulnerable in certain circumstances. For more information, see the [SQL Injection](#sql-injection) section below.
+Wherever possible you should use the `$executeRaw` method instead. When used correctly `$executeRaw` method is significantly safer but note that the `$executeRaw` method can also be made vulnerable in certain circumstances. For more information, see the [SQL injection prevention](#sql-injection-prevention) section below.
 
 </Admonition>
 
@@ -522,7 +522,7 @@ The database will thus provide a `String` representation of your data which Pris
 
 For details of supported Prisma types, see the [Prisma connector overview](/orm/overview/databases) for the relevant database.
 
-## SQL injection
+## SQL injection prevention
 
 The ideal way to avoid SQL injection in Prisma Client is to use the ORM models to perform queries wherever possible.
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -629,31 +629,7 @@ const result = await prisma.$queryRaw(query)
 console.log(result)
 ```
 
-In these examples, the `sql` helper method is used to build the query text including a parameter marker for the input value. Each variable is represented by a marker symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL).
-
-The following example uses a MySQL query and is safe ✅ from SQL Injection:
-
-```ts
-// Version for Typescript
-const query: any
-
-// Version for Javascript
-const query
-
-// Safe if the text query below is completely trusted content
-query = Prisma.sql`SELECT id, name FROM "User" WHERE name = ?`
-
-// inputString can be untrusted input
-const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
-query.values = [inputString]
-
-const result = await prisma.$queryRaw(query)
-console.log(result)
-```
-
-> **Note**: MySQL variables are represented by `?`
-
-The following example uses a PostgreSQL query and is safe ✅ from SQL Injection:
+In this example which is safe ✅ from SQL Injection, the `sql` helper method is used to build the query text including a parameter marker for the input value. Each variable is represented by a marker symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL). Note that the examples just show PostgreSQL queries.
 
 ```ts
 // Version for Typescript
@@ -674,8 +650,6 @@ console.log(result)
 ```
 
 > **Note**: PostgreSQL variables are represented by `$1`, etc
-
-> **Note**: Subsequent examples will just use show PostgreSQL queries.
 
 ##### Building raw queries elsewhere or in stages
 
@@ -741,23 +715,9 @@ console.log(result)
 
 #### Parameterized queries
 
-As an alternative to tagged templates, `$queryRawUnsafe` supports standard parameterized queries where each variable is represented by a symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL).
+As an alternative to tagged templates, `$queryRawUnsafe` supports standard parameterized queries where each variable is represented by a symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL). Note that the examples just show PostgreSQL queries.
 
-The following example uses a MySQL query and is safe ✅ from SQL Injection:
-
-```ts
-const userName = 'Sarah'
-const email = 'sarah@prisma.io'
-const result = await prisma.$queryRawUnsafe(
-  'SELECT * FROM User WHERE (name = ? OR email = ?)',
-  userName,
-  email
-)
-```
-
-> **Note**: MySQL variables are represented by `?`
-
-The following example uses a PostgreSQL query and is safe ✅ from SQL Injection:
+The following example is safe ✅ from SQL Injection:
 
 ```ts
 const userName = 'Sarah'

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -660,14 +660,33 @@ console.log(result)
 
 > **Note**: Subsequent examples will just use show PostgreSQL queries.
 
-##### Building raw queries in stages
+##### Building raw queries elsewhere or in stages
 
-If you want to build your raw queries in stages, this is still possible but requires some care as it is uses the potentially dangerous `Prisma.raw` method.
+If you want to build your raw queries somewhere other than where the query is executed, the ideal way to do this is to create an `Sql` object from the segments of your query and pass it the parameter value.
 
-The following example is safe ✅ from SQL Injection as long as the variables being passed to `Prisma.raw` only contain trusted content:
+In the following example we have two variables to parameterize. The example is safe ✅ from SQL Injection as long as the query strings being passed to `Prisma.sql` only contain trusted content:
 
 ```ts
-// Safe if the text query below is completely trusted content
+// Example is safe if the text query below is completely trusted content
+const query1 = `SELECT id, name FROM "User" WHERE name = ` // The first parameter would be inserted after this string
+const query2 = ` OR name = ` // The second parameter would be inserted after this string
+
+const inputString1 = "Fred"
+const inputString2 = `'Sarah' UNION SELECT id, title FROM "Post"`
+
+const query = Prisma.sql([query1, query2, ""], inputString1, inputString2)
+const result = await prisma.$queryRaw(query);
+console.log(result);
+```
+
+> Note: Notice that the string array being passed as the first parameter `Prisma.sql` needs to have an empty string at the end as the `sql` function expects one more query segment than the number of parameters.
+
+If you want to build your raw queries into one large string, this is still possible but requires some care as it is uses the potentially dangerous `Prisma.raw` method. You also need to build your query using the correct parameter markers for your database as Prisma won't be able to provide markers for the relevant database as it usually is.
+
+The following example is safe ✅ from SQL Injection as long as the query strings being passed to `Prisma.raw` only contain trusted content:
+
+```ts
+// Example is safe if the text query below is completely trusted content
 const query1 = `SELECT id, name FROM "User" `
 const query2 = `WHERE name = $1 `
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -21,7 +21,7 @@ Raw queries are available for all relational databases Prisma ORM supports. In a
 
 ## Raw queries with relational databases
 
-For relational databases, Prisma Client exposes four methods that allow you to send raw queries. The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**. The other two methods are safer to use but with caution as it is **still very possible to introduce SQL injection** if these methods are used in certain ways. For more details, see the [SQL Injection](#sql-injection) section below.
+For relational databases, Prisma Client exposes four methods that allow you to send raw queries. The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**. The other two methods are safe to use with a simple template tag, no string building and no concatenation. However, caution is required for more complex use cases as it is **still very possible to introduce SQL injection** if these methods are used in certain ways. For more details, see the [SQL Injection](#sql-injection) section below.
 
 You can use:
 
@@ -58,7 +58,7 @@ const result = await prisma.$queryRaw(
 
 <Admonition type="warning">
 
-If you incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
+If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
 For more information on this risk, see the [SQL Injection](#sql-injection) section below.
 
@@ -239,7 +239,7 @@ const result: number =
 
 <Admonition type="warning">
 
-If you incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
+If you use string building to incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
 For more information on this risk, see the [SQL Injection](#sql-injection) section below.
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -21,14 +21,14 @@ Raw queries are available for all relational databases Prisma ORM supports. In a
 
 ## Raw queries with relational databases
 
-For relational databases, Prisma Client exposes four methods that allow you to send raw queries. The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**. The other two methods are safe to use with a simple template tag, no string building and no concatenation. However, caution is required for more complex use cases as it is **still very possible to introduce SQL injection** if these methods are used in certain ways. For more details, see the [SQL Injection](#sql-injection) section below.
+For relational databases, Prisma Client exposes four methods that allow you to send raw queries. The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**. The other two methods are safe to use with a simple template tag, no string building, and no concatenation. However, caution is required for more complex use cases as it is still possible to introduce SQL injection if these methods are used in certain ways. For more details, see the [SQL Injection](#sql-injection) section below.
 
 You can use:
 
-- `$queryRaw` to return actual records (for example, using `SELECT`). **Potential risk of SQL injection**
-- `$executeRaw` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`). **Potential risk of SQL injection**
-- `$queryRawUnsafe` to return actual records (for example, using `SELECT`) using a raw string. **High risk of SQL injection**
-- `$executeRawUnsafe` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`) using a raw string. **High risk of SQL injection**
+- `$queryRaw` to return actual records (for example, using `SELECT`).
+- `$executeRaw` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`).
+- `$queryRawUnsafe` to return actual records (for example, using `SELECT`) using a raw string.
+- `$executeRawUnsafe` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`) using a raw string.
 
 > **Note**: All methods in the above list can only run **one** query at a time. You cannot append a second query - for example, calling any of them with `select 1; select 2;` will not work.
 
@@ -326,7 +326,7 @@ const result = prisma.$executeRawUnsafe(
 )
 ```
 
-For more details on using parameterised queries, see the [parameterized queries](#parameterized-queries) section below.
+For more details on using parameterized queries, see the [parameterized queries](#parameterized-queries) section below.
 
 #### Signature
 
@@ -528,7 +528,7 @@ For details of supported Prisma types, see the [Prisma connector overview](/orm/
 
 The ideal way to avoid SQL injection in Prisma Client is to use the ORM models to perform queries wherever possible.
 
-Where this is not possible and raw queries are required, Prisma Client provides various raw methods but it is important to use these methods safely.
+Where this is not possible and raw queries are required, Prisma Client provides various raw methods, but it is important to use these methods safely.
 
 This section will provide various examples of using these methods safely and unsafely. You can test these examples in the [Prisma Playground](https://playground.prisma.io/examples).
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -208,7 +208,9 @@ $queryRawUnsafe<T = unknown>(query: string, ...values: any[]): PrismaPromise<T>;
 
 #### Parameterized queries
 
-As an alternative to tagged templates, `$queryRawUnsafe` supports standard parameterized queries where each variable is represented by a symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL). The following example uses a MySQL query:
+As an alternative to tagged templates, `$queryRawUnsafe` supports standard parameterized queries where each variable is represented by a symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL).
+
+The following example uses a MySQL query and is safe ✅ from SQL Injection:
 
 ```ts
 const userName = 'Sarah'
@@ -222,7 +224,7 @@ const result = await prisma.$queryRawUnsafe(
 
 > **Note**: MySQL variables are represented by `?`
 
-The following example uses a PostgreSQL query:
+The following example uses a PostgreSQL query and is safe ✅ from SQL Injection:
 
 ```ts
 const userName = 'Sarah'
@@ -236,13 +238,13 @@ const result = await prisma.$queryRawUnsafe(
 
 > **Note**: PostgreSQL variables are represented by `$1` and `$2`
 
-As with tagged templates, Prisma Client escapes all variables.
+As with tagged templates, Prisma Client escapes all variables when they are provided in this way.
 
 > **Note**: You cannot pass a table or column name as a variable into a parameterized query. For example, you cannot `SELECT ?` and pass in `*` or `id, name` based on some condition.
 
 ##### Parameterized PostgreSQL `ILIKE` query
 
-When you use `ILIKE`, the `%` wildcard character(s) should be included in the variable itself, not the query (`string`):
+When you use `ILIKE`, the `%` wildcard character(s) should be included in the variable itself, not the query (`string`). This example is safe ✅ from SQL Injection.
 
 ```ts
 const userName = 'Sarah'

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -28,9 +28,9 @@ For relational databases, Prisma Client exposes four methods that allow you to s
 - `$queryRawUnsafe` to return actual records (for example, using `SELECT`) using a raw string.
 - `$executeRawUnsafe` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`) using a raw string.
 
- The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**.
+The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**.
  
- The other two methods are safe to use with a simple template tag, no string building, and no concatenation. **However**, caution is required for more complex use cases as it is still possible to introduce SQL injection if these methods are used in certain ways. For more details, see the [SQL injection prevention](#sql-injection-prevention) section below.
+The other two methods are safe to use with a simple template tag, no string building, and no concatenation. **However**, caution is required for more complex use cases as it is still possible to introduce SQL injection if these methods are used in certain ways. For more details, see the [SQL injection prevention](#sql-injection-prevention) section below.
 
 > **Note**: All methods in the above list can only run **one** query at a time. You cannot append a second query - for example, calling any of them with `select 1; select 2;` will not work.
 
@@ -210,7 +210,7 @@ prisma.$queryRawUnsafe(
 
 > **Note**: Prisma sends JavaScript integers to PostgreSQL as `INT8`. This might conflict with your user-defined functions that accept only `INT4` as input. If you use a parameterized `$queryRawUnsafe` query in conjunction with a PostgreSQL database, update the input types to `INT8`, or cast your query parameters to `INT4`.
 
-For more details on using parameterised queries, see the [parameterized queries](#parameterized-queries) section below.
+For more details on using parameterized queries, see the [parameterized queries](#parameterized-queries) section below.
 
 #### Signature
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -21,12 +21,14 @@ Raw queries are available for all relational databases Prisma ORM supports. In a
 
 ## Raw queries with relational databases
 
-For relational databases, Prisma Client exposes four methods that allow you to send raw queries. You can use:
+For relational databases, Prisma Client exposes four methods that allow you to send raw queries. The methods with "Unsafe" in the name are a lot more flexible but are at **significant risk of making your code vulnerable to SQL injection**. The other two methods are safer to use but with caution as it is **still very possible to introduce SQL injection** if these methods are used in certain ways. For more details, see the [SQL Injection](#sql-injection) section below.
 
-- `$queryRaw` to return actual records (for example, using `SELECT`)
-- `$executeRaw` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`)
-- `$queryRawUnsafe` to return actual records (for example, using `SELECT`) using a raw string. **Potential SQL injection risk**
-- `$executeRawUnsafe` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`) using a raw string. **Potential SQL injection risk**
+You can use:
+
+- `$queryRaw` to return actual records (for example, using `SELECT`). **Potential risk of SQL injection**
+- `$executeRaw` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`). **Potential risk of SQL injection**
+- `$queryRawUnsafe` to return actual records (for example, using `SELECT`) using a raw string. **High risk of SQL injection**
+- `$executeRawUnsafe` to return a count of affected rows (for example, after an `UPDATE` or `DELETE`) using a raw string. **High risk of SQL injection**
 
 > **Note**: All methods in the above list can only run **one** query at a time. You cannot append a second query - for example, calling any of them with `select 1; select 2;` will not work.
 
@@ -53,6 +55,14 @@ const result = await prisma.$queryRaw(
   Prisma.sql`SELECT * FROM User WHERE email = ${email}`
 )
 ```
+
+<Admonition type="warning">
+
+If you incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
+
+For more information on this risk, see the [SQL Injection](#sql-injection) section below.
+
+</Admonition>
 
 #### Considerations
 
@@ -176,7 +186,7 @@ The `$queryRawUnsafe` method allows you to pass a raw string (or template string
 
 If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
-We strongly advise that you use the `$queryRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
+Wherever possible you should use the `$queryRaw` query instead, taking into account that this method can also be made vulnerable in certain circumstances. For more information, see the [SQL Injection](#sql-injection) section below.
 
 </Admonition>
 
@@ -200,63 +210,13 @@ prisma.$queryRawUnsafe(
 
 > **Note**: Prisma sends JavaScript integers to PostgreSQL as `INT8`. This might conflict with your user-defined functions that accept only `INT4` as input. If you use a parameterized `$queryRawUnsafe` query in conjunction with a PostgreSQL database, update the input types to `INT8`, or cast your query parameters to `INT4`.
 
+For more details on using parameterised queries, see the [parameterized queries](#parameterized-queries) section below.
+
 #### Signature
 
 ```ts no-lines
 $queryRawUnsafe<T = unknown>(query: string, ...values: any[]): PrismaPromise<T>;
 ```
-
-#### Parameterized queries
-
-As an alternative to tagged templates, `$queryRawUnsafe` supports standard parameterized queries where each variable is represented by a symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL).
-
-The following example uses a MySQL query and is safe ✅ from SQL Injection:
-
-```ts
-const userName = 'Sarah'
-const email = 'sarah@prisma.io'
-const result = await prisma.$queryRawUnsafe(
-  'SELECT * FROM User WHERE (name = ? OR email = ?)',
-  userName,
-  email
-)
-```
-
-> **Note**: MySQL variables are represented by `?`
-
-The following example uses a PostgreSQL query and is safe ✅ from SQL Injection:
-
-```ts
-const userName = 'Sarah'
-const email = 'sarah@prisma.io'
-const result = await prisma.$queryRawUnsafe(
-  'SELECT * FROM User WHERE (name = $1 OR email = $2)',
-  userName,
-  email
-)
-```
-
-> **Note**: PostgreSQL variables are represented by `$1` and `$2`
-
-As with tagged templates, Prisma Client escapes all variables when they are provided in this way.
-
-> **Note**: You cannot pass a table or column name as a variable into a parameterized query. For example, you cannot `SELECT ?` and pass in `*` or `id, name` based on some condition.
-
-##### Parameterized PostgreSQL `ILIKE` query
-
-When you use `ILIKE`, the `%` wildcard character(s) should be included in the variable itself, not the query (`string`). This example is safe ✅ from SQL Injection.
-
-```ts
-const userName = 'Sarah'
-const emailFragment = 'prisma.io'
-const result = await prisma.$queryRawUnsafe(
-  'SELECT * FROM "User" WHERE (name = $1 OR email ILIKE $2)',
-  userName,
-  `%${emailFragment}`
-)
-```
-
-> **Note**: Using `%$2` as an argument would not work
 
 ### <inlinecode>$executeRaw</inlinecode>
 
@@ -276,6 +236,16 @@ const active = true
 const result: number =
   await prisma.$executeRaw`UPDATE User SET active = ${active} WHERE emailValidated = ${emailValidated};`
 ```
+
+<Admonition type="warning">
+
+If you incorporate untrusted input into queries passed to this method, then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
+
+For more information on this risk, see the [SQL Injection](#sql-injection) section below.
+
+</Admonition>
+
+#### Considerations
 
 Be aware that:
 
@@ -331,7 +301,7 @@ The `$executeRawUnsafe` method allows you to pass a raw string (or template stri
 
 If you use this method with user inputs (in other words, `SELECT * FROM table WHERE columnx = ${userInput}`), then you open up the possibility for SQL injection attacks. SQL injection attacks can expose your data to modification or deletion.<br /><br />
 
-We strongly advise that you use the `$executeRaw` query instead. For more information on SQL injection attacks, see the [OWASP SQL Injection guide](https://www.owasp.org/index.php/SQL_Injection).
+Wherever possible you should use the `$executeRaw` query instead, taking into account that this method can also be made vulnerable in certain circumstances. For more information, see the [SQL Injection](#sql-injection) section below.
 
 </Admonition>
 
@@ -355,6 +325,8 @@ const result = prisma.$executeRawUnsafe(
   true
 )
 ```
+
+For more details on using parameterised queries, see the [parameterized queries](#parameterized-queries) section below.
 
 #### Signature
 
@@ -552,20 +524,167 @@ The database will thus provide a `String` representation of your data which Pris
 
 For details of supported Prisma types, see the [Prisma connector overview](/orm/overview/databases) for the relevant database.
 
-### SQL injection
+## SQL injection
 
-Prisma Client mitigates the risk of SQL injection in the following ways:
+The ideal way to avoid SQL injection in Prisma Client is to use the ORM models to perform queries wherever possible.
 
-- Prisma Client escapes all variables when you use tagged templates and sends all queries as prepared statements.
+Where this is not possible and raw queries are required, Prisma Client provides various raw methods but it is important to use these methods safely.
 
-  ```ts
-  $queryRaw`...` // Tagged template
-  $executeRaw`...` // Tagged template
-  ```
+This section will provide various examples of using these methods safely and unsafely. You can test these examples in the [Prisma Playground](https://playground.prisma.io/examples).
 
-If you cannot use tagged templates, you can instead use [`$queryRawUnsafe`](/orm/prisma-client/queries/raw-database-access/raw-queries#queryrawunsafe) or [`$executeRawUnsafe`](/orm/prisma-client/queries/raw-database-access/raw-queries#executerawunsafe) but **be aware that your code may be vulnerable to SQL injection**.
+### In <inlinecode>$queryRaw</inlinecode> and <inlinecode>$executeRaw</inlinecode>
 
-#### ⚠️ String concatenation
+#### Simple, safe use of <inlinecode>$queryRaw</inlinecode> and <inlinecode>$executeRaw</inlinecode>
+
+These methods can mitigate the risk of SQL injection by escaping all variables when you use tagged templates and sends all queries as prepared statements.
+
+```ts
+$queryRaw`...` // Tagged template
+$executeRaw`...` // Tagged template
+```
+
+The following example is safe ✅ from SQL Injection:
+
+```ts
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+const result =
+  await prisma.$queryRaw`SELECT id, name FROM "User" WHERE name = ${inputString}`
+
+console.log(result)
+```
+
+#### Unsafe use of <inlinecode>$queryRaw</inlinecode> and <inlinecode>$executeRaw</inlinecode>
+
+However, it is also possible to use these methods in unsafe ways.
+
+One way is by generating a tagged template that unsafely concatenates user input.
+
+The following example is vulnerable ❌ to SQL Injection:
+
+```ts
+//Unsafely generate query text
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"` // SQL Injection
+const query = `SELECT id, name FROM "User" WHERE name = ${inputString}`
+
+// Make into a tagged template
+const stringsArray = [...[query]]
+stringsArray.raw = [query]
+
+// Use queryRaw
+const result = await prisma.$queryRaw(stringsArray)
+console.log(result)
+```
+
+Another way to make these methods vulnerable is misuse of the `Prisma.raw` function.
+
+The following examples are all vulnerable ❌ to SQL Injection:
+
+```ts
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+const result =
+  await prisma.$queryRaw`SELECT id, name FROM "User" WHERE name = ${Prisma.raw(
+    inputString
+  )}`
+console.log(result)
+```
+
+```ts
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+const result = await prisma.$queryRaw(
+  Prisma.raw(`SELECT id, name FROM "User" WHERE name = ${inputString}`)
+)
+console.log(result)
+```
+
+```ts
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+const query = Prisma.raw(
+  `SELECT id, name FROM "User" WHERE name = ${inputString}`
+)
+const result = await prisma.$queryRaw(query)
+console.log(result)
+```
+
+#### Safely using <inlinecode>$queryRaw</inlinecode> and <inlinecode>$executeRaw</inlinecode> in more complex scenarios
+
+##### Building raw queries separate to query execution
+
+If you want to build your raw queries elsewhere or separate to your parameters you will need to use one of the following methods.
+
+In this example, the `sql` helper method is used to build the query text by safely including the variable. It is safe ✅ from SQL Injection:
+
+```ts
+// inputString can be untrusted input
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+
+// Safe if the text query below is completely trusted content
+const query = Prisma.sql`SELECT id, name FROM "User" WHERE name = ${inputString}`
+
+const result = await prisma.$queryRaw(query)
+console.log(result)
+```
+
+In these examples, the `sql` helper method is used to build the query text including a parameter marker for the input value. Each variable is represented by a marker symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL).
+
+The following example uses a MySQL query and is safe ✅ from SQL Injection:
+
+```ts
+// Safe if the text query below is completely trusted content
+const query = Prisma.sql`SELECT id, name FROM "User" WHERE name = $1`
+
+// inputString can be untrusted input
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+query.values = [inputString]
+
+const result = await prisma.$queryRaw(query)
+console.log(result)
+```
+
+> **Note**: MySQL variables are represented by `?`
+
+The following example uses a PostgreSQL query and is safe ✅ from SQL Injection:
+
+```ts
+// Safe if the text query below is completely trusted content
+const query = Prisma.sql`SELECT id, name FROM "User" WHERE name = $1`
+
+// inputString can be untrusted input
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+query.values = [inputString]
+
+const result = await prisma.$queryRaw(query)
+console.log(result)
+```
+
+> **Note**: PostgreSQL variables are represented by `$1`, etc
+
+> **Note**: Subsequent examples will just use show PostgreSQL queries.
+
+##### Building raw queries in stages
+
+If you want to build your raw queries in stages, this is still possible but requires some care as it is uses the potentially dangerous `Prisma.raw` method.
+
+The following example is safe ✅ from SQL Injection as long as the variables being passed to `Prisma.raw` only contain trusted content:
+
+```ts
+// Safe if the text query below is completely trusted content
+const query1 = `SELECT id, name FROM "User" `
+const query2 = `WHERE name = $1 `
+const query = Prisma.raw(`${query1}${query2}`)
+
+// inputString can be untrusted input
+const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`
+query.values = [inputString]
+
+const result = await prisma.$queryRaw(query)
+console.log(result)
+```
+
+### The "Unsafe" methods
+
+#### Using <inlinecode>$queryRawUnsafe</inlinecode> and <inlinecode>$executeRawUnsafe</inlinecode> unsafely
+
+If you cannot use tagged templates, you can instead use [`$queryRawUnsafe`](/orm/prisma-client/queries/raw-database-access/raw-queries#queryrawunsafe) or [`$executeRawUnsafe`](/orm/prisma-client/queries/raw-database-access/raw-queries#executerawunsafe) but **be aware that your these functions make it much more likely that your code will be vulnerable to SQL injection**.
 
 The following example concatenates `query` and `inputString`. Prisma Client ❌ **cannot** escape `inputString` in this example, which makes it vulnerable to SQL injection:
 
@@ -576,6 +695,58 @@ const result = await prisma.$queryRawUnsafe(query)
 
 console.log(result)
 ```
+
+#### Parameterized queries
+
+As an alternative to tagged templates, `$queryRawUnsafe` supports standard parameterized queries where each variable is represented by a symbol (`?` for mySQL, `$1`, `$2`, and so on for PostgreSQL).
+
+The following example uses a MySQL query and is safe ✅ from SQL Injection:
+
+```ts
+const userName = 'Sarah'
+const email = 'sarah@prisma.io'
+const result = await prisma.$queryRawUnsafe(
+  'SELECT * FROM User WHERE (name = ? OR email = ?)',
+  userName,
+  email
+)
+```
+
+> **Note**: MySQL variables are represented by `?`
+
+The following example uses a PostgreSQL query and is safe ✅ from SQL Injection:
+
+```ts
+const userName = 'Sarah'
+const email = 'sarah@prisma.io'
+const result = await prisma.$queryRawUnsafe(
+  'SELECT * FROM User WHERE (name = $1 OR email = $2)',
+  userName,
+  email
+)
+```
+
+> **Note**: PostgreSQL variables are represented by `$1` and `$2`
+
+As with tagged templates, Prisma Client escapes all variables when they are provided in this way.
+
+> **Note**: You cannot pass a table or column name as a variable into a parameterized query. For example, you cannot `SELECT ?` and pass in `*` or `id, name` based on some condition.
+
+##### Parameterized PostgreSQL `ILIKE` query
+
+When you use `ILIKE`, the `%` wildcard character(s) should be included in the variable itself, not the query (`string`). This example is safe ✅ from SQL Injection.
+
+```ts
+const userName = 'Sarah'
+const emailFragment = 'prisma.io'
+const result = await prisma.$queryRawUnsafe(
+  'SELECT * FROM "User" WHERE (name = $1 OR email ILIKE $2)',
+  userName,
+  `%${emailFragment}`
+)
+```
+
+> **Note**: Using `%$2` as an argument would not work
 
 ## Raw queries with MongoDB
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -670,7 +670,12 @@ The following example is safe ✅ from SQL Injection as long as the variables be
 // Safe if the text query below is completely trusted content
 const query1 = `SELECT id, name FROM "User" `
 const query2 = `WHERE name = $1 `
+
+// Version for Javascript
 const query = Prisma.raw(`${query1}${query2}`)
+
+// Version for Typescript
+const query: any = Prisma.raw(`${query1}${query2}`)
 
 // inputString can be untrusted input
 const inputString = `'Sarah' UNION SELECT id, title FROM "Post"`


### PR DESCRIPTION
## Describe this PR

See discussion here;
https://discord.com/channels/937751382725886062/1218200207884288071

Basically, the docs make it seem like `queryRaw` and `executeRaw` are safe from SQL injection when it fact is possible to use them unsafely as well.

I have prepared an update to the documentation to reflect this.

## Changes

* I have moved the "parameterized queries" section into the "SQL Injection" section (only minor changes which you can see in this specific commit: https://github.com/prisma/docs/commit/8575fc5403f1c14d1b49fb17ccb51789da422240
* I have made SQL injection a top level section so that I can include navigation within it
* I have provided example of how `queryRaw` and `executeRaw` are used safely in a simple case.
* I have provided examples of how `queryRaw` and `executeRaw` can also be used unsafely.
* I have provided examples of how `queryRaw` and `executeRaw` can be used safely in more complicated cases as well.

## What issue does this fix?

N/A

## Any other relevant information

I deliberately tried to make all examples compatible with the Prisma playground so you can verify them.
