### PR TITLE
Fix incorrect data type in updateManyAndReturn example

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -1423,9 +1423,9 @@ const users = await prisma.user.updateManyAndReturn({
       contains: 'prisma.io',
     }
   },
-  data: [
-    { role: 'ADMIN' }
-  ],
+  data: {
+    role: 'ADMIN'
+  },
 })
 ```
 


### PR DESCRIPTION
The current example incorrectly uses an array for the data property in updateManyAndReturn.
According to the Prisma Client API, data should be a single object, not an array.
This PR fixes the example to reflect the correct usage.