### PR TITLE
Update 100-operating-against-partial-structures-of-model-types.mdx

### DIFF
--- a/content/200-orm/200-prisma-client/400-type-safety/100-operating-against-partial-structures-of-model-types.mdx
+++ b/content/200-orm/200-prisma-client/400-type-safety/100-operating-against-partial-structures-of-model-types.mdx
@@ -131,19 +131,5 @@ const usersWithPosts: UsersWithPosts = await getUsersWithPosts()
 You can use native the TypeScript utility type [`Awaited`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) and [`ReturnType`](https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype) to solve the problem elegantly:
 
 ```ts
-type UsersWithPosts = Prisma.Awaited<ReturnType<typeof getUsersWithPosts>>
+type UsersWithPosts = Awaited<ReturnType<typeof getUsersWithPosts>>
 ```
-
-When using the `prisma-client-js` generator, a `PromiseReturnType` is exposed by the `Prisma` namespace, you can solve the problem using the `PromiseReturnType` type:
-
-```ts
-import { Prisma } from '@prisma/client'
-
-type UsersWithPosts = Prisma.PromiseReturnType<typeof getUsersWithPosts>
-```
-
-:::warning
-
-If you're using the new [`prisma-client`](/orm/prisma-schema/overview/generators#prisma-client-early-access) generator, the `PromiseReturnType` type is no longer available. Instead, you can use a combination of the built-in TypeScript type `Awaited` and `ReturnType` to achieve the same result. 
-
-:::


### PR DESCRIPTION
Remove `PromiseReturnType` following the suggestion made in [this comment](https://github.com/prisma/docs/pull/6920/files/4b3a185aef8e7f2773c0324c6d286c1e1b7c3abd#r2100284941).