### PR TITLE
fix(docs): Update Snaplet Seed tutorial.

### DIFF
--- a/content/200-orm/300-prisma-migrate/300-workflows/10-seeding.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/10-seeding.mdx
@@ -494,7 +494,7 @@ npx prisma db seed
   "scripts": {
     //add-start
     "migrate": "prisma migrate dev",
-    "postmigrate": "npx @snaplet/seed --config prisma/seed/seed.config.ts sync"
+    "postmigrate": "npx @snaplet/seed sync"
     //add-end
   }
   "devDependencies": {


### PR DESCRIPTION
We now have the option to persist a custom configuration path in `package.json`, which is automatically populated on `init` if the user initializes the project in a custom folder, so we can now remove the need for `--config` in the tutorial. 😄 

Here is the piece of docs about it: https://docs.snaplet.dev/seed/reference/configuration#config-location