### PR TITLE
docs: clarify dependency management and version synchronization in monorepo

### DIFF
--- a/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
@@ -60,7 +60,7 @@ Monorepos allow multiple projects to share code and dependencies, making them a 
 
 - **Centralize the Prisma Schema**: Place the `schema.prisma` file in a shared package, such as `@myorg/db`, to ensure consistency.
 - **Use a Custom Output Directory for Generated Client**: Define a [custom output directory](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path) for the generated Prisma Client to maintain consistency across packages.
-- **Install Dependencies in the Root**: To prevent version conflicts, install Prisma ORM at the root of the monorepo. If individual packages need direct access to Prisma (e.g., for local client generation), install it within those packages as well. You can use a monorepo tool like Turborepo, following its [best practices](https://turbo.build/repo/docs/crafting-your-repository/managing-dependencies#keeping-dependencies-on-the-same-version), or adopt a similar strategy to keep dependencies synchronized across your app.
+- **Install dependencies in the root**: To prevent version conflicts, install Prisma ORM at the root of the monorepo. If individual packages need direct access to Prisma (e.g., for local client generation), install it within those packages as well. You can use a monorepo tool like Turborepo, following its [best practices](https://turbo.build/repo/docs/crafting-your-repository/managing-dependencies#keeping-dependencies-on-the-same-version), or adopt a similar strategy to keep dependencies synchronized across your app.
 - **Use NPM Scripts for Generation**:
 
   ```json

--- a/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
@@ -59,16 +59,17 @@ Monorepos allow multiple projects to share code and dependencies, making them a 
 #### Best practices for monorepo integration
 
 - **Centralize the Prisma Schema**: Place the `schema.prisma` file in a shared package, such as `@myorg/db`, to ensure consistency.
-- **Install Dependencies in the Root**: Avoid version conflicts by installing Prisma ORM as a dependency at the root of the monorepo.
+- **Use a Custom Output Directory for Generated Client**: Define a [custom output directory](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path) for the generated Prisma Client to maintain consistency across packages.
+- **Install Dependencies in the Root**: To prevent version conflicts, install Prisma ORM at the root of the monorepo. If individual packages need direct access to Prisma (e.g., for local client generation), install it within those packages as well. You can use a monorepo tool like Turborepo, following its [best practices](https://turbo.build/repo/docs/crafting-your-repository/managing-dependencies#keeping-dependencies-on-the-same-version), or adopt a similar strategy to keep dependencies synchronized across your app.
 - **Use NPM Scripts for Generation**:
 
-```json
-{
-  "scripts": {
-    "prisma:generate": "prisma generate --schema=./packages/db/schema.prisma"
-  }
-}
-```
+  ```json
+    {
+      "scripts": {
+        "prisma:generate": "prisma generate --schema=./packages/db/schema.prisma"
+      }
+    }
+  ```
 
 This approach keeps your Prisma Schema and generated client in sync across all projects in the monorepo.
 

--- a/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
@@ -59,7 +59,7 @@ Monorepos allow multiple projects to share code and dependencies, making them a 
 #### Best practices for monorepo integration
 
 - **Centralize the Prisma Schema**: Place the `schema.prisma` file in a shared package, such as `@myorg/db`, to ensure consistency.
-- **Use a Custom Output Directory for Generated Client**: Define a [custom output directory](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path) for the generated Prisma Client to maintain consistency across packages.
+- **Use a custom output directory for generated client**: Define a [custom output directory](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path) for the generated Prisma Client to maintain consistency across packages.
 - **Install dependencies in the root**: To prevent version conflicts, install Prisma ORM at the root of the monorepo. If individual packages need direct access to Prisma (e.g., for local client generation), install it within those packages as well. You can use a monorepo tool like Turborepo, following its [best practices](https://turbo.build/repo/docs/crafting-your-repository/managing-dependencies#keeping-dependencies-on-the-same-version), or adopt a similar strategy to keep dependencies synchronized across your app.
 - **Use NPM Scripts for Generation**:
 

--- a/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
@@ -59,7 +59,7 @@ Monorepos allow multiple projects to share code and dependencies, making them a 
 #### Best practices for monorepo integration
 
 - **Centralize the Prisma Schema**: Place the `schema.prisma` file in a shared package, such as `@myorg/db`, to ensure consistency.
-- **Use a Custom Output Directory for Generated Client**: Define a [custom output directory](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path) for the generated Prisma Client to maintain consistency across packages.
+- **Use a Custom Output Directory for Generated Client**: Define a [custom output directory](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path) for the generated Prisma Client to maintain consistency across packages.
 - **Install Dependencies in the Root**: To prevent version conflicts, install Prisma ORM at the root of the monorepo. If individual packages need direct access to Prisma (e.g., for local client generation), install it within those packages as well. You can use a monorepo tool like Turborepo, following its [best practices](https://turbo.build/repo/docs/crafting-your-repository/managing-dependencies#keeping-dependencies-on-the-same-version), or adopt a similar strategy to keep dependencies synchronized across your app.
 - **Use NPM Scripts for Generation**:
 


### PR DESCRIPTION
Clarified best practices for installing Prisma ORM in a monorepo, explaining when to install it at the root vs. within individual packages. Updated wording to use Turborepo as an example for version synchronization.

This is based off of this [docs issue](https://github.com/prisma/docs/issues/6608)