### PR TITLE
Add troubleshooting tip for Aiven MySQL connection issue with ssl-mode parameter

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -88,6 +88,7 @@
     "autoscale"
   ],
   "ignoreWords": [
+    "Aiven",
     "Ania",
     "Koyeb",
     "Neward",

--- a/content/300-accelerate/650-troubleshoot.mdx
+++ b/content/300-accelerate/650-troubleshoot.mdx
@@ -124,3 +124,22 @@ If the database’s server address (hostname) and port are incorrect or unreacha
 This error can happen when the wrong credentials are provided to Prisma Accelerate, preventing it from establishing a connection to your database.
 
 **Suggested solution:** Verify the correctness of your database's username, password, and name in the connection string provided to Prisma Accelerate. Ensure that these credentials match those required by your database. Testing the connection using a direct database GUI tool can also help in confirming if the provided credentials are correct.
+
+## Other errors
+
+### Error with MySQL (Aiven): "We were unable to process your request. Please refresh and try again."
+
+**Issue**  
+When using an Aiven MySQL connection string that includes the `?ssl-mode=REQUIRED` parameter, you may encounter the following error:  
+*We were unable to process your request. Please refresh and try again.*
+
+**Cause**  
+The `ssl-mode=REQUIRED` parameter is incompatible with Accelerate, which leads to connection issues.
+
+**Suggested Solution**  
+To resolve this error, remove the `?ssl-mode=REQUIRED` parameter from your MySQL connection string.
+
+**Example**  
+Original connection string: `mysql://username:password@host:port/database?ssl-mode=REQUIRED`
+
+Updated connection string:  `mysql://username:password@host:port/database`

--- a/content/300-accelerate/650-troubleshoot.mdx
+++ b/content/300-accelerate/650-troubleshoot.mdx
@@ -129,17 +129,23 @@ This error can happen when the wrong credentials are provided to Prisma Accelera
 
 ### Error with MySQL (Aiven): "We were unable to process your request. Please refresh and try again."
 
-**Issue**  
-When using an Aiven MySQL connection string that includes the `?ssl-mode=REQUIRED` parameter, you may encounter the following error:  
-*We were unable to process your request. Please refresh and try again.*
+#### Issue
 
-**Cause**  
+When using an Aiven MySQL connection string that includes the `?ssl-mode=REQUIRED` parameter, you may encounter the following error:  
+
+```
+We were unable to process your request. Please refresh and try again.
+```
+
+#### Cause
+
 The `ssl-mode=REQUIRED` parameter is incompatible with Accelerate, which leads to connection issues.
 
-**Suggested Solution**  
+#### Suggested solution 
+
 To resolve this error, remove the `?ssl-mode=REQUIRED` parameter from your MySQL connection string.
 
-**Example**  
-Original connection string: `mysql://username:password@host:port/database?ssl-mode=REQUIRED`
+#### Example
 
-Updated connection string:  `mysql://username:password@host:port/database`
+- Original connection string: `mysql://username:password@host:port/database?ssl-mode=REQUIRED`
+- Updated connection string:  `mysql://username:password@host:port/database`


### PR DESCRIPTION
Added a new section under "Other errors" in the troubleshooting docs to address an issue where Aiven MySQL users encounter an error when using `?ssl-mode=REQUIRED` in their connection string on Accelerate. Provided the solution to remove the parameter and included an example.

This is based on this [discord](https://discord.com/channels/937751382725886062/1305848713259909193/1305848713259909193) thread.