### PR TITLE
400-nextjs-prisma-client-dev-practices: Fix incorrect globalThis property name

### DIFF
--- a/content/200-orm/800-more/600-help-and-troubleshooting/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/100-help-articles/400-nextjs-prisma-client-dev-practices.mdx
@@ -30,7 +30,7 @@ const prismaClientSingleton = () => {
 }
 
 declare const globalThis: {
-  prisma: ReturnType<typeof prismaClientSingleton>;
+  prismaGlobal: ReturnType<typeof prismaClientSingleton>;
 } & typeof global;
 
 const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()


### PR DESCRIPTION
A wrong property name in the example of initializing single instance `Prisma Client` resulted in a Typescript error.