### PR TITLE
docs(03-prisma-and-mongoose.mdx): fix bold subtitle typo

### DIFF
--- a/content/200-orm/800-more/400-comparisons/03-prisma-and-mongoose.mdx
+++ b/content/200-orm/800-more/400-comparisons/03-prisma-and-mongoose.mdx
@@ -213,7 +213,7 @@ await user.save()
 
 ## Updating objects
 
-**Prisma ORM **
+**Prisma ORM**
 
 ```ts
 const user = await prisma.user.update({


### PR DESCRIPTION
There was a space between the end of the word and the trailing two "\*", resulting in the title not being bold on render and the "\*" being visible.