### PR TITLE
Clarify Prisma v6 schema changes for CockroachDB users

### DIFF
--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/500-upgrading-to-prisma-6.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/500-upgrading-to-prisma-6.mdx
@@ -75,6 +75,13 @@ There is _no_ official support for Node.js 16, 17, 19 and 21.
 
 The new minimum supported TypeScript version for Prisma ORM v6 is: **5.1.0**.
 
+<Admonition type="info">
+
+This schema change only applies to PostgreSQL.  
+If you are using CockroachDB, you do not need to take any action—the schema for implicit m-to-n relationships remains unchanged.
+
+</Admonition>
+
 ### Schema change for implicit m-n relations on PostgreSQL
 
 If you're using PostgreSQL and are defining [implicit many-to-many relations](/orm/prisma-schema/data-model/relations/many-to-many-relations#implicit-many-to-many-relations) in your Prisma schema, Prisma ORM maintains the [relation table](/orm/prisma-schema/data-model/relations/many-to-many-relations#relation-tables) for you under the hood. This relation table has `A` and `B` columns to represent the tables of the models that are part of this relation.

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/500-upgrading-to-prisma-6.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/500-upgrading-to-prisma-6.mdx
@@ -75,12 +75,12 @@ There is _no_ official support for Node.js 16, 17, 19 and 21.
 
 The new minimum supported TypeScript version for Prisma ORM v6 is: **5.1.0**.
 
-<Admonition type="info">
+:::info
 
 This schema change only applies to PostgreSQL.  
 If you are using CockroachDB, you do not need to take any action—the schema for implicit m-to-n relationships remains unchanged.
 
-</Admonition>
+:::
 
 ### Schema change for implicit m-n relations on PostgreSQL
 


### PR DESCRIPTION
Added an admonition to specify that the schema changes for implicit m-to-n relationships in Prisma v6 only apply to PostgreSQL.  CockroachDB users do not need to take any action as their schema remains unchanged.

Link to [Discord](https://discord.com/channels/937751382725886062/1328674641019015221/1328674641019015221) conversation and Internal [Slack](https://prisma-company.slack.com/archives/C04QXS1E3A6/p1736863690570069) conversation.