### PR TITLE
fix: broken link failing linkspector

### DIFF
--- a/content/200-orm/800-more/400-comparisons/04-prisma-and-drizzle.mdx
+++ b/content/200-orm/800-more/400-comparisons/04-prisma-and-drizzle.mdx
@@ -450,7 +450,7 @@ These products work hand-in-hand with Prisma ORM to offer comprehensive data too
 
 Both Drizzle and Prisma ORM have cases where users want to do something not directly supported by the library. Drizzle relies on the expressiveness of SQL to avoid these cases, while Prisma ORM has [Prisma Client extensions](/orm/prisma-client/client-extensions) to allow any user to add additional behaviors to their instance of Prisma Client. These extensions are also shareable, meaning teams can develop them for use across their projects or even for use by other teams.
 
-While Drizzle is a relatively new product, Prisma ORM was [released in 2021](https://www.prisma.io/blog/prisma-the-complete-orm-inw24qjeawmb) and is well established in the JavaScript/TypeScript space. It has proven value and many companies trust [Prisma ORM in production](https://www.prisma.io/showcase).
+While Drizzle is a relatively new product, Prisma ORM was [released in 2021](https://www.prisma.io/blog/how-prisma-orm-became-the-most-downloaded-orm-for-node-js) and is well established in the JavaScript/TypeScript space. It has proven value and many companies trust [Prisma ORM in production](https://www.prisma.io/showcase).
 
 Prisma ORM is also included as the data layer tool of choice in many meta-frameworks and development platforms like [Amplication](https://amplication.com/), [Wasp](https://wasp.sh/), [RedwoodJS](https://redwoodjs.com/), [KeystoneJS](https://keystonejs.com/), [Remix](https://remix.run/) and the [t3 stack](https://create.t3.gg/).
 


### PR DESCRIPTION
Replaces broken link with a more recent article. See, Slack thread for more [context](https://prisma-company.slack.com/archives/C601F4CF8/p1739544543464869).