### PR TITLE
Add instruction about specifiying timeout value in Interactive Transaction

### DIFF
--- a/content/300-accelerate/250-connection-pooling.mdx
+++ b/content/300-accelerate/250-connection-pooling.mdx
@@ -91,6 +91,19 @@ Accelerate has a default global timeout of `15s` for each [interactive transacti
 
 See the [troubleshooting guide](/accelerate/troubleshoot#p6004-querytimeout) and our [pricing page](https://www.prisma.io/pricing#accelerate) for more information.
 
+When you set a higher interactive transaction timeout in the Prisma Console, you **must also** specify a matching `timeout` value in your interactive transaction query via timeout [transaction option](/orm/prisma-client/queries/transactions#transaction-options). Otherwise, transactions will still time out at the lower default (e.g., 5 seconds limit when no timeout value is specified). Here’s an example of how to set a 30-second timeout in your code:
+
+```ts
+await prisma.$transaction(
+  async (tx) => {
+    // Your queries go here
+  },
+  {
+    timeout: 30000, // 30s
+  }
+);
+```
+
 :::warning
 While you can increase the interactive transaction timeout limit, it’s recommended to inspect and optimize your database transactions if they take longer than 15 seconds. Long-running transactions can negatively impact performance and often signal the need for optimization. Learn more in the [troubleshooting guide](/accelerate/troubleshoot#p6004-querytimeout) and review the [warning in the Interactive Transactions section](/orm/prisma-client/queries/transactions#interactive-transactions-1) in our documentation.
 :::


### PR DESCRIPTION
It is mandatory to specify `timeout` value when interactive transaction duration is increased. 