### PR TITLE
Fix typo: rename `migration` block to `migrate` in Cloudflare D1 integration guide

### DIFF
--- a/content/800-guides/070-cloudflare-d1.mdx
+++ b/content/800-guides/070-cloudflare-d1.mdx
@@ -125,7 +125,7 @@ type Env = {
 export default {
   earlyAccess: true,
   schema: path.join('prisma', 'schema.prisma'),
-  migration: {
+  migrate: {
     async adapter(env) {
       return new PrismaD1HTTP({
         CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,


### PR DESCRIPTION
This PR corrects a typo in the Prisma Cloudflare D1 guide. The `PrismaConfig` API expects a `migrate` property (per the PrismaConfig reference), not `migration`.

Closes #6879.