### PR TITLE
fix: update PostgreSQL connection strings to use db.prisma.io

### DIFF
--- a/content/100-getting-started/03-prisma-postgres/115-import-from-existing-database-mysql.mdx
+++ b/content/100-getting-started/03-prisma-postgres/115-import-from-existing-database-mysql.mdx
@@ -75,7 +75,7 @@ Open the `config.load` file in your preferred text editor and copy-paste the fol
 ```text file=config.load
 LOAD DATABASE
     FROM mysql://username:password@host:PORT/database_name
-    INTO postgres://__USER__:__PASSWORD__@postgres.prisma-data.net:5432/?sslmode=require
+    INTO postgres://__USER__:__PASSWORD__@db.prisma.io:5432/?sslmode=require
 
 WITH quote identifiers,    -- preserve table/column name case by quoting them
      include drop,

--- a/content/200-orm/500-reference/380-connection-urls.mdx
+++ b/content/200-orm/500-reference/380-connection-urls.mdx
@@ -53,13 +53,13 @@ The connection string formats of these are covered below.
 When you connect to Prisma Postgres via direct TCP, your connection string looks as follows:
 
 ```bash
-DATABASE_URL="postgres://USER:PASSWORD@postgres.prisma-data.net:5432/?sslmode=require"
+DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require"
 ```
 
 The `USER` and `PASSWORD` values are provided when you generate credentials for your Prisma Postgres instance in the [Prisma Console](https://console.prisma.io). Here is an example with sample values:
 
 ```bash
-DATABASE_URL="postgres://2f9881cc7eef46f094ac913df34c1fb441502fe66cbe28cc48998d4e6b20336b:sk_QZ3u8fMPFfBzOID4ol-mV@postgres.prisma-data.net:5432/?sslmode=require"
+DATABASE_URL="postgres://2f9881cc7eef46f094ac913df34c1fb441502fe66cbe28cc48998d4e6b20336b:sk_QZ3u8fMPFfBzOID4ol-mV@db.prisma.io:5432/?sslmode=require"
 ```
 
 #### Via Prisma Accelerate (HTTP)

--- a/content/250-postgres/300-database/500-backups.mdx
+++ b/content/250-postgres/300-database/500-backups.mdx
@@ -91,7 +91,7 @@ Get your direct connection string for Prisma Postgres by following the instructi
 You can now dump the database by running the following command and using your own connection string:
 
 ```terminal
-pg_dump --dbname="postgres://USER:PASSWORD@postgres.prisma-data.net:5432/?sslmode=require" > ./mydatabase.bak
+pg_dump --dbname="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require" > ./mydatabase.bak
 ```
 
 This will create your backup file named `mydatabase.bak` in the current directory.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all example PostgreSQL connection URLs to use the new host domain `db.prisma.io` instead of `postgres.prisma-data.net` across migration, connection, and backup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->