### PR TITLE
Fix copy/paste error.

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/037-relation-queries.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/037-relation-queries.mdx
@@ -444,7 +444,7 @@ const result = await prisma.user.findFirst({
   include: {
     posts: {
       where: {
-        published: true,
+        published: false,
       },
       orderBy: {
         title: 'asc',


### PR DESCRIPTION
The example talks about "the same query", so I've adjusted the second query to have the same semantics as the first.