### PR TITLE
feat: respect users' preferred color scheme

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -77,7 +77,7 @@ const config: Config = {
         apiKey: DOCUSAURUS_POST_HOG_KEY,
         appUrl: "https://us.i.posthog.com",
         person_profiles: "identified_only",
-        enableInDevelopment: false
+        enableInDevelopment: false,
       },
     ],
   ],
@@ -134,6 +134,11 @@ const config: Config = {
     ],
   ],
   themeConfig: {
+    colorMode: {
+      defaultMode: "light",
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
     image: "/docs/social/docs-social.png",
     metadata: [
       { name: "twitter:card", content: "summary_large_image" },


### PR DESCRIPTION
These are the changes to the [Docusaurus theme config](https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode) so that it prefers the user's system color scheme instead of just defaulting to the light one.

I left the light mode as the default for cases when system preferences are unavailable.