### PR TITLE
docs: Use create-nuxt command for fresh Nuxt projects

### DIFF
--- a/content/200-orm/800-more/600-help-and-troubleshooting/900-prisma-nuxt-module.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/900-prisma-nuxt-module.mdx
@@ -21,7 +21,7 @@ This module provides several features to streamline the setup and usage of Prism
 
 1. Create a [new Nuxt Project](https://nuxt.com/docs/getting-started/installation#new-project):
     ```terminal
-    npx nuxi@latest init test-nuxt-app
+    npm create nuxt test-nuxt-app
     ```
 
 2. Navigate to project directory and install `@prisma/nuxt` using the Nuxt CLI:

--- a/content/800-guides/100-nuxt.mdx
+++ b/content/800-guides/100-nuxt.mdx
@@ -34,7 +34,7 @@ To follow this guide, ensure you have the following:
 
 1. Initialize [a new Nuxt project](https://nuxt.com/docs/getting-started/installation#new-project), select `npm` as the package manager and initialize git:
     ```terminal
-    npx nuxi@latest init hello-world
+    npm create nuxt hello-world
     ```
     :::note
     We recommend using `npm` as it is the most stable option with the `@prisma/nuxt` module.


### PR DESCRIPTION
Nuxt introduced new [`create-nuxt`](https://github.com/nuxt/nuxt/releases/tag/v3.16.0) tool for creating fresh Nuxt projects. This small PR uses that