### PR TITLE
Update 100-prisma-schema-reference.mdx

### DIFF
--- a/content/200-orm/500-reference/100-prisma-schema-reference.mdx
+++ b/content/200-orm/500-reference/100-prisma-schema-reference.mdx
@@ -503,7 +503,7 @@ True or false value.
 | Connector   | Default mapping |
 | ----------- | --------------- |
 | PostgreSQL  | `boolean`       |
-| SQL Server  | `tinyint`       |
+| SQL Server  | `bit`           |
 | MySQL       | `TINYINT(1)`    |
 | MongoDB     | `Bool`          |
 | SQLite      | `INTEGER`       |


### PR DESCRIPTION
fixes #5530

I tested this locally with a SQL Server instance and it indeed uses `bit` and not `tinyint`