### PR TITLE
Add Limitation for Result Client Extension

### DIFF
--- a/content/200-orm/200-prisma-client/300-client-extensions/130-result.mdx
+++ b/content/200-orm/200-prisma-client/300-client-extensions/130-result.mdx
@@ -202,3 +202,22 @@ const user = await xprisma.user.findFirstOrThrow({
 })
 ```
 In this case, omitting both `password` and `sanitizedPassword` will exclude both from the result as well as prevent the `password` field from being read from the database.
+
+## Limitation
+As of now, Prisma Client's result extension component does not support relation fields. This means that you cannot create custom fields or methods based on related models or fields in a relational relationship (e.g., user.posts, post.author). The needs parameter can only reference scalar fields within the same model. Follow [issue #20091 on GitHub](https://github.com/prisma/prisma/issues/20091).
+
+
+```ts
+const prisma = new PrismaClient().$extends({
+  result: {
+    user: {
+      postsCount: {
+        needs: { posts: true }, // This will not work because posts is a relation field
+        compute(user) {
+          return user.posts.length; // Accessing a relation is not allowed
+        },
+      },
+    },
+  },
+})
+```


### PR DESCRIPTION
This PR introduces a new `Limitation` section in the documentation of Prisma Client Extensions, specifically addressing the limitation that relation fields are not supported within the Result Client Extension component. 

This is based on this [discord](https://discord.com/channels/937751382725886062/1319424725767819264) conversation.