### PR TITLE
remove outdated mentions of roadmap

### DIFF
--- a/content/200-orm/050-overview/100-introduction/250-should-you-use-prisma.mdx
+++ b/content/200-orm/050-overview/100-introduction/250-should-you-use-prisma.mdx
@@ -64,7 +64,6 @@ Prisma ORM is the only _fully_ type-safe ORM in the TypeScript ecosystem. The ge
 Development of Prisma ORM's open source tools is happening in the open. Most of it happens directly on GitHub in the main [`prisma/prisma`](https://github.com/prisma/prisma) repo:
 
 - issues and PRs in our repos are triaged and prioritized (usually within 1-2 days)
-- there is a public [roadmap](https://pris.ly/roadmap) that is kept up to date with our plans
 - new [releases](https://github.com/prisma/prisma/releases) with new features and improvements are issued every three weeks
 - we have a dedicated support team that responds to questions in [GitHub Discussions](https://github.com/prisma/prisma/discussions)
 

--- a/content/200-orm/800-more/700-releases.mdx
+++ b/content/200-orm/800-more/700-releases.mdx
@@ -54,12 +54,6 @@ If a feature or product is **Generally Available**:
 - The solution has been tested for some time and we received enough feedback to consider it stable and ready for production use.
 - There should be no bugs in 99% of cases (completely bug-free software cannot be guaranteed)
 
-## Roadmap
-
-Our roadmap helps us share our current priorities: what we are currently working on and what we are planning to work on in the near term. This reflects our _current plans_ today, and the content is subject to change at any time. Actual results and plans may differ as a result of changing our product strategy or reacting to demands from our user base.
-
-You can [check out the full roadmap here](https://pris.ly/roadmap).
-
 ## Versioning
 
 Prisma ORM's release scheme adheres to Semantic Versioning ([SemVer](https://semver.org/)) starting with version `3.x.x`.


### PR DESCRIPTION
The roadmap on Notion has been outdated and we're removing it as part of the published site cleanup.