### PR TITLE
Add FAQ: How to switch from GitHub login to email and password login

### DIFF
--- a/content/300-accelerate/600-faq.mdx
+++ b/content/300-accelerate/600-faq.mdx
@@ -200,3 +200,21 @@ Using on-demand cache invalidation in these scenarios helps keep only the necess
 ## How does Accelerate count queries for billing?
 
 Accelerate counts queries at the Prisma Client invocation level. A single Prisma query may translate into multiple SQL statements under the hood, but it will only count as one query for billing purposes. This ensures straightforward, predictable billing that reflects the Prisma Client usage rather than the complexity of the underlying SQL operations.
+
+## How do I switch from GitHub login to email and password login?
+
+If you previously signed up using GitHub and want to switch to email and password login, follow these steps:
+
+### 1. Verify Your GitHub Email Address
+- Check the primary email address associated with your GitHub account (e.g., from your GitHub profile or notification settings).
+
+### 2. Create a New Email/Password Account
+- Go to the email/password sign-up page.
+- Use the **same email address** linked to your GitHub account to create the new account.
+- Our system will automatically connect your new email/password account to your existing data.
+
+### 3. Test Your Login
+- Log out and try logging in with your email and the password you just created.
+
+> **Note**: If you encounter any issues, please contact our support team for help linking your accounts.
+


### PR DESCRIPTION
This update introduces a FAQ entry that guides users through the process of transitioning from GitHub-based authentication to email and password login. The steps include:

1. Verifying the email address linked to the user's GitHub account.
2. Creating a new email/password account using the same email to ensure data continuity.
3. Testing the new login credentials.

The FAQ also includes a note advising users to contact support if any issues arise during the transition. This addition aims to improve user onboarding.

Link to internal Slack [conversation](https://prisma-company.slack.com/archives/C042HLMAC5U/p1737038038758259)