### PR TITLE
Docusaurus: fix:DA-163 toc badge size

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1000,7 +1000,7 @@ hr {
 .preview-badge ::after{
   position: absolute;
   right: 0px;
-  font-size: 0.875rem;
+  font-size: 12px;
   font-style: normal;
   font-weight: 600;
   color: var(--badge-color);


### PR DESCRIPTION
Fixes [#DA-163](https://linear.app/prisma-company/issue/DA-163/different-font-size-on-toc-labelbadge)