### PR TITLE
Docs for referencing extended model types

### DIFF
--- a/content/200-orm/200-prisma-client/300-client-extensions/index.mdx
+++ b/content/200-orm/200-prisma-client/300-client-extensions/index.mdx
@@ -186,6 +186,48 @@ function getExtendedClient() {
 type ExtendedPrismaClient = ReturnType<typeof getExtendedClient>
 ```
 
+## Extending model types with `Prisma.Result`
+
+You can use the `Prisma.Result` type utility to extend model types to include properties added via client extensions. This allows you to infer the type of the extended model, including the extended properties.
+
+### Example
+
+The following example demonstrates how to use `Prisma.Result` to extend the `User` model type to include a `__typename` property added via a client extension.
+
+```ts
+import { PrismaClient, Prisma } from '@prisma/client'
+
+const prisma = new PrismaClient().$extends({
+  result: {
+    user: {
+      __typename: {
+        needs: {},
+        compute() {
+          return 'User'
+        },
+      },
+    },
+  },
+})
+
+type ExtendedUser = Prisma.Result<typeof prisma.user, { select: { id: true } }, 'findFirstOrThrow'>
+
+async function main() {
+  const user: ExtendedUser = await prisma.user.findFirstOrThrow({
+    select: {
+      id: true,
+      __typename: true,
+    },
+  })
+
+  console.log(user.__typename) // Output: 'User'
+}
+
+main()
+```
+
+The `Prisma.Result` type utility is used to infer the type of the extended `User` model, including the `__typename` property added via the client extension.
+
 ## Limitations
 
 ### Usage of `$on` and `$use` with extended clients


### PR DESCRIPTION
Fixes #5058

Adds a new section on how to use `Prisma.Result` to get the type of an extended model.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/prisma/docs/pull/6505?shareId=5b2bd4ab-a6d2-4d5d-bb5b-880c356424d6).