### PR TITLE
chore: Add FAQ entry about using local databases with Prisma Pulse

### DIFF
--- a/content/400-pulse/600-faq.mdx
+++ b/content/400-pulse/600-faq.mdx
@@ -176,3 +176,12 @@ Yes, users can manually create and manage replication slots. However, Pulse does
 The `walsender_timeout` configuration parameter is a timeout setting that determines the maximum amount of time a WAL sender process (used in replication) will wait for a response from a WAL receiver before disconnecting. It usually defaults to 60 seconds.
 
 Setting a value smaller than 10 seconds may cause connection issues with Pulse.
+
+### Can I use a local database with Prisma Pulse during development?
+
+Prisma Pulse requires a database that is accessible via the network to connect and function correctly. This means it won't work with a locally running database on `localhost`.
+
+If you need to expose a local database for development purposes, you can use a tunneling tool like [ngrok](https://ngrok.com) or a similar solution to make it accessible over the network. However, keep in mind that this setup is primarily for testing and development purposes and may introduce additional security risks. 
+
+For production and best practices, we recommend using a hosted database.
+


### PR DESCRIPTION
This update adds a new FAQ entry addressing whether Prisma Pulse can work with a local database during development. It explains that Pulse requires a network-accessible database and does not support databases running on localhost. The entry also provides a workaround using tools like ngrok for testing purposes, while emphasizing the recommendation to use hosted databases for production environments.

This is based on this [discord conversation](https://discord.com/channels/937751382725886062/1331750113382760559/1331750113382760559)