### PR TITLE
fix(full-text-search): fix _relevance headline

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/060-full-text-search.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/060-full-text-search.mdx
@@ -170,7 +170,7 @@ MySQL also has `>`, `<` and `~` operators for altering the ranking order of sear
 
 For the full range of supported operations, see the [MySQL full text search documentation](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html).
 
-## Sorting results by `\_relevance`
+## Sorting results by `_relevance`
 
 <Admonition type="warning">
 


### PR DESCRIPTION
No idea why it said incorrect `\_relevance` besides it being funny: `\_o_/`