### PR TITLE
improve prisma migrate code snippet

### DIFF
--- a/content/200-orm/300-prisma-migrate/050-getting-started.mdx
+++ b/content/200-orm/300-prisma-migrate/050-getting-started.mdx
@@ -209,18 +209,18 @@ To include [unsupported database features](/orm/prisma-migrate/workflows/unsuppo
 
 1. Modify the generated SQL. For example:
 
-   - If the changes are minor, you can append additional custom SQL to the generated migration - the following example creates a partial index:
+  - If the changes are minor, you can append additional custom SQL to the generated migration - the following example creates a partial index:
 
-   ```sql highlight=3,4;add
-   /* Generated migration SQL */
+    ```sql
+    /* Generated migration SQL */
 
-   // add-start
-   CREATE UNIQUE INDEX tests_success_constraint ON posts (subject, target)
-     WHERE success;
-   // add-end
-   ```
+    --add-start
+    CREATE UNIQUE INDEX tests_success_constraint ON posts (subject, target)
+      WHERE success;
+    --add-end
+    ```
 
-   - If the changes are significant, it can be easier to replace the entire migration file with the result of a database dump ([`mysqldump`](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html), [`pg_dump`](https://www.postgresql.org/docs/12/app-pgdump.html))
+  - If the changes are significant, it can be easier to replace the entire migration file with the result of a database dump ([`mysqldump`](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html), [`pg_dump`](https://www.postgresql.org/docs/12/app-pgdump.html))
 
 <Admonition type="info">
   Note that the order of the tables matters when creating all of them at once,

--- a/content/200-orm/300-prisma-migrate/050-getting-started.mdx
+++ b/content/200-orm/300-prisma-migrate/050-getting-started.mdx
@@ -214,10 +214,10 @@ To include [unsupported database features](/orm/prisma-migrate/workflows/unsuppo
    ```sql highlight=3,4;add
    /* Generated migration SQL */
 
-   //add-start
+   // add-start
    CREATE UNIQUE INDEX tests_success_constraint ON posts (subject, target)
-    WHERE success;
-  //add-end
+     WHERE success;
+   // add-end
    ```
 
    - If the changes are significant, it can be easier to replace the entire migration file with the result of a database dump ([`mysqldump`](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html), [`pg_dump`](https://www.postgresql.org/docs/12/app-pgdump.html))


### PR DESCRIPTION
## Summary
Fix broken code snippet example under `Prisma Migrate` > `Getting Started`

**Link**
https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language

The invalid `//add-start` and `//add-end` placeholders are breaking the markdown rendering. See screenshot for example.

## Screenshot
|Before|
|---|
|<img width="1471" alt="image" src="https://github.com/prisma/docs/assets/7817695/9ed0d7ff-d59e-4afd-840f-d0a0a98c23cc">|
