### PR TITLE
Fixes generator table to display content correctly

### DIFF
--- a/content/200-orm/500-reference/100-prisma-schema-reference.mdx
+++ b/content/200-orm/500-reference/100-prisma-schema-reference.mdx
@@ -165,7 +165,7 @@ A `generator` block accepts the following fields:
 
 | Name              | Required | Type                                            | Description |
 | :-----------------| :----------------------- | :----------------------- | :----------------------- |
-| `provider`        | **Yes**  | String (file path) or Enum (`prisma-client-js` | `prisma-client`) | Describes which [generator](/orm/prisma-schema/overview/generators) to use. This can point to a file that implements a generator or specify a built-in generator directly.                                 |
+| `provider`        | **Yes**  | String (file path) or Enum (`prisma-client-js` or `prisma-client`) | Describes which [generator](/orm/prisma-schema/overview/generators) to use. This can point to a file that implements a generator or specify a built-in generator directly.                                 |
 | `output`          | No*      | String (file path)                              | Determines the location for the generated client, [learn more](/orm/prisma-client/setup-and-configuration/generating-prisma-client#using-a-custom-output-path). **Default**: `node_modules/.prisma/client` |
 | `previewFeatures` | No       | List of Enums                                   | Use intellisense to see list of currently available Preview features (`Ctrl+Space` in Visual Studio Code) **Default**: none                                                                                |     |
 | `engineType`      | No       | Enum (`library` or `binary`)                    | Defines the [query engine](/orm/more/under-the-hood/engines) type to download and use. **Default**: `library`                                                                                              |


### PR DESCRIPTION
Currently the generator table is broken because we used the pipe operator (`|`). This PR fixes it to show all content correctly.

Currently it looks like this:

<img width="886" alt="Screenshot 2025-04-16 at 10 46 50 PM" src="https://github.com/user-attachments/assets/91de0391-deb8-4a22-8d4a-33514628e657" />

After the PR it will display content correctly like this:

<img width="901" alt="Screenshot 2025-04-16 at 10 47 25 PM" src="https://github.com/user-attachments/assets/aaf6247c-75b7-4e52-ad00-a0fa5abdf07e" />

