### PR TITLE
chore: Add documentation on counting large MongoDB collections

### DIFF
--- a/content/200-orm/050-overview/500-databases/600-mongodb.mdx
+++ b/content/200-orm/050-overview/500-databases/600-mongodb.mdx
@@ -49,6 +49,13 @@ MongoDB's document-based structure and flexible schema means that using Prisma O
 
 - **Enabling replication**: Prisma ORM uses [MongoDB transactions](https://www.mongodb.com/docs/manual/core/transactions/) internally to avoid partial writes on nested queries. When using transactions, MongoDB requires replication of your data set to be enabled. To do this, you will need to configure a [replica set](https://www.mongodb.com/docs/manual/replication/) — this is a group of MongoDB processes that maintain the same data set. Note that it is still possible to use a single database, by creating a replica set with only one node in it. If you use MongoDB's [Atlas](https://www.mongodb.com/atlas/database) hosting service, the replica set is configured for you, but if you are running MongoDB locally you will need to set up a replica set yourself. For more information, see MongoDB's [guide to deploying a replica set](https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set/).
 
+- **Performance considerations for large collections**: When working with large MongoDB collections through Prisma, it's important to be aware of certain performance implications that differ from relational databases:
+  1. **Counting large collections**: Operations that require scanning the entire collection, such as count(), can be slow and resource-intensive on very large datasets. MongoDB may hit query execution time limits in these cases.
+  2. **Alternative counting methods**: For large collections, consider using MongoDB's [estimatedDocumentCount()](https://www.mongodb.com/docs/manual/reference/method/db.collection.estimatedDocumentCount/) instead of count(). This method is much faster as it uses metadata about the collection. You can use Prisma's `runCommandRaw` to execute this command:
+  3. **Counter caches**: For frequently accessed counts, consider implementing a counter cache. This involves maintaining a separate document with pre-calculated counts that you update whenever documents are added or removed.
+
+
+
 ## How to use Prisma ORM with MongoDB
 
 This section provides instructions for how to carry out tasks that require steps specific to MongoDB.

--- a/content/200-orm/050-overview/500-databases/600-mongodb.mdx
+++ b/content/200-orm/050-overview/500-databases/600-mongodb.mdx
@@ -49,11 +49,16 @@ MongoDB's document-based structure and flexible schema means that using Prisma O
 
 - **Enabling replication**: Prisma ORM uses [MongoDB transactions](https://www.mongodb.com/docs/manual/core/transactions/) internally to avoid partial writes on nested queries. When using transactions, MongoDB requires replication of your data set to be enabled. To do this, you will need to configure a [replica set](https://www.mongodb.com/docs/manual/replication/) — this is a group of MongoDB processes that maintain the same data set. Note that it is still possible to use a single database, by creating a replica set with only one node in it. If you use MongoDB's [Atlas](https://www.mongodb.com/atlas/database) hosting service, the replica set is configured for you, but if you are running MongoDB locally you will need to set up a replica set yourself. For more information, see MongoDB's [guide to deploying a replica set](https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set/).
 
-- **Performance considerations for large collections**: When working with large MongoDB collections through Prisma, it's important to be aware of certain performance implications that differ from relational databases:
-  1. **Counting large collections**: Operations that require scanning the entire collection, such as count(), can be slow and resource-intensive on very large datasets. MongoDB may hit query execution time limits in these cases.
-  2. **Alternative counting methods**: For large collections, consider using MongoDB's [estimatedDocumentCount()](https://www.mongodb.com/docs/manual/reference/method/db.collection.estimatedDocumentCount/) instead of count(). This method is much faster as it uses metadata about the collection. You can use Prisma's `runCommandRaw` to execute this command:
-  3. **Counter caches**: For frequently accessed counts, consider implementing a counter cache. This involves maintaining a separate document with pre-calculated counts that you update whenever documents are added or removed.
+### Performance considerations for large collections
+#### Problem 
+When working with large MongoDB collections through Prisma, certain operations can become slow and resource-intensive. In particular, operations that require scanning the entire collection, such as `count()`, can hit query execution time limits and significantly impact performance as your dataset grows.
 
+#### Solution
+To address performance issues with large MongoDB collections, consider the following approaches:
+
+1. For large collections, consider using MongoDB's `estimatedDocumentCount()` instead of `count()`. This method is much faster as it uses metadata about the collection. You can use Prisma's `runCommandRaw` method to execute this command.
+
+2. For frequently accessed counts, consider implementing a counter cache. This involves maintaining a separate document with pre-calculated counts that you update whenever documents are added or removed.
 
 
 ## How to use Prisma ORM with MongoDB


### PR DESCRIPTION
Documentation regarding performance considerations for large MongoDB collections, specifically focusing on counting operations. The update highlights potential issues with `count()` on large datasets, suggests alternatives like `estimatedDocumentCount()`, and introduces the concept of counter caches for frequently accessed counts to optimize performance.

Closes #6638