### PR TITLE
fix spelling of environment in Optimize FAQ

### DIFF
--- a/content/700-optimize/600-faq.mdx
+++ b/content/700-optimize/600-faq.mdx
@@ -30,7 +30,7 @@ They are counted based on viewed recommendations. Once you click on a recommenda
 
 No, Prisma Optimize is not intended for production use. It is specifically designed for local development, providing valuable insights and optimizations during that phase. While it’s technically possible to run it in a production environment, doing so could result in performance problems or unexpected behaviors, as Optimize is not built to handle the complexity and scale of production workloads. For the best experience, we recommend using Prisma Optimize solely in your development environment.
 
-You can use the `enable` property in the Optimize extension to run Optimize only in development envrioment. By default, the `enable` property is set to `true`.
+You can use the `enable` property in the Optimize extension to run Optimize only in development environment. By default, the `enable` property is set to `true`.
 
 ```ts file=script.ts copy showLineNumbers
 import { PrismaClient } from '@prisma/client'


### PR DESCRIPTION
This PR fixes the spelling of environment in the Optimize FAQ 