### PR TITLE
docs: adapt docs to PrismaConfig breaking changes in v6.12.0

### DIFF
--- a/content/200-orm/050-overview/500-databases/900-turso.mdx
+++ b/content/200-orm/050-overview/500-databases/900-turso.mdx
@@ -94,7 +94,6 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = "file:./dev.db" // will be ignored
 }
 ```
 
@@ -175,23 +174,16 @@ import { PrismaLibSQL } from '@prisma/adapter-libsql'
 // import your .env file
 import 'dotenv/config'
 
-type Env = {
-  LIBSQL_DATABASE_URL: string
-  LIBSQL_DATABASE_TOKEN: string
-}
-
-export default defineConfig<Env>({
+export default defineConfig({
   earlyAccess: true,
   schema: path.join('prisma', 'schema.prisma'),
 
-  migrate: {
-    async adapter(env) {
-      return new PrismaLibSQL({
-        url: env.LIBSQL_DATABASE_URL,
-        authToken: env.LIBSQL_DATABASE_TOKEN,
-      })
-    }
-  }
+  async adapter() {
+    return new PrismaLibSQL({
+      LIBSQL_DATABASE_URL: process.env.LIBSQL_DATABASE_URL!,
+      LIBSQL_DATABASE_TOKEN: process.env.LIBSQL_DATABASE_TOKEN!,
+    });
+  },
 })
 ```
 

--- a/content/200-orm/050-overview/500-databases/900-turso.mdx
+++ b/content/200-orm/050-overview/500-databases/900-turso.mdx
@@ -180,8 +180,8 @@ export default defineConfig({
 
   async adapter() {
     return new PrismaLibSQL({
-      LIBSQL_DATABASE_URL: process.env.LIBSQL_DATABASE_URL!,
-      LIBSQL_DATABASE_TOKEN: process.env.LIBSQL_DATABASE_TOKEN!,
+      url: process.env.LIBSQL_DATABASE_URL!,
+      authToken: process.env.LIBSQL_DATABASE_TOKEN!,
     });
   },
 })

--- a/content/200-orm/050-overview/500-databases/950-cloudflare-d1.mdx
+++ b/content/200-orm/050-overview/500-databases/950-cloudflare-d1.mdx
@@ -104,31 +104,25 @@ import { PrismaD1 } from '@prisma/adapter-d1'
 // import your .env file
 import 'dotenv/config'
 
-type Env = {
-  CLOUDFLARE_D1_TOKEN: string
-  CLOUDFLARE_ACCOUNT_ID: string
-  CLOUDFLARE_DATABASE_ID: string
-}
-
 export default {
   earlyAccess: true,
   schema: path.join('prisma', 'schema.prisma'),
 
   // add-start
-  migrate: {
-    async adapter(env) {
-      return new PrismaD1({
-        CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,
-        CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
-        CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
-      })
-    },
+  async adapter() {
+    return new PrismaD1({
+      CLOUDFLARE_D1_TOKEN: process.env.CLOUDFLARE_D1_TOKEN!,
+      CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID!,
+      CLOUDFLARE_DATABASE_ID: process.env.CLOUDFLARE_DATABASE_ID!,
+    });
   },
   // add-end
-} satisfies PrismaConfig<Env>
+} satisfies PrismaConfig
 ```
 
 > **Note**: As of [Prisma ORM v6.11.0](https://github.com/prisma/prisma/releases/tag/6.11.0), the D1 adapter has been renamed from `PrismaD1HTTP` to `PrismaD1`.
+
+> **Note**: As of [Prisma ORM v6.12.0](https://github.com/prisma/prisma/releases/tag/6.12.0), the `migrate.adapter` configuration has been renamed to `adapter`.
 
 #### 4. Migrate your database
 

--- a/content/200-orm/100-prisma-schema/10-overview/04-location.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/04-location.mdx
@@ -87,7 +87,7 @@ You can do this in either of three ways:
   export default {
     earlyAccess: true,
     schema: path.join('prisma'),
-  } satisfies PrismaConfig<Env>
+  } satisfies PrismaConfig
   ```
 
 All examples above assume that your `datasource` block is defined in a `.prisma` file inside the `prisma` directory.

--- a/content/200-orm/500-reference/325-prisma-config-reference.mdx
+++ b/content/200-orm/500-reference/325-prisma-config-reference.mdx
@@ -113,21 +113,13 @@ Configures how Prisma ORM locates and loads your schema file(s). Can be a file o
 | -------- | -------- | -------- | ---------------------------------------------- |
 | `schema` | `string` | No       | `./prisma/schema.prisma` and `./schema.prisma` |
 
-### `migrate`
+### `adapter`
 
-Configures how Prisma Migrate communicates with your underlying database. See sub-options below for details.
-
-| Property  | Type     | Required | Default |
-| --------- | -------- | -------- | ------- |
-| `migrate` | `object` | No       | `{}`    |
-
-#### `migrate.adapter`
-
-A function that returns a Prisma driver adapter instance which is used by the Prisma CLI to run migrations. The function receives an `env` parameter containing environment variables and should return a `Promise` that resolves to a valid Prisma driver adapter.
+A function that returns a Prisma driver adapter instance which is used by the Prisma CLI to run migrations. The function should return a `Promise` that resolves to a valid Prisma driver adapter.
 
 | Property          | Type                                                           | Required | Default |
 | ----------------- | -------------------------------------------------------------- | -------- | ------- |
-| `migrate.adapter` | `(env: Env) => Promise<SqlMigrationAwareDriverAdapterFactory>` | No       | none    |
+| `adapter`         | `() => Promise<SqlMigrationAwareDriverAdapterFactory>`         | No       | none    |
 
 Example using the Prisma ORM D1 driver adapter:
 
@@ -139,29 +131,23 @@ import { PrismaD1 } from "@prisma/adapter-d1";
 // import your .env file
 import "dotenv/config";
 
-type Env = {
-  CLOUDFLARE_D1_TOKEN: string;
-  CLOUDFLARE_ACCOUNT_ID: string;
-  CLOUDFLARE_DATABASE_ID: string;
-};
-
 export default {
   earlyAccess: true,
   schema: path.join("prisma", "schema.prisma"),
 
-  migrate: {
-    async adapter(env) {
-      return new PrismaD1({
-        CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,
-        CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
-        CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
-      });
-    },
+  async adapter() {
+    return new PrismaD1({
+      CLOUDFLARE_D1_TOKEN: process.env.CLOUDFLARE_D1_TOKEN!,
+      CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID!,
+      CLOUDFLARE_DATABASE_ID: process.env.CLOUDFLARE_DATABASE_ID!,
+    });
   },
-} satisfies PrismaConfig<Env>;
+} satisfies PrismaConfig;
 ```
 
 > **Note**: As of [Prisma ORM v6.11.0](https://github.com/prisma/prisma/releases/tag/6.11.0), the D1 adapter has been renamed from `PrismaD1HTTP` to `PrismaD1`.
+
+> **Note**: As of [Prisma ORM v6.12.0](https://github.com/prisma/prisma/releases/tag/6.12.0), the `migrate.adapter` configuration has been renamed to `adapter`.
 
 ### `studio`
 

--- a/content/800-guides/070-cloudflare-d1.mdx
+++ b/content/800-guides/070-cloudflare-d1.mdx
@@ -33,7 +33,6 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 model User {
@@ -116,28 +115,22 @@ import { PrismaD1 } from '@prisma/adapter-d1'
 // import your .env file
 import 'dotenv/config'
 
-type Env = {
-  CLOUDFLARE_D1_TOKEN: string
-  CLOUDFLARE_ACCOUNT_ID: string
-  CLOUDFLARE_DATABASE_ID: string
-}
-
 export default {
   earlyAccess: true,
   schema: path.join('prisma', 'schema.prisma'),
-  migrate: {
-    async adapter(env) {
-      return new PrismaD1({
-        CLOUDFLARE_D1_TOKEN: env.CLOUDFLARE_D1_TOKEN,
-        CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
-        CLOUDFLARE_DATABASE_ID: env.CLOUDFLARE_DATABASE_ID,
-      })
-    },
+  async adapter() {
+    return new PrismaD1({
+      CLOUDFLARE_D1_TOKEN: process.env.CLOUDFLARE_D1_TOKEN!,
+      CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID!,
+      CLOUDFLARE_DATABASE_ID: process.env.CLOUDFLARE_DATABASE_ID!,
+    });
   },
-} satisfies PrismaConfig<Env>
+} satisfies PrismaConfig
 ```
 
 > **Note**: As of [Prisma ORM v6.11.0](https://github.com/prisma/prisma/releases/tag/6.11.0), the D1 adapter has been renamed from `PrismaD1HTTP` to `PrismaD1`.
+
+> **Note**: As of [Prisma ORM v6.12.0](https://github.com/prisma/prisma/releases/tag/6.12.0), the `migrate.adapter` configuration has been renamed to `adapter`.
 
 This will allow `prisma migrate` to interact with your D1 database. 
 


### PR DESCRIPTION
The latest release ([v6.12.0](https://github.com/prisma/prisma/releases/tag/6.12.0)) includes some breaking changes to `PrismaConfig` that were introduced in [#27618](https://github.com/prisma/prisma/pull/27618). Which made a bunch of documentation pages out of date. Mainly affects [Cloudflare D1](https://www.prisma.io/docs/orm/overview/databases/cloudflare-d1) and [Turso](https://www.prisma.io/docs/orm/overview/databases/turso) guides.

This PR includes the following changes:
1. Update code examples to rename the "migrate.adapter" configuration to "adapter"
2. Refactor the examples as `defineConfig` and `PrismaConfig` no longer expect an environment type parameter and `adapter` no longer has `env` as an argument
3. Added a note on the renaming
4. Updated PrismaConfig docs as well to remove the eliminated `migrate` key