### PR TITLE
fix: correct spelling in Prisma 6 upgrade guide

### DIFF
--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/500-upgrading-to-prisma-6.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/500-upgrading-to-prisma-6.mdx
@@ -210,7 +210,7 @@ generator client {
 
 In an effort to improve compatibility between Prisma and new modern JavaScript runtimes, we're gradually moving away from Node.js-specific APIs in favor of standard JavaScript.
 
-Prisma v6 replaces the usage of [`Buffer`](https://nodejs.org/api/buffer.html)  with [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) to represent fields of type `Bytes`. Make sure to replace all your occurences of the `Buffer` type with the new `Uint8Array`.
+Prisma v6 replaces the usage of [`Buffer`](https://nodejs.org/api/buffer.html)  with [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) to represent fields of type `Bytes`. Make sure to replace all your occurrences of the `Buffer` type with the new `Uint8Array`.
 
 <details>
 <summary>Expand to view how to convert between <code>Buffer</code> and <code>Uint8Array</code></summary>


### PR DESCRIPTION
## Description

Fixed a spelling error in the Prisma 6 upgrade guide documentation.

## Changes

- Changed "occurences" to "occurrences" in the Buffer to Uint8Array migration section
- This fixes a common spelling mistake where the double 'r' was missing

## File Changed

- `content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/500-upgrading-to-prisma-6.mdx`

## Context

The word "occurrences" was misspelled as "occurences" in the section explaining how to replace Buffer types with Uint8Array when upgrading to Prisma 6. This documentation is likely to be read by many developers upgrading their projects, so correct spelling improves the professional quality of the documentation.
