### PR TITLE
feat: add pulse faq for types to work

### DIFF
--- a/content/400-pulse/600-faq.mdx
+++ b/content/400-pulse/600-faq.mdx
@@ -56,3 +56,21 @@ While ensuring Database event size can be tricky, we recommend some best practic
 ## Can I use Pulse in my front-end code?
 
 No, Pulse is server-side and subscriptions cannot be initiated directly within client-side code. If you would find this feature valuable, please share your thoughts on the `#help-and-questions` channel in our community [Discord](https://pris.ly/discord).
+
+## How can I enable types for Prisma Pulse in Cloudflare Workers?
+
+The Prisma Pulse extension offers separate implementations tailored for various runtimes, such as Node.js and Cloudflare Workers. If you're using [bundler moduleResolution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#bundler) in your TSConfig, you must also explicitly set [`customConditions`](https://www.typescriptlang.org/tsconfig/#customConditions) to either `node` or `workerd` depending on your target runtime. 
+
+In Cloudflare Workers, you have to set `customConditions` to `workerd` for types to work. This will instruct TypeScript to match the correct type definitions of the Prisma Pulse extension, as well as any other packages that expose multiple entrypoints.
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    // ...other options
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "customConditions": ["workerd"] // or "node"
+  }
+}
+```

--- a/content/400-pulse/600-faq.mdx
+++ b/content/400-pulse/600-faq.mdx
@@ -59,7 +59,7 @@ No, Pulse is server-side and subscriptions cannot be initiated directly within c
 
 ## How can I enable types for Prisma Pulse in Cloudflare Workers?
 
-The Prisma Pulse extension offers separate implementations tailored for various runtimes, such as Node.js and Cloudflare Workers. If you're using [bundler moduleResolution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#bundler) in your TSConfig, you must also explicitly set [`customConditions`](https://www.typescriptlang.org/tsconfig/#customConditions) to either `node` or `workerd` depending on your target runtime. 
+The [Prisma Pulse extension](https://www.npmjs.com/package/@prisma/extension-pulse) offers separate implementations tailored for various runtimes, such as Node.js and Cloudflare Workers. If you're using [bundler moduleResolution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#bundler) in your TSConfig, you must also explicitly set [`customConditions`](https://www.typescriptlang.org/tsconfig/#customConditions) to either `node` or `workerd` depending on your target runtime. 
 
 In Cloudflare Workers, you have to set `customConditions` to `workerd` for types to work. This will instruct TypeScript to match the correct type definitions of the Prisma Pulse extension, as well as any other packages that expose multiple entrypoints.
 


### PR DESCRIPTION
This exists in the Pulse extension [README](https://www.npmjs.com/package/@prisma/extension-pulse), however, users seem to miss it. Hence adding this to the doc.

![image](https://github.com/prisma/docs/assets/64993082/25b4793a-9016-469b-98fe-dec34b469f6a)
