### PR TITLE
feat: #5969 Add custom button for MDX usage

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -27,9 +27,9 @@ type Button = {
 
 // Button component that accepts the specified props.
 export default function Button ({ 
-    variant = 'secondary', 
+    variant = 'primary', 
     disabled = false, 
-    color = 'teal',
+    color = 'indigo',
     leftIcon,
     className, 
     style, 

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,63 @@
+import Link from '@docusaurus/Link';
+import clsx from 'clsx';
+import React, { CSSProperties } from 'react';
+import styles from "./styles.module.scss";
+import { Icon } from '../Icon';
+
+// Define the Button type to control the props that can be passed to the Button component.
+type Button = {
+    // The variant prop is a string that determines the color of the button.
+    // It can be one of the following values: 'primary', 'secondary', 'danger', 'warning', 'success', 'info', 'link', or any other string.
+    // The default value is 'primary'.
+    variant: 'primary' | 'secondary' | 'link';
+    
+    color: 'indigo' | 'teal' | null;
+    // The disabled prop is a boolean that determines if the button should be disabled.
+    disabled?: boolean;
+    leftIcon?: string;
+    // The className prop is a string that allows you to add custom classes to the button.
+    className?: string;
+    // The style prop is an object that allows you to add custom styles to the button.
+    style?: CSSProperties;
+    // The link prop is a string that determines the URL the button should link to.
+    link: string;
+    // The label prop is a string that determines the text of the button.
+    label: string;
+}
+
+// Button component that accepts the specified props.
+export default function Button ({ 
+    variant = 'secondary', 
+    disabled = false, 
+    color = 'teal',
+    leftIcon,
+    className, 
+    style, 
+    link, 
+    label 
+}: Button) {
+    const colorClass = color ? styles[`button--${color}`] : '';
+    const variantClass = variant ? styles[`button--${variant}`] : '';
+    const disabledClass = disabled ? styles['disabled'] : '';
+    // If the button is disabled, set the destination to null.
+    return (
+        <Link to={link}>
+            <button
+                className={clsx(
+                    styles['custom-button'],
+                    colorClass,
+                    variantClass,
+                    disabledClass,
+                    className
+                )}
+                style={style}
+                role='button'
+                aria-disabled={disabled}
+            >
+                {leftIcon && <Icon className={styles.leftIcon} icon={leftIcon} size='inherit' color='inherit' /> }
+                {label}
+                {(link || variant == 'link') && <Icon className={styles['fa-arrow-right']} icon='fa-regular fa-arrow-right' size='inherit' color='inherit' /> }
+            </button>
+        </Link>
+    );
+}

--- a/src/components/button/styles.module.scss
+++ b/src/components/button/styles.module.scss
@@ -1,0 +1,122 @@
+.custom-button {
+  padding: 6px 12px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 150ms ease-in-out;
+  white-space: nowrap;
+  font-family: Barlow;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 20px;
+  text-align: center;
+  .leftIcon {
+    margin-right: 4px;
+  }
+  .fa-arrow-right {
+    transition: all 150ms ease-in-out;
+    transition: translateX(4px);
+    margin-left: 4px;
+  }
+  &:hover:not(&.disabled) {
+    .fa-arrow-right {
+      transform: translateX(4px);
+    }
+  }
+
+  &.button--indigo {
+    &.button--primary {
+      border-color: var(--indigo-600);
+      background-color: var(--indigo-600);
+      color: var(--white-color);
+      &:hover {
+        background-color: var(--indigo-700);
+      }
+      &:focus {
+        background-color: var(--indigo-600);
+        border-color: var(--indigo-100);
+      }
+    }
+    &.button--secondary {
+      background-color: var(--white-color);
+      border-color: var(--indigo-600);
+      color: var(--indigo-600);
+      border-width: 2px;
+      &:hover {
+        color: var(--indigo-700);
+        border-color: var(--indigo-700);
+      }
+      &:focus {
+        border-color: var(--indigo-600);
+        color: var(--indigo-600);
+      }
+    }
+    &.button--link {
+      background-color: transparent;
+      padding: 0;
+      text-decoration: underline;
+      color: var(--indigo-600);
+      text-underline-offset: 2px;
+      &:hover {
+        color: var(--indigo-700);
+      }
+      > *:not(i) {
+        text-decoration: underline;
+      }
+    }
+  }
+  &.button--teal {
+    &.button--primary {
+      border-color: var(--teal-600);
+      background-color: var(--teal-600);
+      color: var(--white-color);
+      &:hover {
+        background-color: var(--teal-700);
+      }
+      &:focus {
+        background-color: var(--teal-600);
+        border-color: var(--teal-100);
+      }
+    }
+    &.button--secondary {
+      background-color: var(--white-color);
+      border-color: var(--teal-600);
+      color: var(--teal-600);
+      border-width: 2px;
+      &:hover {
+        color: var(--teal-700);
+        border-color: var(--teal-700);
+      }
+      &:focus {
+        border-color: var(--teal-600);
+        color: var(--teal-600);
+      }
+    }
+    &.button--link {
+      background-color: transparent;
+      padding: 0;
+      text-decoration: underline;
+      color: var(--teal-600);
+      text-underline-offset: 2px;
+      &:hover {
+        color: var(--teal-700);
+      }
+      > *:not(i) {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    color: #CBD5E0 !important;
+    &.button--primary {
+      background: #F7FAFC !important;
+      border-color: #F7FAFC !important;
+    }
+    &.button--secondary {
+      border-color: #E2E8F0 !important;
+      background-color: var(--white) !important;
+    }
+  }
+}

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -16,6 +16,7 @@ import TopSection from "@site/src/components/topSection";
 import { useLocation } from "@docusaurus/router";
 import styles from "./styles.module.scss";
 import clsx from "clsx";
+import Button from "../components/button/Button";
 
 // TODO: do we want to fix this?
 const TopBlock: React.FC<React.PropsWithChildren> = ({
@@ -193,5 +194,6 @@ export default {
   table: (p: any) => <div className="mdx-table"><table {...p}>{p.children}</table></div>,
   ParallelBlocks,
   ButtonLink,
+  Button,
   NavigationLinksContainer,
 };


### PR DESCRIPTION
⚠️ I miswrote the name of the branch... issue should be #5969 

Resolves WEB-353
Resolves DA-839

Adds these buttons to our repo, which you can use by writing:

```mdx
<Button label="Click me" link="#using" variant="secondary" leftIcon={"fa-regular fa-arrow-left"} disabled />
```

| indigo | teal |
| ----- | ----- |
| <img width="123" alt="Screenshot 2024-12-04 at 15 04 13" src="https://github.com/user-attachments/assets/a0d08f7f-ef66-48c2-b715-fb754e985353"> | <img width="107" alt="Screenshot 2024-12-04 at 15 04 54" src="https://github.com/user-attachments/assets/1fa98c0c-a057-4f39-ad90-e3b5f16d5ca2">|
| <img width="105" alt="Screenshot 2024-12-04 at 15 05 16" src="https://github.com/user-attachments/assets/91c3fae3-88c5-4503-92d2-269a7e59ff40"> |  <img width="102" alt="Screenshot 2024-12-04 at 15 05 21" src="https://github.com/user-attachments/assets/fb16c58a-7730-4af9-a3e1-d1f55716c5ef"> |
|  <img width="86" alt="Screenshot 2024-12-04 at 15 05 50" src="https://github.com/user-attachments/assets/c05fe45f-2fa0-4af8-8af1-c65d48b7b9fb"> |  <img width="93" alt="Screenshot 2024-12-04 at 15 05 57" src="https://github.com/user-attachments/assets/989c7664-4803-414c-849b-96b069bf86d1"> |

