### PR TITLE
docs: clarify non-postgres pnpm workspace setup

### DIFF
--- a/content/800-guides/140-use-prisma-in-pnpm-workspaces.mdx
+++ b/content/800-guides/140-use-prisma-in-pnpm-workspaces.mdx
@@ -115,7 +115,7 @@ pnpm tsc --init
 
 ### 2.2. Setup Prisma ORM in your database package
 
-Initialize Prisma ORM  with an instance of [Prisma Postgres](/postgres) in the `database` package by running the following command: 
+Initialize Prisma ORM with an instance of [Prisma Postgres](/postgres) in the `database` package by running the following command: 
 
 ```terminal
 pnpm prisma init --db
@@ -180,7 +180,7 @@ Next, add helper scripts to your `package.json` to simplify Prisma commands:
 
 :::info
 
-[Prisma Postgres](/postgres/getting-started) database, exclude the `--no-engine` flag from the `db:generate` script.
+If you're not using [Prisma Postgres](/postgres/getting-started) for your database, exclude the `--no-engine` flag from the `db:generate` script.
 
 :::
 
@@ -211,7 +211,7 @@ export { prisma };
 
 :::info
 
-[Prisma Postgres](/postgres/getting-started) database, exclude the `import { withAccelerate }` line and `.$extends(withAccelerate())` from the following line.
+If you're not using [Prisma Postgres](/postgres/getting-started) for your database, exclude the `import { withAccelerate }` line and `.$extends(withAccelerate())` from the line following it.
 
 :::
 

--- a/content/800-guides/140-use-prisma-in-pnpm-workspaces.mdx
+++ b/content/800-guides/140-use-prisma-in-pnpm-workspaces.mdx
@@ -178,6 +178,12 @@ Next, add helper scripts to your `package.json` to simplify Prisma commands:
 }
 ```
 
+:::info
+
+[Prisma Postgres](/postgres/getting-started) database, exclude the `--no-engine` flag from the `db:generate` script.
+
+:::
+
 Use [Prisma Migrate](/orm/prisma-migrate) to migrate your database changes:
 
 ```terminal
@@ -202,6 +208,12 @@ if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 export { prisma };
 // add-end
 ```
+
+:::info
+
+[Prisma Postgres](/postgres/getting-started) database, exclude the `import { withAccelerate }` line and `.$extends(withAccelerate())` from the following line.
+
+:::
 
 Then, create an `index.ts` file to re-export the instance of Prisma Client and all generated types:
 
@@ -232,6 +244,14 @@ Create a new Next.js app named `web`:
 pnpm create next-app@latest web --yes
 ```
 
+:::note[important]
+
+The `--yes` flag uses default configurations to bootstrap the Next.js app (which in this guide uses the app router without a `src/` directory and `pnpm` as the installer). 
+
+Additionally, the flag may automatically initialize a Git repository in the `web` folder. If that happens, please remove the `.git` directory by running `rm -r .git`.
+
+:::
+
 Then, navigate into the web directory:
 
 ```terminal
@@ -243,14 +263,6 @@ Copy the `.env` file from the database package to ensure the same environment va
 ```terminal
 cp ../../packages/database/.env .
 ```
-
-:::note[important]
-
-The `--yes` flag uses default configurations to bootstrap the Next.js app (which in this guide uses the app router without a `src/` directory and `pnpm` as the installer). 
-
-Additionally, the flag may automatically initialize a Git repository in the `web` folder. If that happens, please remove the `.git` directory by running `rm -r .git`.
-
-:::
 
 Open the `package.json` file of your Next.js app and add the shared `database` package as a dependency:
 
@@ -330,7 +342,7 @@ Open your browser at [`http://localhost:3000`](http://localhost:3000) to see you
 
 ### 3.5. (Optional) Add data to your database using Prisma Studio
 
-Their shouldn't be data in your database yet. You can execute `pnpm run studio` in your CLI to start a [Prisma Studio](/orm/tools/prisma-studio) in [`http://localhost:5555`](http://localhost:5555) to interact with your database and add data to it.
+There shouldn't be data in your database yet. You can execute `pnpm run studio` in your CLI to start a [Prisma Studio](/orm/tools/prisma-studio) in [`http://localhost:5555`](http://localhost:5555) to interact with your database and add data to it.
 
 ## Next Steps
 


### PR DESCRIPTION
- Added some clarifications for modifications that need to be made
  when not using Postgres, based on my experience using MySQL
- Move note about `create next-app` command to follow the command
- Fixed a typo (their/there)