### PR TITLE
Add prisma-extension-casl to community extensions

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -82,7 +82,8 @@
     "Solidstart",
     "Astro",
     "unikernels",
-    "Postico"
+    "Postico",
+    "CASL"
   ],
   "ignoreWords": [
     "Ania",

--- a/content/200-orm/200-prisma-client/300-client-extensions/200-extension-examples.mdx
+++ b/content/200-orm/200-prisma-client/300-client-extensions/200-extension-examples.mdx
@@ -32,6 +32,7 @@ The following is a list of extensions created by the community. If you want to c
 | [`prisma-rbac`](https://github.com/multipliedtwice/prisma-rbac) | Adds customizable role-based access control |
 | [`prisma-extension-redis`](https://github.com/yxx4c/prisma-extension-redis)                    | Extensive Prisma extension designed for efficient caching and cache invalidation using Redis and Dragonfly Databases  |
 | [`prisma-cache-extension`](https://github.com/Shikhar97/prisma-cache)                    | Prisma extension for caching and invalidating cache with Redis(other Storage options to be supported)  |
+| [`prisma-extension-casl`](https://github.com/dennemark/prisma-extension-casl)            | Prisma client extension that utilizes CASL to enforce authorization logic on most simple and nested queries. |
 
 If you have built an extension and would like to see it featured, feel free to add it to the list by opening a pull request.
 


### PR DESCRIPTION
Hi,

Adding another client extension to the docs.

I have created a [prisma client extension](https://github.com/dennemark/prisma-extension-casl) for [CASL](https://casl.js.org/v6/en/). I am using it in a redwood project with graphql where I was annoyed that I could not properly check all prisma queries i.e. in graphql relation queries. To avoid footguns I decided to implement the authorization logic in the prisma client. It can actually create pretty large queries for complicated authorization logic, but so far it works, even for ACL.

Here is an example:
```ts
function builderFactory() {
  const builder = abilityBuilder();
  const { can } = builder;
  can("read", "Post", {
    thread: {
      creatorId: 0,
    },
  });
  can("read", "Thread", "id");
  return builder;
}

const caslClient = prismaClient.$extends(
  useCaslAbilities(builderFactory, "casl")
);
const result = await caslClient.post.findMany({
  include: {
    thread: true,
  },
});
/**
 * creates a query under the hood with assistance of @casl/prisma
 *
 *{
 *   where: {
 *       AND: [{
 *           OR: [{
 *               thread: {
 *                   creatorId: 0
 *                   }
 *                }]
 *            }]
 *        }
 *   include: {
 *       thread: true
 *    }
 *
 * and result will be filtered and should look like
 * { id: 0, threadId: 0, thread: { id: 0 }, casl: ['read'] }
 */
```