### PR TITLE
chore(prisma-client-reference): Fix `createMany` related details

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -1241,7 +1241,7 @@ const deleteUser = await prisma.user.delete({
 - As of Prisma ORM version 5.12.0, `createMany()` is now supported by SQLite.
 - The `skipDuplicates` option is not supported by MongoDB, SQLServer, or SQLite.
 - You **cannot** create or connect relations by using nested `create`, `createMany`, `connect`, `connectOrCreate` queries inside a top-level `createMany()` query.
-- You can use a nested a [`createMany`](#createmany-1) query inside an [`update()`](#update) or [`create()`](#create) query - for example, add a `User` and two `Post` records with a nested `createMany` at the same time.
+- You can use a nested [`createMany`](#createmany-1) query inside an [`update()`](#update) or [`create()`](#create) query - for example, add a `User` and two `Post` records with a nested `createMany` at the same time.
 
 #### Examples
 
@@ -2776,13 +2776,12 @@ const distinctCitiesAndCountries = await prisma.user.findMany({
 
 ### `create`
 
-A nested `create` query adds a new related record or set of records to a parent record. See: [Working with relations](/orm/prisma-client/queries/relation-queries) .
+A nested `create` query adds a new related record or set of records to a parent record. See: [Working with relations](/orm/prisma-client/queries/relation-queries)
 
 #### Remarks
 
-- `create` is available as a nested query when you `create` (`prisma.user.create(...)`) a new parent record or `update` (`prisma.user.update(...)`) an existing parent record.
-
-> You can use a nested `create` _or_ a nested `createMany` to create multiple related records - [each technique pros and cons](/orm/prisma-client/queries/relation-queries#create-a-single-record-and-multiple-related-records) .
+- `create` is available as a nested query when you `create()` (`prisma.user.create(...)`) a new parent record or `update()` (`prisma.user.update(...)`) an existing parent record.
+- You can use a nested `create` _or_ a nested [`createMany`](#createmany-1) to create multiple related records - [each technique pros and cons](/orm/prisma-client/queries/relation-queries#create-a-single-record-and-multiple-related-records).
 
 #### Examples
 
@@ -2827,7 +2826,7 @@ const user = await prisma.user.create({
 
 ##### Create a new `User` record with two new `Post` records
 
-Because it's a one-to-many relation, you can also create several `Post` records at once by passing an array to `create`:
+Because it's a one-to-many relation, you can also create multiple `Post` records at once by passing an array to `create`:
 
 ```ts highlight=5-12;normal
 const user = await prisma.user.create({
@@ -2847,7 +2846,7 @@ const user = await prisma.user.create({
 })
 ```
 
-You can also use a nested [`createMany`](#createmany-1) to achieve the same result.
+Note: You can also use a nested [`createMany`](#createmany-1) to achieve the same result.
 
 ##### Update an existing `User` record by creating a new `Profile` record
 
@@ -2877,18 +2876,24 @@ const user = await prisma.user.update({
 
 ### `createMany`
 
-A nested `createMany` query adds a new set of records to a parent record. See: [Working with relations](/orm/prisma-client/queries/relation-queries) .
+A nested `createMany` query adds a new set of records to a parent record. See: [Working with relations](/orm/prisma-client/queries/relation-queries)
 
 #### Remarks
 
 - `createMany` is available as a nested query when you `create()` (`prisma.user.create(...)`) a new parent record or `update()` (`prisma.user.update(...)`) an existing parent record.
-- Available in the context of a one-to-many relation — for example, you can `prisma.user.create(...)` a user and use a nested `createMany` to create multiple posts (posts have one user).
-- **Not** available in the context of a many-to-many relation — for example, you **cannot** `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
-- Does not support nesting additional relations — you cannot nest an additional `create` or `createMany`.
+  - Available in the context of a one-to-many relation — for example, you can `prisma.user.create(...)` a user and use a nested `createMany` to create multiple posts (posts have one user).
+  - **Not** available in the context of a many-to-many relation — for example, you **cannot** `prisma.post.create(...)` a post and use a nested `createMany` to create categories (many posts have many categories).
+- You cannot nest an additional `create` or `createMany`.
 - Allows setting foreign keys directly — for example, setting the `categoryId` on a post.
-- As of Prisma ORM version 5.12.0, nested `createMany` is now supported by SQLite.
+- As of Prisma ORM version 5.12.0, nested `createMany` is supported by SQLite.
+- You can use a nested `create` _or_ a nested `createMany` to create multiple related records - [each technique pros and cons](/orm/prisma-client/queries/relation-queries#create-a-single-record-and-multiple-related-records).
 
-> You can use a nested `create` _or_ a nested `createMany` to create multiple related records - [each technique pros and cons](/orm/prisma-client/queries/relation-queries#create-a-single-record-and-multiple-related-records) .
+#### Options
+
+| Name              | Type                              | Required | Description                                                                                                                                                                                                                                             |
+| ----------------- | --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`            | `Enumerable<UserCreateManyInput>` | **Yes**  | Wraps all the model fields in a type so that they can be provided when creating new records. Fields that are marked as optional or have default values in the datamodel are optional.                                                                   |
+| `skipDuplicates?` | `boolean`                         | No       | Do not insert records with unique fields or ID fields that already exist. Only supported by databases that support [`ON CONFLICT DO NOTHING`](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT). This excludes MongoDB and SQLServer |
 
 #### Examples
 


### PR DESCRIPTION
- Add "Options" table for `createMany`
- Fix a bunch of misplaced words and periods
- Turn quote into Remark list item
- Bunch of other small things