### PR TITLE
docs: install nuxt module using nuxi cli

### DIFF
--- a/content/200-orm/800-more/600-help-and-troubleshooting/100-help-articles/900-prisma-nuxt-module.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/100-help-articles/900-prisma-nuxt-module.mdx
@@ -26,21 +26,13 @@ This module provides several features to streamline the setup and usage of Prism
     npx nuxi@latest init test-nuxt-app
     ```
 
-2. Navigate to project directory and install `@prisma/nuxt`:
+2. Navigate to project directory and install `@prisma/nuxt` using the Nuxt CLI:
     ```terminal
     cd test-nuxt-app
-    npm install @prisma/nuxt
+    npx nuxi@latest module add @prisma/nuxt
     ```
 
-3. Add `@prisma/nuxt` to your `nuxt.config.ts`:
-    ```typescript
-    export default defineNuxtConfig({
-      modules: ["@prisma/nuxt"],
-      devtools: { enabled: true },
-    });
-    ```
-
-4. Start the development server:
+3. Start the development server:
     ```terminal
     npm run dev
     ```
@@ -85,7 +77,7 @@ This module provides several features to streamline the setup and usage of Prism
     5. Install and generate a [Prisma Client](/orm/reference/prisma-client-reference) which enables you to query your DB
     6. Prompt you to start the [Prisma Studio](/orm/tools/prisma-studio)
 
-5. You can now use Prisma ORM in your project. If you accepted the prompt to add Prisma Studio, you can access Prisma Studio through the Nuxt Devtools. See the [usage section](#usage) to learn how to use Prisma Client in your app.
+4. You can now use Prisma ORM in your project. If you accepted the prompt to add Prisma Studio, you can access Prisma Studio through the Nuxt Devtools. See the [usage section](#usage) to learn how to use Prisma Client in your app.
 
 ## Using a different database provider
 


### PR DESCRIPTION
Changes install docs to install using `nuxi module add`. This is the new standard way of installing modules across the Nuxt ecosystem, as it automatically adds the module to `nuxt.config.ts`.