### PR TITLE
Update 055-pagination.mdx

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/055-pagination.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/055-pagination.mdx
@@ -214,7 +214,6 @@ const myOldCursor = 200
 
 const firstQueryResults = await prisma.post.findMany({
   take: -4,
-  skip: 1,
   cursor: {
     id: myOldCursor,
   },


### PR DESCRIPTION
When using cursor navigation, you can move forward by skipping the current cursor (using skip: 1) to ensure it's not included in the next set of results. However, when navigating backward, there's no need to skip again, as the previous cursor already represents the position from the last "take" operation. Each cursor inherently holds the correct position relative to the data, eliminating the need for additional skipping when going backward.