### PR TITLE
fix: add missing "`" in 400-mysql.mdx

### DIFF
--- a/content/200-orm/050-overview/500-databases/400-mysql.mdx
+++ b/content/200-orm/050-overview/500-databases/400-mysql.mdx
@@ -150,7 +150,7 @@ The MySQL connector maps the [scalar types](/orm/prisma-schema/data-model/models
 | `Float`    | `DOUBLE`         |                                                    |
 | `Decimal`  | `DECIMAL(65,30)` |                                                    |
 | `DateTime` | `DATETIME(3)`    |                                                    |
-| `Json`     | `LONGTEXT        | See https://mariadb.com/kb/en/json-data-type/      |
+| `Json`     | `LONGTEXT`       | See https://mariadb.com/kb/en/json-data-type/      |
 | `Bytes`    | `LONGBLOB`       |                                                    |
 
 ### Native type mappings


### PR DESCRIPTION
## Describe this PR

Add the missing "`" to fix markdown syntax.

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

Added "`"

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

![image](https://github.com/prisma/docs/assets/11341955/9c95f678-ca8b-45fb-9030-68743e79588d)

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
