### PR TITLE
fix(docs): document behavior of `not` with `NULL` values

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -3560,13 +3560,34 @@ const result = await prisma.user.findMany({
 })
 ```
 
+:::warning
+
+`not` will return all items that do not match a given value. However, if the column is nullable, `NULL` values will not be returned. If you require null values to be returned, use an [`OR`](#or) to include `NULL` values.
+
+:::
+
+##### Return all users where `name` does **not** equal `"Eleanor"` **including** users where `name` is `NULL`
+
+```ts
+await prisma.user.findMany({
+  where: {
+    OR: [
+      { name: { not: 'Eleanor' } },
+      { name: null }
+    ]
+  }
+})
+```
+
 ### `in`
 
 Value `n` exists in list.
 
-#### Remarks
+:::note
 
-- `null` values are not returned. For example, if you combine `in` and `NOT` to return user whose name is _not_ in the list, users with `null` value names are not returned.
+`null` values are not returned. For example, if you combine `in` and `NOT` to return user whose name is _not_ in the list, users with `null` value names are not returned.
+
+:::
 
 #### Examples
 

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -3562,7 +3562,7 @@ const result = await prisma.user.findMany({
 
 :::warning
 
-`not` will return all items that do not match a given value. However, if the column is nullable, `NULL` values will not be returned. If you require null values to be returned, use an [`OR`](#or) to include `NULL` values.
+`not` will return all items that do not match a given value. However, if the column is nullable, `NULL` values will not be returned. If you require null values to be returned, use an [`OR`](#or) operator to include `NULL` values.
 
 :::
 
@@ -3585,7 +3585,7 @@ Value `n` exists in list.
 
 :::note
 
-`null` values are not returned. For example, if you combine `in` and `NOT` to return user whose name is _not_ in the list, users with `null` value names are not returned.
+`null` values are not returned. For example, if you combine `in` and `NOT` to return a user whose name is _not_ in the list, users with `null` value names are not returned.
 
 :::
 


### PR DESCRIPTION
Resolves DA-623
Resolves #3812