### PR TITLE
Fix: WEB-404 wrong color on TOC hover

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1095,9 +1095,13 @@ hr {
   color: white !important;
 }
 
-.table-of-contents__link:hover,
-.table-of-contents__link:hover code {
+:root[data-theme="light"] .table-of-contents__link:hover,
+:root[data-theme="light"] .table-of-contents__link:hover code {
   color: rgb(26, 32, 44) !important;
+}
+:root[data-theme="dark"] .table-of-contents__link:hover,
+:root[data-theme="dark"] .table-of-contents__link:hover code {
+  color: #f7fafc !important;
 }
 
 .table-of-contents__link--active code {


### PR DESCRIPTION
When hovering on the right-side TOC on dark mode, the color of each item turns darker instead of lighter. 

This PR fixes [#WEB-404](https://linear.app/prisma-company/issue/WEB-404/update-hover-color-in-right-side-nav-for-dark-mode)