### PR TITLE
Change `filePath` to `folderPath` to avoid error when using multiple schema.

### DIFF
--- a/content/200-orm/500-reference/325-prisma-config-reference.mdx
+++ b/content/200-orm/500-reference/325-prisma-config-reference.mdx
@@ -71,7 +71,7 @@ import path from "node:path";
 export default {
   schema: {
     kind: "multi",
-    filePath: path.join("custom", "prisma", "schema/"),
+    folderPath: path.join("custom", "prisma", "schema"),
   },
 };
 ```


### PR DESCRIPTION
When using multiple `schema` use `folderPath` insted of `filePath`

With `filePath`

`npx prisma generate`
Failed to parse config file at "C:\path\to\project\prisma.config.ts"

With `folderPath`

`npx prisma generate`
Loaded Prisma config from "C:\path\to\project\prisma.config.ts".