### PR TITLE
fix: DC-4861 Fix right-side TOC overflow

### DIFF
--- a/src/theme/TOC/styles.module.css
+++ b/src/theme/TOC/styles.module.css
@@ -2,6 +2,7 @@
   max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
   position: sticky;
   top: calc(var(--ifm-navbar-height) + 1rem);
+  overflow: auto;
 }
 
 .tableOfContents {


### PR DESCRIPTION
Fixes #DC-4861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the Table of Contents container to use an internal scrollbar when content exceeds its max height. This prevents the TOC from spilling into surrounding content, improving readability and navigation on long pages and smaller screens. Existing inner scroll behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->