### PR TITLE
fix: correct small typo on data sources overview page

### DIFF
--- a/content/200-orm/100-prisma-schema/10-overview/02-data-sources.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/02-data-sources.mdx
@@ -6,7 +6,7 @@ metaDescription: 'Data sources enable Prisma to connect to your database. This p
 
 <TopBlock>
 
-A data source determines how Prisma ORM connects your database, and is represented by the [`datasource`](/orm/reference/prisma-schema-reference#datasource) block in the Prisma schema. The following data source uses the `postgresql` provider and includes a connection URL:
+A data source determines how Prisma ORM connects to your database, and is represented by the [`datasource`](/orm/reference/prisma-schema-reference#datasource) block in the Prisma schema. The following data source uses the `postgresql` provider and includes a connection URL:
 
 ```prisma
 datasource db {
@@ -35,7 +35,7 @@ Some data source `provider`s allow you to configure your connection with SSL/TLS
 Prisma ORM resolves SSL certificates relative to the `./prisma` directory. If your certificate files are located outside that directory, e.g. your project root directory, use relative paths for certificates:
 
 :::note
-When your are using a [multi-file Prisma schema](/orm/prisma-schema/overview/location#multi-file-prisma-schema), Prisma ORM resolves SSL certificates relative to the `./prisma/schema` directory.
+When you're using a [multi-file Prisma schema](/orm/prisma-schema/overview/location#multi-file-prisma-schema), Prisma ORM resolves SSL certificates relative to the `./prisma/schema` directory.
 :::
 
 ```prisma


### PR DESCRIPTION
## PR Description:
This PR fixes a few small grammar and clarity issues on the Data Sources overview page.

**Affected Page**: https://www.prisma.io/docs/orm/prisma-schema/overview/data-sources

- Added missing **"to"** in the intro paragraph (`connects to your database`)
- Replaced **"your are"** with the correct **"you're"** in the note box under the SSL section