### PR TITLE
chore: fix model name reserved words link

### DIFF
--- a/content/200-orm/500-reference/100-prisma-schema-reference.mdx
+++ b/content/200-orm/500-reference/100-prisma-schema-reference.mdx
@@ -343,7 +343,7 @@ Defines a Prisma [model](/orm/prisma-schema/data-model/models#defining-models) .
 - Model names must adhere to the following regular expression: `[A-Za-z][A-Za-z0-9_]*`
 - Model names must start with a letter and are typically spelled in [PascalCase](https://wiki.c2.com/?PascalCase)
 - Model names should use the singular form (for example, `User` instead of `user`, `users` or `Users`)
-- Prisma ORM has a number of **reserved words** that are being used by Prisma ORM internally and therefore cannot be used as a model name. You can find the reserved words [here](https://github.com/prisma/prisma/blob/main/packages/client/src/generation/generateClient.ts#L376) and [here](https://github.com/prisma/prisma-engines/blob/main/psl/parser-database/src/names/reserved_model_names.rs#L44).
+- Prisma ORM has a number of **reserved words** that are being used by Prisma ORM internally and therefore cannot be used as a model name. You can find the reserved words [here](https://github.com/prisma/prisma/blob/main/packages/client/src/generation/generateClient.ts#L556-L605) and [here](https://github.com/prisma/prisma-engines/blob/main/psl/parser-database/src/names/reserved_model_names.rs#L44).
 
 > **Note**: You can use the [`@@map` attribute](#map-1) to map a model (for example, `User`) to a table with a different name that does not match model naming conventions (for example, `users`).
 


### PR DESCRIPTION
Hey 👋 

The link, due to code changes over time (not sure this is healthy), is pointing to an irrelevant line in the source code. This PR corrects that.