### PR TITLE
fix: use mysql instead of postgresql in datasource db

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-node-mysql.mdx
@@ -16,7 +16,7 @@ To connect your database, you need to set the `url` field of the `datasource` bl
 
 ```prisma file=prisma/schema.prisma showLineNumbers
 datasource db {
-  provider = "postgresql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 ```

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-node-mysql.mdx
@@ -19,7 +19,7 @@ To connect your database, you need to set the `url` field of the `datasource` bl
 
 ```prisma file=prisma/schema.prisma showLineNumbers
 datasource db {
-  provider = "postgresql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 ```

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/100-connect-your-database-typescript-mysql.mdx
@@ -19,7 +19,7 @@ To connect your database, you need to set the `url` field of the `datasource` bl
 
 ```prisma file=prisma/schema.prisma showLineNumbers
 datasource db {
-  provider = "postgresql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 ```


### PR DESCRIPTION
[I created this PR earlier.](https://dev.socialproduction.io/app/machines/445305027/production-monitor/scale)

Now i noticed, that more pages have that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples to use MySQL as the database provider instead of PostgreSQL in relevant Prisma schema configuration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->