### PR TITLE
tweak: ⚙️ remove password k/v pair

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/035-select-fields.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/035-select-fields.mdx
@@ -319,7 +319,6 @@ const users = await prisma.user.findFirst({
   id: 9
   name: "Sabelle",
   email: "sabelle@prisma.io",
-  password: "mySecretPassword4",
   profileViews: 90,
   role: "USER",
   coinflips: [],


### PR DESCRIPTION
Removes the K/V Pair from the docs, because the sentence underneath says "notice how it DOESNT show up", whilst showing a JSON object containing what we're showing we're "omitting".

![{9BD4E6D3-CF94-4F56-A76E-6158E8F31350}](https://github.com/user-attachments/assets/f6eab4db-541f-409d-baa0-0c4267af8106)
