### PR TITLE
Remove unecessary build step

### DIFF
--- a/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
@@ -58,7 +58,6 @@ jobs:
         uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install
-      - run: npm run build
       - name: Apply all pending migrations to the database
         run: npx prisma migrate deploy
         env:

--- a/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
@@ -45,6 +45,8 @@ Here is an example action that will run your migrations against your database:
 name: Deploy
 on:
   push:
+    paths:
+      - ./prisma/migrations/** # Only run this workflow when migrations are updated
     branches:
       - main
 


### PR DESCRIPTION
Perhaps I'm being a little pernickety, but the build step isn't required so no need to have this in there.  Also it's probably best to only run this action when the migrations folder is changed.