### PR TITLE
Fix syntax for composite type filters in Prisma documentation examples

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -4837,11 +4837,11 @@ Use `every` to filter for lists of composite types where every item in the list 
 ##### Find the first product where every photo has a `height` of `200`
 
 ```ts
-const product = prisma.product.findFirst({
+const product = await prisma.product.findFirst({
   where: {
     photos: {
       every: {
-        { height: 200 },
+        height: 100,
       }
     }
   },
@@ -4857,11 +4857,11 @@ Use `some` to filter for lists of composite types where one or more items in the
 ##### Find the first product where one or more photos have a `url` of `2.jpg`
 
 ```ts
-const product = prisma.product.findFirst({
+const product = await prisma.product.findFirst({
   where: {
     photos: {
       some: {
-        { url: "2.jpg" },
+         url: "2.jpg",
       }
     }
   },
@@ -4877,16 +4877,15 @@ Use `none` to filter for lists of composite types where no items in the list mat
 ##### Find the first product where no photos have a `url` of `2.jpg`
 
 ```ts
-const product = prisma.product.findFirst({
+const product = await prisma.product.findFirst({
   where: {
     photos: {
       none: {
-        { url: "2.jpg" },
+         url: "2.jpg",
       }
     }
   },
 })
-
 ```
 
 ## Atomic number operations


### PR DESCRIPTION
This PR adds a fix for the syntax issues in [#6545](https://github.com/prisma/docs/issues/6545)