### PR TITLE
fix(raw-queries): Rewrite "PostgreSQL typecasting fixes" to "Raw query typecasting behavior"

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -414,9 +414,9 @@ The solution in this case is to explicitly cast `42` to the `text` type:
 await prisma.$queryRaw`SELECT LENGTH(${42}::text);`
 ```
 
-<Admonition type="info">
+:::info
 
-**Feature availability:** This funtionality is [Generally Available](/orm/more/releases#generally-available-ga) since version 4.0.0. In v3.14.x and v3.15.x, it was were available with the preview feature `improvedQueryRaw`.
+**Feature availability:** This funtionality is [Generally Available](/orm/more/releases#generally-available-ga) since version 4.0.0. In v3.14.x and v3.15.x, it was available with the preview feature `improvedQueryRaw`.
 
 For the example above before version 4.0.0, Prisma ORM silently coerces `42` to `text` and does not require the explicit cast. 
 
@@ -429,7 +429,7 @@ await prisma.$queryRaw`SELECT ${1.5}::int as int`
 // Before: db error: ERROR: incorrect binary data format in bind parameter 1
 ```
 
-</Admonition>
+:::
 
 ### Transactions
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -393,7 +393,7 @@ Note that the exact name for each database type will vary between databases – 
 
 ### Raw query typecasting behavior
 
-Raw queries with Prisma Client might require parameters to be in the expected types of the SQL function or query and does not do subtle implicit casts.
+Raw queries with Prisma Client might require parameters to be in the expected types of the SQL function or query. Prisma Client does not do subtle, implicit casts.
 
 As an example, take the following query using PostgreSQL's `LENGTH` function, which only accepts the `text` type as an input:
 

--- a/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/090-raw-database-access/050-raw-queries.mdx
@@ -391,43 +391,45 @@ The following table shows the conversion between types used in the database and 
 
 Note that the exact name for each database type will vary between databases – for example, the boolean type is known as `boolean` in PostgreSQL and `STRING` in CockroachDB. See the [Scalar types reference](/orm/reference/prisma-schema-reference#model-field-scalar-types) for full details of type names for each database.
 
-### PostgreSQL typecasting fixes
+### Raw query typecasting behavior
 
-Prisma ORM resolves a number of issues with typecasting in PostgreSQL.
+Raw queries with Prisma Client might require parameters to be in the expected types of the SQL function or query and does not do subtle implicit casts.
 
-<Admonition type="info">
-
-**Feature availability:** In v3.14.x and v3.15.x, these PostgreSQL fixes were available with the preview feature `improvedQueryRaw`. We made these fixes [Generally Available](/orm/more/releases#generally-available-ga) in version 4.0.0, so you do not need to use `improvedQueryRaw` in version 4.0.0 or later.
-
-</Admonition>
-
-For example, the following raw query now works correctly, returning an integer result:
-
-```ts
-await prisma.$queryRaw`SELECT ${1.5}::int as int`
-
-// Before: db error: ERROR: incorrect binary data format in bind parameter 1
-// After: [{ int: 2 }]
-```
-
-A consequence of this fix is that some subtle implicit casts are now handled more strictly, so some queries that previously were allowed will now fail. As an example, take the following query using PostgreSQL's `LENGTH` function, which only accepts the `text` type as an input:
+As an example, take the following query using PostgreSQL's `LENGTH` function, which only accepts the `text` type as an input:
 
 ```ts
 await prisma.$queryRaw`SELECT LENGTH(${42});`
 ```
 
-Before version 4.0.0, Prisma ORM silently coerces `42` to `text`. From version 4.0.0, the query returns an error:
+This query returns an error:
 
 ```terminal wrap
 // ERROR: function length(integer) does not exist
 // HINT: No function matches the given name and argument types. You might need to add explicit type casts.
 ```
 
-The fix in this case is to explicitly cast `42` to the `text` type:
+The solution in this case is to explicitly cast `42` to the `text` type:
 
 ```ts
 await prisma.$queryRaw`SELECT LENGTH(${42}::text);`
 ```
+
+<Admonition type="info">
+
+**Feature availability:** This funtionality is [Generally Available](/orm/more/releases#generally-available-ga) since version 4.0.0. In v3.14.x and v3.15.x, it was were available with the preview feature `improvedQueryRaw`.
+
+For the example above before version 4.0.0, Prisma ORM silently coerces `42` to `text` and does not require the explicit cast. 
+
+On the other hand the following raw query now works correctly, returning an integer result, and failed before:
+
+```ts
+await prisma.$queryRaw`SELECT ${1.5}::int as int`
+
+// Now: [{ int: 2 }]
+// Before: db error: ERROR: incorrect binary data format in bind parameter 1
+```
+
+</Admonition>
 
 ### Transactions
 


### PR DESCRIPTION
This was a super weird section that did not follow our usual style at all.