### PR TITLE
exclude admin emails from user query

### DIFF
--- a/content/200-orm/200-prisma-client/100-queries/050-filtering-and-sorting.mdx
+++ b/content/200-orm/200-prisma-client/100-queries/050-filtering-and-sorting.mdx
@@ -87,7 +87,7 @@ Refer to Prisma Client's reference documentation for [a full list of operators](
 
 #### Combining operators
 
-You can use operators (such as [`NOT`](/orm/reference/prisma-client-reference#not-1) and [`OR`](/orm/reference/prisma-client-reference#or) ) to filter by a combination of conditions. The following query returns all users with an `email` that ends in `"prisma.io"` or `"gmail.com"`, but not `"hotmail.com"`:
+You can use operators (such as [`NOT`](/orm/reference/prisma-client-reference#not-1) and [`OR`](/orm/reference/prisma-client-reference#or) ) to filter by a combination of conditions. The following query returns all users whose `email` ends with `gmail.com` or `company.com`, but excludes any emails ending with `admin.company.com`
 
 <CodeWithResult>
 <cmd>
@@ -98,14 +98,14 @@ const result = await prisma.user.findMany({
     OR: [
       {
         email: {
-          endsWith: 'prisma.io',
+          endsWith: 'gmail.com',
         },
       },
-      { email: { endsWith: 'gmail.com' } },
+      { email: { endsWith: 'company.com' } },
     ],
     NOT: {
       email: {
-        endsWith: 'hotmail.com',
+        endsWith: 'admin.company.com',
       },
     },
   },
@@ -119,7 +119,7 @@ const result = await prisma.user.findMany({
 <cmdResult>
 
 ```json5 no-copy
-[{ email: 'yewande@prisma.io' }, { email: `raheem@gmail.com` }]
+[{ email: 'alice@gmail.com' }, { email: 'bob@company.com' }]
 ```
 
 </cmdResult>


### PR DESCRIPTION
Update example on filtering. 

See the internal [conversation](https://prisma-company.slack.com/archives/C0669F0FH3M/p1739215211479679) 