### PR TITLE
Pulse docs improvements

### DIFF
--- a/content/400-pulse/300-database-events.mdx
+++ b/content/400-pulse/300-database-events.mdx
@@ -203,3 +203,4 @@ If the `name` option is omitted, no cursor will be associated with the stream an
 
 ![](/img/pulse/without-name.png)
 
+Note that if `name` is provided, only one client can be connected to a stream with that particular `name` at any given time.

--- a/content/400-pulse/400-api-reference.mdx
+++ b/content/400-pulse/400-api-reference.mdx
@@ -42,12 +42,12 @@ for await (let event of subscription) {
 
 You can pass an object with configuration options to `stream()`. The object has the following fields:
 
-| Name     | Description                                                                                                                                                                                                                                                                                                               |
-| :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`   | The name of the stream. Providing this option enables "resumability" and will make sure you receive events later if your stream isn't active at the time when the event actually happened (e.g. because your server was down).                                                                                            |
-| `create` | An object to specify filters for the create events to be received. If you leave the object empty with `create: {}`, you will receive _all_ create events. You can filter on any scalar field of your model.                                                                                                               |
-| `update` | An object with an `after` field to specify filters for the update events to be received. If you leave the object empty with `update: {}`, you will receive _all_ update events. The filter is applied to the values of the record _after_ an update has been performed. You can filter on any scalar field of your model. |
-| `delete` | An object to specify filters for the delete events to be received. You can filter on any scalar field of your model.                                                                                                                                                                                                      |
+| Name     | Description                                                                                                                                                                                                                                                                                                                                               |
+| :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`   | The name of the stream. Providing this option enables "resumability" and will make sure you receive events later if your stream isn't active at the time when the event actually happened (e.g. because your server was down). Note that if `name` is provided, only one client can be connected to a stream with that particular `name` at any given time. |
+| `create` | An object to specify filters for the create events to be received. If you leave the object empty with `create: {}`, you will receive _all_ create events. You can filter on any scalar field of your model.                                                                                                                                               |
+| `update` | An object with an `after` field to specify filters for the update events to be received. If you leave the object empty with `update: {}`, you will receive _all_ update events. The filter is applied to the values of the record _after_ an update has been performed. You can filter on any scalar field of your model.                                 |
+| `delete` | An object to specify filters for the delete events to be received. You can filter on any scalar field of your model.                                                                                                                                                                                                                                      |
 
 ### Return type
 
@@ -97,7 +97,7 @@ const stream = await prisma.user.stream({
 });
 ```
 
-Learn more about resuming streams [here](/pulse/database-events#resuming-event-streams)
+Learn more about resuming streams [here](/pulse/database-events#resuming-event-streams).
 
 #### Filter for new `User` records with a non-null value for `name`
 
@@ -289,7 +289,7 @@ The type of the event is generic to the fields of your model. In the case, of th
 
 ```ts
 PulseCreateEvent<{
-  id: number;
+
   email: string;
   name: string | null;
 }>;
@@ -316,13 +316,13 @@ An object of type `PulseUpdateEvent` is returned by any `delete` event that happ
 
 A `PulseUpdateEvent` has the following fields:
 
-| Name        | Type     | Example value                     | Description                                                                                                                                                                                         |
-| :---------- | :------- | :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`        | `string` | `01HYBEER1JPSBVPG2NQADNQTA6`      | A unique identifier / idempotency key following the [ULID](https://github.com/ulid/spec#specification) specification.                                                                               |
-| `modelName` | `string` | `User`                            | The name of the model affected by this event. This is a model name from your Prisma schema.                                                                                                         |
-| `action`    | `string` | `update`                          | The kind of write-operation performed in the database: `update`                                                                                                                                     |
+| Name        | Type     | Example value                     | Description                                                                                                                                                                                                                                                                 |
+| :---------- | :------- | :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | `string` | `01HYBEER1JPSBVPG2NQADNQTA6`      | A unique identifier / idempotency key following the [ULID](https://github.com/ulid/spec#specification) specification.                                                                                                                                                       |
+| `modelName` | `string` | `User`                            | The name of the model affected by this event. This is a model name from your Prisma schema.                                                                                                                                                                                 |
+| `action`    | `string` | `update`                          | The kind of write-operation performed in the database: `update`                                                                                                                                                                                                             |
 | `before`    | `User`   | `null`                            | An object with the _old_ values of the record that was just updated. This only works with when the [`REPLICA IDENTITY`](/pulse/database-setup/general-database-instructions#replica-identity) in your database is set to `FULL`. Otherwise the value will always be `null`. |
-| `after`     | `User`   | See `after` in the example below. | An object with the _new_ values of the record that was just updated.                                                                                                                                |
+| `after`     | `User`   | See `after` in the example below. | An object with the _new_ values of the record that was just updated.                                                                                                                                                                                                        |
 
 The type of the event is generic to the fields of your model. In the case, of the `User` model above, it looks as follows:
 
@@ -366,11 +366,11 @@ _With_ having set the `REPLICA IDENDITY` to `FULL`:
 
 A `PulseDeleteEvent` has the following fields:
 
-| Name        | Type     | Example value                | Description                                                                                                                                                                                            |
-| :---------- | :------- | :--------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`        | `string` | `01HYBEER1JPSBVPG2NQADNQTA6` | A unique identifier / idempotency key following the [ULID](https://github.com/ulid/spec#specification) specification.                                                                                  |
-| `modelName` | `string` | `User`                       | The name of the model affected by this event. This is a model name from your Prisma schema.                                                                                                            |
-| `action`    | `string` | `delete`                     | The kind of write-operation performed in the database: `create`, `update` or `delete`.                                                                                                                 |
+| Name        | Type     | Example value                | Description                                                                                                                                                                                                                                                                    |
+| :---------- | :------- | :--------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | `string` | `01HYBEER1JPSBVPG2NQADNQTA6` | A unique identifier / idempotency key following the [ULID](https://github.com/ulid/spec#specification) specification.                                                                                                                                                          |
+| `modelName` | `string` | `User`                       | The name of the model affected by this event. This is a model name from your Prisma schema.                                                                                                                                                                                    |
+| `action`    | `string` | `delete`                     | The kind of write-operation performed in the database: `create`, `update` or `delete`.                                                                                                                                                                                         |
 | `deleted`   | `User`   | `{ id: 3 }`                  | An object with the values of the record that was just deleted. This only works with when the [`REPLICA IDENTITY`](/pulse/database-setup/general-database-instructions#replica-identity) in your database is set to `FULL`. Otherwise the object will only carry an `id` field. |
 
 The type of the event is generic to the fields of your model. In the case, of the `User` model above, it looks as follows:

--- a/content/400-pulse/600-faq.mdx
+++ b/content/400-pulse/600-faq.mdx
@@ -37,6 +37,10 @@ Usage of the API is billed according to these factors:
 - **Events reads**: The number of database events _read_ and _delivered_ by Pulse via `.stream()`
 - **Event storage**: The amount of disk space the stored events consume (in GiB)
 
+## Will I get charged for event persistence even if I don't use named streams via `name`?
+
+Yes. If you enable **Event persistence** in your project, your database events will be persisted and you will be charged accordingly.
+
 ## How many Prisma Client instances can subscribe to a database event?
 
 The number of Prisma Client instances that can subscribe to via Prisma Pulse has the following limits:


### PR DESCRIPTION
closes:
- https://linear.app/prisma-company/issue/DA-973/document-why-pulse-stream-throws-generic-error-when-multiple-clients
- https://linear.app/prisma-company/issue/DA-1152/question-about-possible-charges-for-enabling-event-persistence-without