### PR TITLE
Fix Pagination Navigation in "Get Started" Section

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-cockroachdb.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-mysql.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-planetscale.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-postgresql.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-sqlserver.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-cockroachdb.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-mysql.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-planetscale.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-postgresql.mdx
@@ -6,6 +6,7 @@ hide_table_of_contents: true
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-sqlserver.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/index
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-node-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-node-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-node-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-node-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-node-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: 'hidden-sidebar tech-switch'
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Connect your database to your project using TypeScript and Pos
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Create database tables with Prisma Migrate using TypeScript an
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-node-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-node-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-node-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Install and generate Prisma Client in your project using TypeS
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-cockroachdb.mdx
@@ -6,7 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
-pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-typescript-cockroachdb
+pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---
  

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-node-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-mysql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Write data to and query the database using TypeScript and Post
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-postgresql
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-node-mongodb.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 pagination_next: getting-started/setup-prisma/start-from-scratch/mongodb/connect-your-database-node-mongodb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/mongodb-
 ---

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-typescript-mongodb.mdx
@@ -6,6 +6,7 @@ hide_table_of_contents: true
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 sidebar_custom_props: { badge: '15 min' }
+pagination_prev: getting-started/setup-prisma/start-from-scratch/relational-databases/next-steps
 pagination_next: getting-started/setup-prisma/start-from-scratch/mongodb/connect-your-database-typescript-mongodb
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/mongodb-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-cockroachdb.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 toc: false
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-node-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-mysql.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-node-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-node-planetscale
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/using-prisma-migrate-node-planetscale
 slugSwitch: /getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-postgresql.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-node-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-sqlserver.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-node-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-cockroachdb.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: 'hidden-sidebar tech-switch'
 hide_table_of_contents: true
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-mysql.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-planetscale.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-planetscale
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-planetscale
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-sqlserver.mdx
@@ -7,6 +7,7 @@ dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 toc: false
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-node-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-node-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-node-planetscale
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-node-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-node-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Introspect your existing project with Prisma ORM, TypeScript, 
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/150-introspection-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-node-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Baseline your database with Prisma ORM, TypeScript, and Postgr
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/170-baseline-your-database-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/introspection-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-planetscale
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-node-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-planetscale
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Install and generate Prisma Client in your existing TypeScript
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/200-install-prisma-client-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/baseline-your-database-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-node-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-node-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-planetscale
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-node-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 --- 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-node-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-node-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-node-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-typescript-cockroachdb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-typescript-mysql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-planetscale.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-planetscale
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Write data to and query the PostgreSQL database with your Type
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-typescript-postgresql
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/install-prisma-client-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-typescript-sqlserver
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-postgresql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-node-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-node-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-cockroachdb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-cockroachdb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-mysql.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-mysql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-postgresql.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Evolve your Prisma schema with Prisma Migrate inside of your T
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-postgresql
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/275-evolve-your-schema-typescript-sqlserver.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'cockroachdb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/querying-the-database-typescript-sqlserver
 pagination_next: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/relational-databases/evolve-your-schema-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb-node-mongodb.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 hide_table_of_contents: true
 dbSwitcher: ['mongodb']
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/connect-your-database-node-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb-typescript-mongodb.mdx
@@ -7,6 +7,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/relational-databases/next-steps
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/connect-your-database-typescript-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database-node-mongodb.mdx
@@ -7,6 +7,7 @@ sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true
 dbSwitcher: ['mongodb']
 toc: false
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb-node-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/introspection-node-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/100-connect-your-database-typescript-mongodb.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Connect your MongoDB database to your existing TypeScript proj
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb-typescript-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/introspection-typescript-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/connect-your-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-node-mongodb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb/connect-your-database-node-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/install-prisma-client-node-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-typescript-mongodb.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Introspection your MongoDB database with Prisma ORM'
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb/connect-your-database-typescript-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/install-prisma-client-typescript-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/introspection-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-typescript-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Introspection'
 metaTitle: 'Introspection: MongoDB and TypeScript'
-metaDescription: 'Introspection your MongoDB database with Prisma ORM'
+metaDescription: 'Introspect your MongoDB database with Prisma ORM'
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/200-install-prisma-client-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/200-install-prisma-client-node-mongodb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb/introspection-node-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/querying-the-database-node-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/200-install-prisma-client-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/200-install-prisma-client-typescript-mongodb.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Install and generate Prisma Client in your existing project us
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb/introspection-typescript-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/querying-the-database-typescript-mongodb
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/install-prisma-client-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-node-mongodb.mdx
@@ -6,6 +6,7 @@ langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb/install-prisma-client-node-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/querying-the-database-
 ---

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
@@ -5,6 +5,7 @@ metaDescription: 'Write data to and query your MongoDB database'
 langSwitcher: ['typescript', 'node']
 dbSwitcher: ['mongodb']
 hide_table_of_contents: true
+pagination_prev: getting-started/setup-prisma/add-to-existing-project/mongodb/install-prisma-client-typescript-mongodb
 pagination_next: getting-started/setup-prisma/add-to-existing-project/mongodb/next-steps
 slugSwitch: /getting-started/setup-prisma/add-to-existing-project/mongodb/querying-the-database-
 ---


### PR DESCRIPTION
### Description
This PR addresses the pagination issues in the Getting Started section by updating the front matter of each MDX file to include the `pagination_prev` field.

### Issue Details
The "Previous" navigation buttons were self-referential so it was not possible to go back on most pages. In most cases clicking Previous reloaded the Typescript/Postgres version of the current page no matter what language/database configuration the user was in. The buttons worked on a few of the title pages but not in nested routes. This PR allows navigation back and forth through the docs and maintains the user's choices where possible. (There are a couple of cases where there is a missing Planetscale page so the Postgresql version was chosen in those cases.)