### PR TITLE
AWS added support ?

### DIFF
--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/index.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/index.mdx
@@ -349,7 +349,3 @@ More information about the `directUrl` field can be found [here](/orm/reference/
 PostgreSQL only supports a certain amount of concurrent connections, and this limit can be reached quite fast when the service usage goes up – especially in [serverless environments](#serverless-environments-faas).
 
 [PgBouncer](https://www.pgbouncer.org/) holds a connection pool to the database and proxies incoming client connections by sitting between Prisma Client and the database. This reduces the number of processes a database has to handle at any given time. PgBouncer passes on a limited number of connections to the database and queues additional connections for delivery when connections becomes available. To use PgBouncer, see [Configure Prisma Client with PgBouncer](/orm/prisma-client/setup-and-configuration/databases-connections/pgbouncer).
-
-### AWS RDS Proxy
-
-Due to the way AWS RDS Proxy pins connections, [it does not provide any connection pooling benefits](/orm/prisma-client/deployment/caveats-when-deploying-to-aws-platforms#aws-rds-proxy) when used together with Prisma Client.


### PR DESCRIPTION
Wondering if this part of the documentation is still relevant. Is there a benchmark to compare the usage of RDS proxy to the other proxy using prisma ? 

https://aws.amazon.com/fr/blogs/database/amazon-rds-proxy-multiplexing-support-for-postgresql-extended-query-protocol/