### PR TITLE
fix: update link type for hero section on docs

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -222,11 +222,11 @@ const TabBox = ({icon, label, description, list, link}: any) => {
           </div>
         </div>
       </div>
-      <a href={link.url}>
+      <Link to={link.url}>
         <Icon icon={link.icon} size="inherit" color="inherit" btn="left"/>
         <span>{link.label}</span>
         <Icon icon={"fa-regular fa-arrow-right"} size="inherit" color="inherit" btn="right"/>
-        </a>
+      </Link>
     </div>
   )
 }


### PR DESCRIPTION
<img width="1147" alt="Screenshot 2025-04-07 at 18 03 37" src="https://github.com/user-attachments/assets/c43f42eb-f693-4b74-85f7-df8a111cc026" />
links under the tab boxes aren't working!