### PR TITLE
Docusaurus: fix:DA-167 remove last breadcrumb

### DIFF
--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -10,15 +10,8 @@ import {translate} from '@docusaurus/Translate';
 import HomeBreadcrumbItem from '@theme/DocBreadcrumbs/Items/Home';
 import styles from './styles.module.css';
 // TODO move to design system folder
-function BreadcrumbsItemLink({children, href, isLast}) {
+function BreadcrumbsItemLink({children, href}) {
   const className = 'breadcrumbs__link';
-  if (isLast) {
-    return (
-      <span className={className} itemProp="name">
-        {children}
-      </span>
-    );
-  }
   return href ? (
     <Link className={className} href={href} itemProp="item">
       <span itemProp="name">{children}</span>
@@ -84,13 +77,13 @@ export default function DocBreadcrumbs() {
             item.type === 'category' && item.linkUnlisted
               ? undefined
               : item.href;
-          return (
+          return ( !isLast && 
             <BreadcrumbsItem
               key={idx}
               active={isLast}
               index={idx}
               addMicrodata={!!href}>
-              <BreadcrumbsItemLink href={href} isLast={isLast}>
+              <BreadcrumbsItemLink href={href}>
                 {item.label}
               </BreadcrumbsItemLink>
             </BreadcrumbsItem>

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -66,7 +66,7 @@ export default function DocBreadcrumbs() {
         message: 'Breadcrumbs',
         description: 'The ARIA label for the breadcrumbs',
       })}>
-      {repeatedBreadcrumbs() && <ul
+      {repeatedBreadcrumbs() && breadcrumbs.length > 1 && <ul
         className="breadcrumbs"
         itemScope
         itemType="https://schema.org/BreadcrumbList">


### PR DESCRIPTION
Fixes [#DA-167](https://linear.app/prisma-company/issue/DA-167/breadcrumbs-should-not-include-the-current-page)