### PR TITLE
Add explanation of connection pooling and autoscaling in Accelerate

### DIFF
--- a/content/300-accelerate/250-connection-pooling.mdx
+++ b/content/300-accelerate/250-connection-pooling.mdx
@@ -34,6 +34,15 @@ When not using Prisma Accelerate, you can configure the connection pool of Prism
 
 Autoscaling allows Accelerate to dynamically allocate resources based on your application's traffic. As consistent usage approaches the current connection limit, Accelerate will begin allocating new resources to handle the increased load. If traffic continues to rise, Accelerate will scale up further. Conversely, when traffic decreases, Accelerate will scale down accordingly.
 
+*To provide more context, Accelerate horizontally scales your environment by distributing the total available connections across multiple Query Engine instances. For example:*
+
+- If your environment connection limit is set to 1000, Accelerate will scale up to multiple Query Engine instances (e.g., 100 instances).
+- Each Query Engine instance is then assigned a share of the total connections— in this case, 10 connections per instance.
+- This is why an individual Query Engine instance reports a connection limit of 10, even though the total connection limit for the environment is 1000.
+
+*This scaling mechanism ensures that your application can handle higher traffic loads by increasing the number of Query Engine instances while keeping the connection pool management efficient and distributed.*
+
+
 Autoscaling is enabled when the Accelerate connection limit is set above the default value. This feature is not available on the Starter plan.
 
 The maximum value of your Accelerate connection limit is based on your [Prisma Data Platform plan](https://www.prisma.io/pricing). 


### PR DESCRIPTION

Explain how Prisma Accelerate handles connection pooling across multiple Query Engine instances. Added details on how the total connection limit is distributed among instances when autoscaling is enabled. Explained the mechanism behind individual instance connection limits and the overall scaling process. This helps users understand how Accelerate efficiently manages connections and scales resources in high-traffic environments.

Internal [conversation](https://prisma-company.slack.com/archives/C06R7FTQBST/p1736808886196309) on Slack