### PR TITLE
Fix $queryRaw typos to $executeRaw

### DIFF
--- a/content/200-orm/200-prisma-client/150-using-raw-sql/200-raw-queries.mdx
+++ b/content/200-orm/200-prisma-client/150-using-raw-sql/200-raw-queries.mdx
@@ -256,31 +256,31 @@ Be aware that:
 
   ```ts no-lines
   const name = 'Bob'
-  await prisma.$queryRaw`UPDATE user SET greeting = 'My name is ${name}';`
+  await prisma.$executeRaw`UPDATE user SET greeting = 'My name is ${name}';`
   ```
 
   Instead, you can either pass the whole string as a variable, or use string concatenation:
 
   ```ts no-lines
   const name = 'My name is Bob'
-  await prisma.$queryRaw`UPDATE user SET greeting = ${name};`
+  await prisma.$executeRaw`UPDATE user SET greeting = ${name};`
   ```
 
   ```ts no-lines
   const name = 'Bob'
-  await prisma.$queryRaw`UPDATE user SET greeting = 'My name is ' || ${name};`
+  await prisma.$executeRaw`UPDATE user SET greeting = 'My name is ' || ${name};`
   ```
 
 - Template variables can only be used for data values (such as `email` in the example above). Variables cannot be used for identifiers such as column names, table names or database names, or for SQL keywords. For example, the following two queries would **not** work:
 
   ```ts no-lines
   const myTable = 'user'
-  await prisma.$queryRaw`UPDATE ${myTable} SET active = true;`
+  await prisma.$executeRaw`UPDATE ${myTable} SET active = true;`
   ```
 
   ```ts no-lines
   const ordering = 'desc'
-  await prisma.$queryRaw`UPDATE User SET active = true ORDER BY ${desc};`
+  await prisma.$executeRaw`UPDATE User SET active = true ORDER BY ${desc};`
   ```
 
 #### Return type


### PR DESCRIPTION
It appears that the `$queryRaw` usages in the `$executeRaw` section are typos:

![Screenshot 2024-09-05 at 17 06 13](https://github.com/user-attachments/assets/fd4145d0-ddb7-4ee2-bea3-51df7fe7cd15)
