### PR TITLE
Update 01-quickstart.mdx ts-node to tsx

### DIFF
--- a/content/100-getting-started/01-quickstart.mdx
+++ b/content/100-getting-started/01-quickstart.mdx
@@ -185,7 +185,7 @@ Next, execute the script with the following command:
 <cmd>
 
 ```terminal
-npx ts-node script.ts
+npx tsx script.ts
 ```
 </cmd>
 


### PR DESCRIPTION
The current documentation contains a call to `ts-node`. However ts-node does not play nicely with ES-modules, and can be a pain to setup. As can be seen in [this stackoverflow post](https://stackoverflow.com/questions/62096269/unknown-file-extension-ts-for-a-typescript-file). Furthermore, prisma is a platinum sponsor of tsx. 

I changed the call from `ts-node` to `tsx` to make it easier for beginners to follow the getting started without needing to setup a lot.

This is my first pull request, so please let me know if there are any changes to be made.