### PR TITLE
Clarify docs for Next.js Edge runtime users

### DIFF
--- a/content/200-orm/050-overview/500-databases/890-neon.mdx
+++ b/content/200-orm/050-overview/500-databases/890-neon.mdx
@@ -196,3 +196,21 @@ const adapter = new PrismaNeon(pool, {
   schema: 'myPostgresSchema'
 })
 ```
+
+#### Next.js Edge runtime
+
+If your runtime provides a WebSocket class, you don't need to install `ws` and `@types/ws` and you might get errors if you do. If your framework provides support for `.env` files, then you don't need the `dotenv` package. For example if using Next.js with Edge runtime, the following code will work:
+
+```ts
+import { PrismaClient } from "@prisma/client";
+import { Pool } from "@neondatabase/serverless";
+import { PrismaNeon } from "@prisma/adapter-neon";
+
+const pool = new Pool({ connectionString: process.env.POSTGRES_PRISMA_URL || process.env.DATABASE_URL });
+
+const adapter = new PrismaNeon(pool);
+
+export const prisma = new PrismaClient({ adapter });
+```
+
+


### PR DESCRIPTION
This might save others some time. Basically:

- Using `ws` in Vercel Edge functions or Cloudflare Workers will fail. 
- These runtimes provide a native WebSocket implementation which should be used.
- Dotenv isn't needed in some frameworks.