### PR TITLE
fix: relation load strategie version number

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/037-relation-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/037-relation-queries.mdx
@@ -26,7 +26,7 @@ Nested reads allow you to read related data from multiple tables in your databas
 
 ### Relation load strategies (Preview)
 
-Since version [5.9.0](https://github.com/prisma/prisma/releases/tag/5.9.0), you can decide on a per-query-level _how_ you want Prisma Client to execute a relation query (i.e. what _load strategy_ should be applied) via the `relationLoadStrategy` option.
+Since version [5.10.0](https://github.com/prisma/prisma/releases/tag/5.10.0), you can decide on a per-query-level _how_ you want Prisma Client to execute a relation query (i.e. what _load strategy_ should be applied) via the `relationLoadStrategy` option.
 
 Because the `relationLoadStrategy` option is currently in Preview, you need to enable it via the `relationJoins` preview feature flag in your Prisma schema file:
 

--- a/content/200-orm/200-prisma-client/100-queries/037-relation-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/037-relation-queries.mdx
@@ -26,7 +26,9 @@ Nested reads allow you to read related data from multiple tables in your databas
 
 ### Relation load strategies (Preview)
 
-Since version [5.10.0](https://github.com/prisma/prisma/releases/tag/5.10.0), you can decide on a per-query-level _how_ you want Prisma Client to execute a relation query (i.e. what _load strategy_ should be applied) via the `relationLoadStrategy` option.
+Since version [5.8.0](https://github.com/prisma/prisma/releases/tag/5.8.0), you can decide on a per-query-level _how_ you want Prisma Client to execute a relation query (i.e. what _load strategy_ should be applied) via the `relationLoadStrategy` option for PostgreSQL databases.
+
+Since version [5.10.0](https://github.com/prisma/prisma/releases/tag/5.10.0), this feature is also available for MySQL.
 
 Because the `relationLoadStrategy` option is currently in Preview, you need to enable it via the `relationJoins` preview feature flag in your Prisma schema file:
 


### PR DESCRIPTION
Looks like it should be the release version [5.10.0](https://github.com/prisma/prisma/releases/tag/5.10.0) 