### PR TITLE
fix(head metadata): add twitter specific metadata.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -117,6 +117,11 @@ const config: Config = {
   ],
   themeConfig: {
     image: "/docs/social/docs-social.png",
+    metadata: [
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:site", content: "@prisma" },
+      { name: "twitter:creator", content: "@prisma" },
+    ],
     navbar: {
       logo: {
         srcDark: "img/logo-white.svg",


### PR DESCRIPTION
Resolves WEB-382

Added `twitter:card`, `twitter:site`, and `twitter:creator`. The rest of the fields are not needed as Twitter will use existing og metadata.