### PR TITLE
docs: fix typo in `100-team-development.mdx`

### DIFF
--- a/content/200-orm/300-prisma-migrate/300-workflows/100-team-development.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/100-team-development.mdx
@@ -16,7 +16,7 @@ To incorporate changes from collaborators:
    npx prisma migrate dev
    ```
 
-Migrations are **applied in the same order as they were created**. The creation date is part of the migration subfolder name - for example, `20210316081837-updated-fields` was created on `2021-03-16-08:08:37`.
+Migrations are **applied in the same order as they were created**. The creation date is part of the migration subfolder name - for example, `20210316081837-updated-fields` was created on `2021-03-16-08:18:37`.
 
 <Admonition type="warning">
 


### PR DESCRIPTION
Just a small typo in the file `content/200-orm/300-prisma-migrate/300-workflows/100-team-development.mdx`, where an incorrect date is printed.