### PR TITLE
feat: WEB-407 Add stronger highlight

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -510,6 +510,11 @@ const config: Config = {
           line: "highlight-next-line",
           block: { start: "highlight-start", end: "highlight-end" },
         },
+        {
+          className: "theme-code-block-stronger-line stronger-line",
+          line: "stronger-next-line",
+          block: { start: "stronger-start", end: "stronger-end" },
+        },
       ],
     },
   } satisfies Preset.ThemeConfig,

--- a/src/theme/CodeBlock/Line/styles.module.scss
+++ b/src/theme/CodeBlock/Line/styles.module.scss
@@ -45,6 +45,27 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
   position: relative;
 }
 
+:global(.theme-code-block-stronger-line.theme-code-block-highlighted-line) {
+  background-color: rgba(0, 0, 0, 0.15);
+  display: block;
+  position: relative;
+}
+:global(.theme-code-block-stronger-line.theme-code-block-added-line) {
+  background-color: rgba(71, 187, 120, 0.30);
+  display: block;
+  position: relative;
+}
+:global(.theme-code-block-stronger-line.theme-code-block-deleted-line) {
+  background-color: rgba(229, 62, 62, 0.30);
+  display: block;
+  position: relative;
+}
+:global(.theme-code-block-stronger-line.theme-code-block-edited-line) {
+  background-color: rgba(10, 104, 255, 0.35);
+  display: block;
+  position: relative;
+}
+
 .codeLine {
   display: table-row;
   counter-increment: line-count;


### PR DESCRIPTION
Works by applying a `stronger-start`/`stronger-end` or `stronger-next-line` inside `[highlight]|[delete][add]-[start]/[end]` highlights. Like so:
```mdx
view UserInfo {
  //delete-next-line
  id    Int?
  //add-next-line
  id    Int    @unique
  email String?
  name  String?
  bio   String?
  //delete-start
  
  //stronger-start
  @@ignore
  //stronger-end
  //delete-end
}
```
| highlight | delete | add |
| ----- | ----- | ----- |
| <img width="539" alt="Screenshot 2024-08-14 at 10 37 34" src="https://github.com/user-attachments/assets/419ba49b-32f5-4a70-a6ce-5b94324f6ed7"> | <img width="531" alt="Screenshot 2024-08-14 at 10 37 08" src="https://github.com/user-attachments/assets/a4983efb-f0d3-4474-a3d4-9c0927d3ea0e"> | <img width="522" alt="Screenshot 2024-08-14 at 10 37 28" src="https://github.com/user-attachments/assets/088347b5-c5e0-4115-aa1e-d6abf0662e3e"> |

