### PR TITLE
Generated prisma client code doesn't declare types, that doesn't make sense

### DIFF
--- a/content/200-orm/050-overview/100-introduction/300-data-modeling.mdx
+++ b/content/200-orm/050-overview/100-introduction/300-data-modeling.mdx
@@ -200,7 +200,7 @@ Once the application models are in your Prisma schema (whether they were added t
 Prisma Client uses TypeScript [type aliases](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-aliases) to represent your application models in your code. For example, the `User` model would be represented as follows in the generated Prisma Client library:
 
 ```ts
-export declare type User = {
+export type User = {
   id: number
   name: string | null
   email: string

--- a/content/200-orm/200-prisma-client/200-special-fields-and-types/100-working-with-json-fields.mdx
+++ b/content/200-orm/200-prisma-client/200-special-fields-and-types/100-working-with-json-fields.mdx
@@ -37,7 +37,7 @@ Example field value:
 The `Json` field supports a few additional types, such as `string` and `boolean`. These additional types exist to match the types supported by [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse):
 
 ```ts
-export declare type JsonValue =
+export type JsonValue =
   | string
   | number
   | boolean

--- a/content/200-orm/200-prisma-client/400-type-safety/100-operating-against-partial-structures-of-model-types.mdx
+++ b/content/200-orm/200-prisma-client/400-type-safety/100-operating-against-partial-structures-of-model-types.mdx
@@ -28,7 +28,7 @@ model Post {
 The Prisma Client code that's generated from this schema contains this representation of the `User` type:
 
 ```ts
-export declare type User = {
+export type User = {
   id: string
   email: string
   name: string | null


### PR DESCRIPTION
https://stackoverflow.com/a/59552002/

> Your specific example is different since you are declaring a type, not a variable, types already do not compile into any JavaScript. I do not know if there is any reason to declare a type.