### PR TITLE
fix: #2947 vertical alignment/padding for bloquote content

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -463,7 +463,7 @@ blockquote {
   color: var(--code-inner-color);
   padding-left: 2rem;
   padding-bottom: 8px;
-  padding-bottom: 8px;
+  padding-top: 8px;
   margin: 2rem 0px;
   position: relative;
 }
@@ -477,6 +477,7 @@ blockquote::before {
   position: absolute;
   width: 8px;
   height: 100%;
+  top: 0;
   left: 0px;
   background: var(--code-bgd-color);
   border-radius: 5px;


### PR DESCRIPTION
As seen here: https://fix-2947-blockquote-alignmen.docs-51g.pages.dev/getting-started/setup-prisma/start-from-scratch/relational-databases-node-cockroachdb
| | |
|----- |----- |
| <img width="528" alt="Screenshot 2024-12-04 at 13 51 14" src="https://github.com/user-attachments/assets/e33f4a54-22bd-4602-a62d-c4092b2424ba"> | <img width="580" alt="Screenshot 2024-12-04 at 13 48 18" src="https://github.com/user-attachments/assets/f52b61bc-ab5f-4e67-bce2-3cb80595b3d7"> |
