### PR TITLE
feat(system-requirements): bump minimum required TypeScript version to `5.1.x`

### DIFF
--- a/content/200-orm/500-reference/400-system-requirements.mdx
+++ b/content/200-orm/500-reference/400-system-requirements.mdx
@@ -22,7 +22,7 @@ The latest version of Prisma ORM requires the following software:
 |                       | Minimum required version |
 | :-------------------- | :----------------------- |
 | Node.js               | 16.13 / 18.X / 20.X      |
-| TypeScript (optional) | 4.7.X                    |
+| TypeScript (optional) | 5.1.X                    |
 | Yarn (optional)       | 1.19.2                   |
 
 Notes:


### PR DESCRIPTION
As per [Slack](https://prisma-company.slack.com/archives/C1FPU5FPT/p1730388931466269?thread_ts=1729262220.797909&cid=C1FPU5FPT), Prisma 6 will require [TypeScript 5.1.x](https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/) as the minimum supported TypeScript version.

Please don't merge this until Prisma 6 is ready.