### PR TITLE
Update instances of createMany() not supported by SQLite

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/030-crud.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/030-crud.mdx
@@ -260,7 +260,7 @@ const createMany = await prisma.user.createMany({
 
 <Admonition type="warning">
 
-Note `skipDuplicates` is not supported when using MongoDB or SQLServer.
+Note `skipDuplicates` is not supported when using MongoDB, SQLServer, or SQLite.
 
 </Admonition>
 

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -1231,6 +1231,7 @@ const deleteUser = await prisma.user.delete({
 
 #### Remarks
 
+- As of Prisma ORM version 5.12.0, `createMany` is now supported by SQLite.
 - The `skipDuplicates` option is not supported by MongoDB and SQLServer.
 - You **cannot** create or connect relations - you cannot nest `create`, `createMany`, `connect`, `connectOrCreate` inside a top-level `createMany`
 - You can nest a [`createMany`](#createmany-1) inside an `update` or `create` query - for example, add a `User` and two `Post` records at the same time.
@@ -2778,6 +2779,7 @@ A nested `createMany` query adds a new set of records to a parent record. See: [
 - **Not** available in the context of a many-to-many relation — for example, you **cannot** `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
 - Does not support nesting additional relations — you cannot nest an additional `create` or `createMany`.
 - Allows setting foreign keys directly — for example, setting the `categoryId` on a post.
+- As of Prisma ORM version 5.12.0, nested `createMany` is now supported by SQLite.
 
 > You can use a nested `create` _or_ a nested `createMany` to create multiple related records - [each technique pros and cons](/orm/prisma-client/queries/relation-queries#create-a-single-record-and-multiple-related-records) .
 

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -1232,7 +1232,7 @@ const deleteUser = await prisma.user.delete({
 #### Remarks
 
 - As of Prisma ORM version 5.12.0, `createMany` is now supported by SQLite.
-- The `skipDuplicates` option is not supported by MongoDB and SQLServer.
+- The `skipDuplicates` option is not supported by MongoDB, SQLServer, or SQLite.
 - You **cannot** create or connect relations - you cannot nest `create`, `createMany`, `connect`, `connectOrCreate` inside a top-level `createMany`
 - You can nest a [`createMany`](#createmany-1) inside an `update` or `create` query - for example, add a `User` and two `Post` records at the same time.
 

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -1231,7 +1231,6 @@ const deleteUser = await prisma.user.delete({
 
 #### Remarks
 
-- `createMany` is not supported by SQLite.
 - The `skipDuplicates` option is not supported by MongoDB and SQLServer.
 - You **cannot** create or connect relations - you cannot nest `create`, `createMany`, `connect`, `connectOrCreate` inside a top-level `createMany`
 - You can nest a [`createMany`](#createmany-1) inside an `update` or `create` query - for example, add a `User` and two `Post` records at the same time.

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -2778,7 +2778,6 @@ A nested `createMany` query adds a new set of records to a parent record. See: [
 - **Not** available in the context of a many-to-many relation — for example, you **cannot** `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
 - Does not support nesting additional relations — you cannot nest an additional `create` or `createMany`.
 - Allows setting foreign keys directly — for example, setting the `categoryId` on a post.
-- Nested `createMany` is not supported by SQLite.
 
 > You can use a nested `create` _or_ a nested `createMany` to create multiple related records - [each technique pros and cons](/orm/prisma-client/queries/relation-queries#create-a-single-record-and-multiple-related-records) .
 


### PR DESCRIPTION
Fixes #5747:
Update instances where: 
- [ ]  `createMany()` not supported by SQLite
- [ ]  nested `createMany` not supported
- [ ]  bulk-insert optimization for nested `create` not supported for SQLite