### PR TITLE
fixes typo

### DIFF
--- a/content/200-orm/800-more/450-migrating-to-prisma/03-migrate-from-mongoose.mdx
+++ b/content/200-orm/800-more/450-migrating-to-prisma/03-migrate-from-mongoose.mdx
@@ -23,7 +23,7 @@ Note that the steps for migrating from Mongoose to Prisma ORM are always the sam
 
 These steps apply whether you're building a REST API (e.g. with Express, koa or NestJS), a GraphQL API (e.g. with Apollo Server, TypeGraphQL or Nexus) or any other kind of application that uses Mongoose for database access.
 
-Prisma ORM lends itself really well for **incremental adoption**. This means, you don't have migrate your entire project from Mongoose to Prisma ORM at once, but rather you can _step-by-step_ move your database queries from Mongoose to Prisma ORM.
+Prisma ORM lends itself really well for **incremental adoption**. This means, you don't have to migrate your entire project from Mongoose to Prisma ORM at once, but rather you can _step-by-step_ move your database queries from Mongoose to Prisma ORM.
 
 ## Overview of the sample project
 


### PR DESCRIPTION
This fixes a typo in the documentation for migrating from mongoose to prisma ORM.