### PR TITLE
update prisma client instantiation code snippet for next js to match new version

### DIFF
--- a/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
+++ b/content/200-orm/800-more/600-help-and-troubleshooting/400-nextjs-help.mdx
@@ -31,7 +31,7 @@ To avoid this, create a single Prisma Client instance by using a global variable
 
 ```typescript
 // lib/prisma.ts
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@/generated/prisma";
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 


### PR DESCRIPTION
The next.js primaClient instantiation code snippet is not up to date, I was getting error even after following the docs provided. Then I tried import from all the available files and it worked when I imported prismaClient from `@/generated/prisma` . So the fix I made is just changed a line of import statement. 

From 
````typescript
import { PrismaClient } from "@prisma/client";
````
to 
````typescript
import { PrismaClient } from "@/generated/prisma";
````
