### PR TITLE
fix(deployment): use absolute path for prisma directory

### DIFF
--- a/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/550-deploy-database-changes-with-prisma-migrate.mdx
@@ -46,7 +46,7 @@ name: Deploy
 on:
   push:
     paths:
-      - ./prisma/migrations/** # Only run this workflow when migrations are updated
+      - prisma/migrations/** # Only run this workflow when migrations are updated
     branches:
       - main
 


### PR DESCRIPTION
In the section "Deploying database changes using GitHub Actions", the current version of the docs uses a relative path to point to the prisma directory and, as a result, the workflow will never be triggered. This PR solves that issue, by using an [absolute path](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths).

Current: `./prisma/migrations/**`
After PR: `prisma/migrations/**`