### PR TITLE
DA-3233 Style Issues in `<TabbedContent>`

### DIFF
--- a/src/theme/CodeBlock/Container/styles.module.scss
+++ b/src/theme/CodeBlock/Container/styles.module.scss
@@ -53,4 +53,9 @@
       margin-right: 0.5rem;
     }
   }
+
+  :global(.tabs-container) & {
+    padding: 1rem 1rem 0rem;
+    margin-bottom: 0rem;
+  }
 }

--- a/src/theme/Tabs/styles.module.scss
+++ b/src/theme/Tabs/styles.module.scss
@@ -20,6 +20,7 @@
 
 .code {
   pre {
+    border-radius: 0;
     padding-bottom: 0 !important;
     code {
       padding-bottom: var(--ifm-pre-padding) !important;


### PR DESCRIPTION
1. Fixed the code block file path within a `<TabbedContent code>` having no spacing and was flush against the edge.

2. Fixed the code block within a `<TabbedContent code>` having a border radius causing a color mismatch around the corners.

Before: <img width="777" alt="Screenshot 2025-04-21 at 6 45 49 AM" src="https://github.com/user-attachments/assets/e4cfad62-3582-4625-a7a3-23efbb1fcf45" />

After:
<img width="693" alt="Screenshot 2025-04-21 at 6 45 02 AM" src="https://github.com/user-attachments/assets/688cadd9-1921-46c8-a42f-1e6ec3177423" />