### PR TITLE
Showcase `enable` property of Optimize extension

### DIFF
--- a/content/700-optimize/600-faq.mdx
+++ b/content/700-optimize/600-faq.mdx
@@ -29,3 +29,17 @@ They are counted based on viewed recommendations. Once you click on a recommenda
 ## Can I use Prisma Optimize in production?
 
 No, Prisma Optimize is not intended for production use. It is specifically designed for local development, providing valuable insights and optimizations during that phase. While it’s technically possible to run it in a production environment, doing so could result in performance problems or unexpected behaviors, as Optimize is not built to handle the complexity and scale of production workloads. For the best experience, we recommend using Prisma Optimize solely in your development environment.
+
+You can use the `enable` property in the Optimize extension to run Optimize only in development envrioment. By default, the `enable` property is set to `true`.
+
+```ts file=script.ts copy showLineNumbers
+import { PrismaClient } from '@prisma/client'
+import { withOptimize } from "@prisma/extension-optimize"
+
+const prisma = new PrismaClient().$extends(
+  withOptimize({
+    apiKey: process.env.OPTIMIZE_API_KEY,
+    enable: process.env.ENVIRONMENT === 'development',
+  })
+);
+```


### PR DESCRIPTION
`enable` property can be used to easily configure environments in which Optimize should run. This example snippet adds an example showcasing how Optimize can be enabled only for development environment.