### PR TITLE
Added missing instructions for @prisma/client for quick start

### DIFF
--- a/content/100-getting-started/01-quickstart-sqlite.mdx
+++ b/content/100-getting-started/01-quickstart-sqlite.mdx
@@ -113,6 +113,14 @@ Congratulations, you now have your database and tables ready. Let's go and learn
 
 ## 4. Explore how to send queries to your database with Prisma Client
 
+To get started with Prisma Client, you need to install the `@prisma/client` package:
+
+```terminal copy
+npm install @prisma/client
+```
+
+The install command invokes `prisma generate` for you which reads your Prisma schema and generates a version of Prisma Client that is _tailored_ to your models.
+
 To send queries to the database, you will need a TypeScript file to execute your Prisma Client queries. Create a new file called `script.ts` for this purpose:
 
 ```terminal


### PR DESCRIPTION
Add missing @prisma/client install step to Quickstart docs

Ensures users install `@prisma/client` before using it in code examples, fixing an omitted step.

They are official instructions from setup-prisma/start-from-scratch/relational-databases/install-prisma-client-typescript-postgresql which i also included in the quick start