### PR TITLE
added specfic title to index of docs

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -207,7 +207,7 @@ export default function Home(): JSX.Element {
   } = useDocusaurusContext();
   return (
     <Layout
-      title={title}
+      title="Prisma ORM, Accelerate, Pulse & More"
       description="Get started with Prisma in the official documentation, and learn more about all Prisma's features with reference documentation, guides, and more."
     >
       <Head>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -206,10 +206,7 @@ export default function Home(): JSX.Element {
     siteConfig: { title },
   } = useDocusaurusContext();
   return (
-    <Layout
-      title="Prisma ORM, Accelerate, Pulse & More"
-      description="Get started with Prisma in the official documentation, and learn more about all Prisma's features with reference documentation, guides, and more."
-    >
+    <Layout description="Get started with Prisma in the official documentation, and learn more about all Prisma's features with reference documentation, guides, and more.">
       <Head>
         <link rel="canonical" href="https://www.prisma.io/docs" />
       </Head>


### PR DESCRIPTION
Hard coded the title tag inside of layout. The `| Prisma Documentation` That follows it is default for all pages. So all you need to change here is the first part if you want. 