### PR TITLE
feat: add more callouts to the rust-free prisma orm

### DIFF
--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/010-generating-prisma-client.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/010-generating-prisma-client.mdx
@@ -12,6 +12,30 @@ In Prisma ORM 7, Prisma Client will no longer be generated in `node_modules` by 
 
 :::
 
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
+
 To generate and instantiate Prisma Client:
 
 1. Ensure that you have [Prisma CLI installed on your machine](/orm/tools/prisma-cli#installation).

--- a/content/200-orm/200-prisma-client/500-deployment/001-deploy-prisma.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/001-deploy-prisma.mdx
@@ -5,11 +5,30 @@ metaDescription: 'Learn more about the different deployment paradigms for Node.j
 tocDepth: 2
 ---
 
-<TopBlock>
-
 Projects using Prisma Client can be deployed to many different cloud platforms. Given the variety of cloud platforms and different names, it's noteworthy to mention the different deployment paradigms, as they affect the way you deploy an application using Prisma Client.
 
-</TopBlock>
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma's Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
 
 ## Deployment paradigms
 

--- a/content/200-orm/200-prisma-client/500-deployment/001-deploy-prisma.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/001-deploy-prisma.mdx
@@ -26,8 +26,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
-
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 :::
 
 ## Deployment paradigms

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/150-deploy-to-azure-functions.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/150-deploy-to-azure-functions.mdx
@@ -27,7 +27,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/150-deploy-to-azure-functions.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/150-deploy-to-azure-functions.mdx
@@ -27,7 +27,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/150-deploy-to-azure-functions.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/150-deploy-to-azure-functions.mdx
@@ -8,6 +8,30 @@ This guide explains how to avoid common issues when deploying a Node.js-based fu
 
 Azure Functions is a serverless deployment platform. You do not need to maintain infrastructure to deploy your code. With Azure Functions, the fundamental building block is the [function app](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob&pivots=programming-language-typescript). A function app provides an execution context in Azure in which your functions run. It is comprised of one or more individual functions that Azure manages, deploys, and scales together. You can organize and collectively manage multiple functions as a single logical unit.
 
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
+
 ## Prerequisites
 
 - An existing function app project with Prisma ORM

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/300-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/300-deploy-to-vercel.mdx
@@ -31,8 +31,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
-
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 :::
 
 ## Build configuration

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/300-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/300-deploy-to-vercel.mdx
@@ -12,6 +12,29 @@ We created an [example application](https://github.com/prisma/deployment-example
 
 While our examples use Next.js, you can deploy other applications to Vercel. See [Using Express with Vercel](https://vercel.com/guides/using-express-with-vercel) and [Nuxt on Vercel](https://vercel.com/docs/frameworks/nuxt) as examples of other options.
 
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
 ## Build configuration
 
 ### Updating Prisma Client during Vercel builds

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/300-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/300-deploy-to-vercel.mdx
@@ -31,7 +31,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -5,7 +5,6 @@ metaDescription: 'Learn how to deploy your Prisma ORM-backed applications to AWS
 tocDepth: 3
 ---
 
-<TopBlock>
 
 This guide explains how to avoid common issues when deploying a project using Prisma ORM to [AWS Lambda](https://aws.amazon.com/lambda/).
 
@@ -15,7 +14,30 @@ While a deployment framework is not required to deploy to AWS Lambda, this guide
 - [Serverless Framework](https://www.serverless.com/framework) provides a CLI that helps with workflow automation and AWS resource provisioning. While Prisma ORM works well with the Serverless Framework "out of the box", there are a few improvements that can be made within your project to ensure a smooth deployment and performance. There is also additional configuration that is needed if you are using the [`serverless-webpack`](https://www.npmjs.com/package/serverless-webpack) or [`serverless-bundle`](https://www.npmjs.com/package/serverless-bundle) libraries.
 - [SST](https://sst.dev/) provides tools that make it easy for developers to define, test, debug, and deploy their applications. Prisma ORM works well with SST but must be configured so that your schema is correctly packaged by SST.
 
-</TopBlock>
+
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
 
 ## General considerations when deploying to AWS Lambda
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -36,7 +36,7 @@ When using this architecture:
 
 This setup can simplify deployments in serverless or edge runtimes. If you adopt the no-Rust-engine setup, you can ignore subsequent sections about `binaryTargets`, copying/packaging native engine files, and pruning `libquery_engine-*` artifacts. 
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -34,9 +34,12 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+This setup can simplify deployments in serverless or edge runtimes. If you adopt the no-Rust-engine setup, you can ignore subsequent sections about `binaryTargets`, copying/packaging native engine files, and pruning `libquery_engine-*` artifacts. 
+
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). 
 
 :::
+
 
 
 ## General considerations when deploying to AWS Lambda

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -36,7 +36,7 @@ When using this architecture:
 
 This setup can simplify deployments in serverless or edge runtimes. If you adopt the no-Rust-engine setup, you can ignore subsequent sections about `binaryTargets`, copying/packaging native engine files, and pruning `libquery_engine-*` artifacts. 
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). 
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
@@ -27,7 +27,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
@@ -8,6 +8,30 @@ This guide covers the steps you will need to take in order to deploy your applic
 
 Netlify is a cloud platform for continuous deployment, static sites, and serverless functions. Netlify integrates seamlessly with GitHub for automatic deployments upon commits. When you follow the steps below, you will use that approach to create a CI/CD pipeline that deploys your application from a GitHub repository.
 
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
+
 ## Prerequisites
 
 Before you can follow this guide, you will need to set up your application to begin deploying to Netlify. We recommend the ["Get started with Netlify"](https://docs.netlify.com/get-started/) guide for a quick overview and ["Deploy functions"](https://docs.netlify.com/functions/deploy/?fn-language=ts) for an in-depth look at your deployment options.

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
@@ -63,7 +63,7 @@ binaryTargets = ["native", "rhel-openssl-3.0.x"]
 
 ## Store environment variables in Netlify
 
-We recommend keeping `.env` files in your `.gitignore` in order to prevent leakage of sensitives connection strings. Instead, you can use the Netlify CLI to [import values into netlify directly](https://docs.netlify.com/environment-variables/get-started/#import-variables-with-the-netlify-cli).
+We recommend keeping `.env` files in your `.gitignore` in order to prevent leakage of sensitive connection strings. Instead, you can use the Netlify CLI to [import values into netlify directly](https://docs.netlify.com/environment-variables/get-started/#import-variables-with-the-netlify-cli).
 
 
 Assuming you have a file like the following:
@@ -102,7 +102,7 @@ site: my-very-very-cool-site
 <details>
 <summary>If you are not using an `.env` file</summary>
 
-If you are storing your database connection string and other environment variables in a different method, you will need to manually upload your environment variables to Netlify. These options are [discussed in Netlfiy's documentation](https://docs.netlify.com/environment-variables/get-started/) and one method, uploading via the UI, is described below.
+If you are storing your database connection string and other environment variables in a different method, you will need to manually upload your environment variables to Netlify. These options are [discussed in Netlify's documentation](https://docs.netlify.com/environment-variables/get-started/) and one method, uploading via the UI, is described below.
 
 1. Open the Netlify admin UI for the site. You can use Netlify CLI as follows:
    ```terminal

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
@@ -27,7 +27,9 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). 
+
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/500-deploy-to-netlify.mdx
@@ -27,7 +27,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). 
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). If you use this setup, you do not need to configure `binaryTargets` in your Prisma schema below.
 
 Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/index.mdx
@@ -5,11 +5,37 @@ metaDescription: 'Learn how to deploy your Prisma ORM-backed apps to FaaS provid
 tocDepth: 2
 ---
 
-<TopBlock>
-
 If your application is deployed via a "Serverless Function" or "Function-as-a-Service (FaaS)" offering and uses a standard Node.js runtime, it is a serverless app. Common deployment examples include [AWS Lambda](/orm/prisma-client/deployment/serverless/deploy-to-aws-lambda) and [Vercel Serverless Functions](/orm/prisma-client/deployment/serverless/deploy-to-vercel).
 
-</TopBlock>
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in:
+
+* Serverless functions
+* Edge runtimes
+* Read-only filesystem environments
+* CI/CD pipelines with strict size limits
+
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
 
 ## Guides for Serverless Function providers
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/index.mdx
@@ -33,7 +33,7 @@ This setup can simplify deployments in:
 * Read-only filesystem environments
 * CI/CD pipelines with strict size limits
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/index.mdx
@@ -33,7 +33,7 @@ This setup can simplify deployments in:
 * Read-only filesystem environments
 * CI/CD pipelines with strict size limits
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/100-overview.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/100-overview.mdx
@@ -46,7 +46,7 @@ This setup can simplify deployments in:
 * Read-only filesystem environments
 * CI/CD pipelines with strict size limits
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/100-overview.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/100-overview.mdx
@@ -46,7 +46,7 @@ This setup can simplify deployments in:
 * Read-only filesystem environments
 * CI/CD pipelines with strict size limits
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/100-overview.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/100-overview.mdx
@@ -20,6 +20,37 @@ Here is a brief overview of all the edge function providers that are currently s
 
 Deploying edge functions that use Prisma ORM on Cloudflare and Vercel is currently in [Preview](/orm/more/releases#preview).
 
+:::note
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in:
+
+* Serverless functions
+* Edge runtimes
+* Read-only filesystem environments
+* CI/CD pipelines with strict size limits
+
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
+
 ## Edge-compatibility of database drivers
 
 ### Why are there limitations around database drivers in edge functions?

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
@@ -28,8 +28,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
-
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 :::
 
 ## General considerations when deploying to Cloudflare Workers

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
@@ -9,6 +9,29 @@ sidebar_class_name: preview-badge
 
 This page covers everything you need to know to deploy an app with Prisma ORM to a [Cloudflare Worker](https://developers.cloudflare.com/workers/) or to [Cloudflare Pages](https://developers.cloudflare.com/pages).
 
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma's Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
 ## General considerations when deploying to Cloudflare Workers
 
 This section covers _general_ things you need to be aware of when deploying to Cloudflare Workers or Pages and are using Prisma ORM, regardless of the database provider you use.

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
@@ -28,7 +28,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
@@ -7,13 +7,32 @@ tocDepth: 3
 sidebar_class_name: preview-badge
 ---
 
-<TopBlock>
-
 This page covers everything you need to know to deploy an app that uses Prisma Client for talking to a database in [Vercel Edge Middleware](https://vercel.com/docs/functions/edge-middleware) or a [Vercel Function](https://vercel.com/docs/functions) deployed to the [Vercel Edge Runtime](https://vercel.com/docs/functions/runtimes/edge-runtime).
 
 To deploy a Vercel Function to the Vercel Edge Runtime, you can set `export const runtime = 'edge'` outside the request handler of the Vercel Function.
 
-</TopBlock>
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma's Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
 
 ## General considerations when deploying to Vercel Edge Functions & Edge Middleware
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
@@ -30,8 +30,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
-
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 :::
 
 ## General considerations when deploying to Vercel Edge Functions & Edge Middleware

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
@@ -30,7 +30,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
@@ -12,7 +12,7 @@ This guide covers the use of Prisma CLI with Deno CLI, Deno Deploy, Prisma Clien
 
 :::info 
 
-This guide demonstrates how to deploy an application to Deno Deploy in conjunction with a Prisma Postgres database, but you can also use [your own database with Prisma Accelerate](/accelerate/getting-started#prerequisites).
+This guide demonstrates how to deploy an application to Deno Deploy with a Prisma Postgres database, but you can also use [your own database with Prisma Accelerate](/accelerate/getting-started#prerequisites).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
@@ -24,7 +24,8 @@ If Prisma's Rust engine binaries cause large bundle sizes, slow builds, or deplo
 
 ```prisma
 generator client {
-  provider        = "prisma-client-js"
+  provider        = "prisma-client"
+  runtime         = "deno"
   previewFeatures = ["queryCompiler", "driverAdapters"]
 }
 ```

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
@@ -36,8 +36,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
-
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 :::
 
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
@@ -4,19 +4,41 @@ metaTitle: 'Deploy to Deno Deploy'
 metaDescription: 'Learn how to deploy a TypeScript application to Deno Deploy.'
 ---
 
-<TopBlock>
+
 
 With this guide, you can learn how to build and deploy a simple application to [Deno Deploy](https://deno.com/deploy). The application uses Prisma ORM to save a log of each request to a [Prisma Postgres](/postgres) database.
 
 This guide covers the use of Prisma CLI with Deno CLI, Deno Deploy, Prisma Client, and Prisma Postgres.
 
-<Admonition type="info">
+:::info 
 
 This guide demonstrates how to deploy an application to Deno Deploy in conjunction with a Prisma Postgres database, but you can also use [your own database with Prisma Accelerate](/accelerate/getting-started#prerequisites).
 
-</Admonition>
+:::
 
-</TopBlock>
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma's Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
 
 ## Prerequisites
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/550-deploy-to-deno-deploy.mdx
@@ -36,7 +36,8 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+
 :::
 
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/index.mdx
@@ -5,11 +5,33 @@ metaDescription: 'Learn how to deploy your Prisma ORM-backed apps to edge functi
 tocDepth: 2
 ---
 
-<TopBlock>
 
 If your application is deployed via an "Edge Function" offering or is deployed from a [serverless](/orm/prisma-client/deployment/serverless) offering and has a non-standard runtime, it is a _edge-deployed_ app. Common examples for such offerings include [Cloudflare Workers or Pages](/orm/prisma-client/deployment/edge/deploy-to-cloudflare), [Vercel Edge Functions or Edge Middleware](/orm/prisma-client/deployment/edge/deploy-to-vercel), and [Deno Deploy](/orm/prisma-client/deployment/edge/deploy-to-deno-deploy).
 
-</TopBlock>
+
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma's Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
 
 ## In this section
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/index.mdx
@@ -28,7 +28,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/index.mdx
@@ -28,7 +28,7 @@ When using this architecture:
 * No Rust query engine binary is downloaded or shipped.
 * The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
 
-This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/700-deploy-to-a-different-os.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/700-deploy-to-a-different-os.mdx
@@ -22,6 +22,8 @@ generator client {
 
 > Note that the [driver adapters](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is required alongside `queryCompiler`.
 
+To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+
 :::
 
 

--- a/content/200-orm/200-prisma-client/500-deployment/700-deploy-to-a-different-os.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/700-deploy-to-a-different-os.mdx
@@ -22,10 +22,9 @@ generator client {
 
 > Note that the [driver adapters](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is required alongside `queryCompiler`.
 
-To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
-
 
 The query engine is implemented in Rust and is used by Prisma Client in the form of executable binary files. The binary is downloaded when `prisma generate` is called.
 

--- a/content/200-orm/200-prisma-client/500-deployment/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/index.mdx
@@ -33,7 +33,7 @@ This setup can simplify deployments in:
 * Read-only filesystem environments
 * CI/CD pipelines with strict size limits
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/500-deployment/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/index.mdx
@@ -5,11 +5,38 @@ metaDescription: 'How to deploy a Node.js application that uses Prisma Client an
 hide_table_of_contents: true
 ---
 
-<TopBlock>
-
 This section describes how to deploy Node.js applications that use Prisma Client and TypeScript to various platforms.
 
-</TopBlock>
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in:
+
+* Serverless functions
+* Edge runtimes
+* Read-only filesystem environments
+* CI/CD pipelines with strict size limits
+
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
 
 ## In this section
 

--- a/content/200-orm/200-prisma-client/500-deployment/index.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/index.mdx
@@ -33,7 +33,7 @@ This setup can simplify deployments in:
 * Read-only filesystem environments
 * CI/CD pipelines with strict size limits
 
-Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine). To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 :::
 

--- a/content/200-orm/200-prisma-client/700-debugging-and-troubleshooting/245-troubleshooting-binary-size-issues.mdx
+++ b/content/200-orm/200-prisma-client/700-debugging-and-troubleshooting/245-troubleshooting-binary-size-issues.mdx
@@ -32,5 +32,5 @@ This setup can help if you are:
 * Running in read-only filesystem environments
 * Working within CI/CD pipelines with strict size limits
 
-Visit [this page](/orm/prisma-client/setup-and-configuration/no-rust-engine) for complete setup instructions and supported databases. To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
+Visit [this page](/orm/prisma-client/setup-and-configuration/no-rust-engine) for complete setup instructions and supported databases. Curious why we're moving away from the Rust engine? Take a look at why we're transitioning from Rust binary engines to an all-TypeScript approach for a faster, lighter Prisma ORM in our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 

--- a/content/200-orm/200-prisma-client/700-debugging-and-troubleshooting/245-troubleshooting-binary-size-issues.mdx
+++ b/content/200-orm/200-prisma-client/700-debugging-and-troubleshooting/245-troubleshooting-binary-size-issues.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Troubleshooting binary size and deployment issues'
+metaTitle: 'Troubleshooting Prisma ORM binary size and deployment issues'
+metaDescription: 'This page covers how to resolve large bundle sizes, slow builds, and deployment errors caused by Prisma ORM Rust engine binaries'
+hide_table_of_contents: true
+---
+
+If you encounter **large bundle sizes**, **slow builds**, or **deployment errors** related to Prisma’s Rust engine binaries, for example, in serverless or edge environments, the issue may be caused by the default native Rust query engine that ships with Prisma Client.
+
+As of [v6.7.0](https://pris.ly/release/6.7.0), you can resolve these issues by enabling the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature.  
+When enabled, Prisma Client is generated **without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies.
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+````
+
+:::note
+The [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`. 
+:::
+
+With this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JavaScript database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can help if you are:
+
+* Deploying to serverless functions or edge runtimes
+* Running in read-only filesystem environments
+* Working within CI/CD pipelines with strict size limits
+
+Visit [this page](/orm/prisma-client/setup-and-configuration/no-rust-engine) for complete setup instructions and supported databases.
+

--- a/content/200-orm/200-prisma-client/700-debugging-and-troubleshooting/245-troubleshooting-binary-size-issues.mdx
+++ b/content/200-orm/200-prisma-client/700-debugging-and-troubleshooting/245-troubleshooting-binary-size-issues.mdx
@@ -32,5 +32,5 @@ This setup can help if you are:
 * Running in read-only filesystem environments
 * Working within CI/CD pipelines with strict size limits
 
-Visit [this page](/orm/prisma-client/setup-and-configuration/no-rust-engine) for complete setup instructions and supported databases.
+Visit [this page](/orm/prisma-client/setup-and-configuration/no-rust-engine) for complete setup instructions and supported databases. To understand the reasoning behind eventually removing the Rust engine from Prisma ORM, read our [blog post](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -7,6 +7,29 @@ tocDepth: 3
 toc: true
 ---
 
+:::tip Use Prisma ORM without Rust binaries
+
+If Prisma’s Rust engine binaries cause large bundle sizes, slow builds, or deployment issues (for example, in serverless or edge environments), you can switch to the [`queryCompiler`](/orm/prisma-client/setup-and-configuration/no-rust-engine) Preview feature introduced in [v6.7.0](https://pris.ly/release/6.7.0).
+
+**When enabled, Prisma Client is generated without a Rust-based query engine binary**, reducing build artifacts and removing native binary dependencies:
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler", "driverAdapters"]
+}
+```
+
+Note that the [`driverAdapters`](/orm/overview/databases/database-drivers#driver-adapters) Preview feature is **required** alongside `queryCompiler`.
+When using this architecture:
+
+* No Rust query engine binary is downloaded or shipped.
+* The database connection pool is maintained by the native JS database driver you install (e.g., `@prisma/adapter-pg` for PostgreSQL).
+
+This setup can simplify deployments in serverless or edge runtimes. Learn more in the [docs here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+:::
+
 The Prisma Client API reference documentation is based on the following schema:
 
 ```prisma


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added tips and callouts across Prisma Client setup, deployment guides (serverless/edge: Vercel, AWS Lambda, Netlify, Azure, Cloudflare, Deno) and API reference for running Prisma without Rust binaries via the queryCompiler + driverAdapters preview flow.
  * Included generator examples, links to detailed guidance and a blog post, and deployment notes for serverless/edge and size-constrained environments.
  * Highlighted benefits: no Rust engine download/shipping, smaller artifacts, native JS driver pooling.
  * Added a troubleshooting page for binary-size issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->