### PR TITLE
fix: WEB-448 code highlighted margin

### DIFF
--- a/src/theme/CodeBlock/Line/styles.module.scss
+++ b/src/theme/CodeBlock/Line/styles.module.scss
@@ -84,6 +84,6 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
 .highlightedNumbers {
   margin: 0 !important;
   .codeHighlighted {
-    margin-left: var(--ifm-pre-padding);
+    margin-left: calc(var(--ifm-pre-padding) + 8.41px);
   }
 }


### PR DESCRIPTION
Fixes[ #WEB-448](https://linear.app/prisma-company/issue/WEB-448/line-highlighting-issue-rendered-page-misaligns-lines-with-the-source)

Issue can be seen [here](https://www.prisma.io/docs/orm/prisma-schema/data-model/multi-schema#how-to-apply-your-schema-changes-with-prisma-migrate-and-db-push)
<img width="175" alt="Screenshot 2024-08-12 at 11 17 22" src="https://github.com/user-attachments/assets/a0959742-aa70-4a0a-9764-febd9163ce2c">
