### PR TITLE
Added authSource configuration to the "Start from Scratch" section for MongoDB.

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database-typescript-mongodb.mdx
@@ -40,4 +40,4 @@ Here's a short explanation of each component:
 - `PORT`: The port where your database server is running (typically `27017` for MongoDB)
 - `DATABASE`: The name of the database
 
-> If you see the following error: `Error in connector: SCRAM failure: Authentication failed.`, you can specify the source database for the authentication by [adding](https://github.com/prisma/prisma/discussions/9994#discussioncomment-1562283) `?authSource=admin` to the end of the connection string.
+If you see the following error: `Error in connector: SCRAM failure: Authentication failed.`, you can specify the source database for the authentication by adding `?authSource=admin` to the end of the connection string. See [this GitHub discussion](https://github.com/prisma/prisma/discussions/9994#discussioncomment-1562283) for additional details.

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb/100-connect-your-database-typescript-mongodb.mdx
@@ -39,3 +39,5 @@ Here's a short explanation of each component:
 - `HOST`: The host where a [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/#mongodb-binary-bin.mongod) (or [`mongos`](https://docs.mongodb.com/manual/reference/program/mongos/#mongodb-binary-bin.mongos)) instance is running
 - `PORT`: The port where your database server is running (typically `27017` for MongoDB)
 - `DATABASE`: The name of the database
+
+> If you see the following error: `Error in connector: SCRAM failure: Authentication failed.`, you can specify the source database for the authentication by [adding](https://github.com/prisma/prisma/discussions/9994#discussioncomment-1562283) `?authSource=admin` to the end of the connection string.


### PR DESCRIPTION
### Update `100-connect-your-database-typescript-mongodb.mdx`

Added `authSource` configuration to the "Start from Scratch" section for MongoDB.

**Reason for this update:** The `authSource` option was not mentioned in the "Start from Scratch" section, which could be particularly crucial for new developers. Including this tip here can help address potential authentication issues for those setting up their environment from the beginning, whereas experienced developers might already be familiar with such details.

Reference: [Issue](https://github.com/prisma/prisma/discussions/9994#discussioncomment-1562283)