### PR TITLE
Resolves Import and Type Issues in Next.js Guide

### DIFF
--- a/content/800-guides/090-nextjs.mdx
+++ b/content/800-guides/090-nextjs.mdx
@@ -155,7 +155,7 @@ Now, let's add some initial data to our database.
 Prisma ORM has built-in support for seeding your database with initial data. To do this, you can create a new file called `seed.ts` in the `prisma` directory.
 
 ```ts file=prisma/seed.ts
-import { PrismaClient, Prisma } from '@prisma/client'
+import { PrismaClient, Prisma } from '../app/generated/prisma'
 
 const prisma = new PrismaClient()
 
@@ -283,10 +283,12 @@ mkdir -p lib && touch lib/prisma.ts
 Now, add the following code to your `lib/prisma.ts` file:
 
 ```ts file=lib/prisma.ts
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '../app/generated/prisma'
 import { withAccelerate } from '@prisma/extension-accelerate'
 
-const globalForPrisma = global as unknown as { prisma: typeof prisma }
+const globalForPrisma = global as unknown as { 
+    prisma: PrismaClient
+}
 
 const prisma = globalForPrisma.prisma || new PrismaClient().$extends(withAccelerate())
 


### PR DESCRIPTION
In the Next.js Guide we were generating PrismaClient at a custom location but were importing it from the default location of `node_modules`. This caused issues in `seed.ts` and `prisma.ts` file.

This PR fixes both the issues.

