### PR TITLE
update PPg env vars

### DIFF
--- a/content/800-guides/090-prisma-orm-with-nextjs.mdx
+++ b/content/800-guides/090-prisma-orm-with-nextjs.mdx
@@ -124,18 +124,11 @@ If you don't have a database yet, you can create a new one through the [Prisma C
 
 :::
 
-When you have created your Prisma Postgres project, you'll get a `DATABASE_URL` and `PULSE_API_KEY`. Store these in your `.env` file.
+When you have created your Prisma Postgres project, you'll get a `DATABASE_URL`. Store it in your `.env` file.
 
 ```env file=.env
-DATABASE_URL=[Your Database URL Here]
-PULSE_API_KEY=[Your Pulse API Key Here]
+DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=eyJhbGciOiJIU...""
 ```
-
-:::info
-
-If you're not using Prisma Postgres you won't need the `PULSE_API_KEY` here.
-
-:::
 
 ### 2.3 Update your database schema
 


### PR DESCRIPTION
removes the `PULSE_API_KEY` as Pulse is no longer automatically provisioned for new Prisma Postgres instances.