### PR TITLE
Update index.mdx

### DIFF
--- a/content/200-orm/100-prisma-schema/20-data-model/20-relations/index.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/20-relations/index.mdx
@@ -385,7 +385,7 @@ Both `posts` and `author` are relation fields because their types are not scalar
 
 Also note that the [annotated relation field](#annotated-relation-fields) `author` needs to link the relation scalar field `authorId` on the `Post` model inside the `@relation` attribute. The relation scalar field represents the foreign key in the underlying database.
 
-The other relation field called `posts` is defined purely on a Prisma ORM-level, it doesn't manifest in the database.
+Both the relation fields (i.e. `posts` and `author`) are defined purely on a Prisma ORM-level, they don't manifest in the database.
 
 ### Annotated relation fields
 


### PR DESCRIPTION
The current text makes the reader think the `author` field will manifest in database, whereas both `author` and `posts` are on prisma ORM level and they don't manifest in the database.