### PR TITLE
docs: add limitation on pulse type generation

### DIFF
--- a/content/400-pulse/500-known-limitations.mdx
+++ b/content/400-pulse/500-known-limitations.mdx
@@ -34,3 +34,29 @@ Prisma Pulse subscriptions cannot be initiated directly within client-side code.
 ## Limited to Postgres versions 12 or higher
 
 Prisma Pulse is currently supported with Postgres versions 12 or higher. It should work with most Postgres providers that expose Postgres’ native logical replication feature.
+
+## Subscription type limitation with custom publication slots
+
+Our advanced onboarding flow enables you to provide a [custom publication slot](/pulse/database-setup/general-database-instructions#manage-your-own-publication-slot). Should that custom publication slot only contains a subset of your database tables, the Prisma Client generated with the Pulse Client Extension will continue to permit subscriptions to all models based on the entirety of your Prisma Schema definitions.
+
+For example, if you have two models in your schema, the `User` and `Post` model. And you opt to create a publication to monitor changes in the `User` model exclusively:
+
+```sql
+CREATE PUBLICATION user_publication FOR TABLE users;
+```
+
+> To learn more about creating custom publication slots, see [managing your publication slot](https://www.prisma.io/docs/pulse/database-setup/general-database-instructions#manage-your-own-publication-slot).
+
+Your resulting subscription code would be:
+
+```ts
+const userSubscription = prisma.user.subscribe()
+```
+
+However, despite the absence of publication coverage, the generated Prisma client permits subscriptions for all models, such as the `Post` model:
+
+```ts
+const postSubscription = prisma.post.subscribe()
+```
+
+> We are actively working on enhancing type generation for custom publications as part of our ongoing efforts to further refine Prisma Pulse.


### PR DESCRIPTION
If a user provides a custom publication slot, the generated client will still allow them to create a subscription to a model that is not included in their publication.