### PR TITLE
Update 050-prisma-client-reference.mdx

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -1293,7 +1293,7 @@ const updatedUserCount = await prisma.user.updateMany({
 ##### Update all `User` records where the `email` contains `prisma.io` and at least one related `Post` has more than 10 likes
 
 ```ts
-const deleteUser = await prisma.user.updateMany({
+const updateUser = await prisma.user.updateMany({
   where: {
     email: {
       contains: 'prisma.io',

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -1293,7 +1293,7 @@ const updatedUserCount = await prisma.user.updateMany({
 ##### Update all `User` records where the `email` contains `prisma.io` and at least one related `Post` has more than 10 likes
 
 ```ts
-const updateUser = await prisma.user.updateMany({
+const updatedUserCount = await prisma.user.updateMany({
   where: {
     email: {
       contains: 'prisma.io',


### PR DESCRIPTION
Small typo in the 'updateMany' examples.
(https://www.prisma.io/docs/orm/reference/prisma-client-reference#updatemany) 

The const is named 'deleteUser', but you probably meant 'updateUser'. 
It's absolutely not a big deal but it was bugging me so I figured I'd flag it :+1:  