### PR TITLE
fix typo for isNot definition

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -4227,7 +4227,7 @@ const result = await prisma.post.findMany({
 
 ### `isNot`
 
-Returns all records where related record matches filtering criteria (for example, user's name `isNot` Bob).
+Returns all records where the related record does not match the filtering criteria (for example, user's name `isNot` Bob).
 
 #### Examples
 


### PR DESCRIPTION
A PR to fix the typo for isNot definition