### PR TITLE
Update 250-opentelemetry-tracing.mdx: use `SEMRESATTRS_XXXXX` constants and remove deprecated imports

### DIFF
--- a/content/200-orm/200-prisma-client/600-observability-and-logging/250-opentelemetry-tracing.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/250-opentelemetry-tracing.mdx
@@ -115,7 +115,7 @@ The following code provides a minimal tracing configuration. You need to customi
 
 ```ts file=setup.ts
 // Imports
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
@@ -126,7 +126,8 @@ import { Resource } from '@opentelemetry/resources'
 // Configure the trace provider
 const provider = new NodeTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'example application',
+    [SEMRESATTRS_SERVICE_NAME]: 'example application',
+    [SEMRESATTRS_SERVICE_VERSION]: '0.0.1',
   }),
 })
 


### PR DESCRIPTION
Removed deprecated import and replace.

Random find of the day.

See 
```
/**
 * Definition of available values for SemanticResourceAttributes
 * This type is used for backward compatibility, you should use the individual exported
 * constants SemanticResourceAttributes_XXXXX rather than the exported constant map. As any single reference
 * to a constant map value will result in all strings being included into your bundle.
 * @deprecated Use the SEMRESATTRS_XXXXX constants rather than the SemanticResourceAttributes.XXXXX for bundle minification.
 */
export declare type SemanticResourceAttributes = {
```
....