### PR TITLE
fix: add callout to Prisma Config DC-4961

### DIFF
--- a/content/200-orm/100-prisma-schema/10-overview/04-location.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/04-location.mdx
@@ -85,10 +85,15 @@ You can do this in either of three ways:
   import type { PrismaConfig } from 'prisma'
   
   export default {
-    earlyAccess: true,
     schema: path.join('prisma'),
-  } satisfies PrismaConfig<Env>
+  } satisfies PrismaConfig
   ```
+
+  :::note
+
+  We recommend using the [Prisma Config file](/orm/reference/prisma-config-reference#schema) to specify the location of your Prisma schema. This is the most flexible way to specify the location of your Prisma schema alongside other configuration options.
+
+  :::
 
 All examples above assume that your `datasource` block is defined in a `.prisma` file inside the `prisma` directory.
 

--- a/content/200-orm/500-reference/100-prisma-schema-reference.mdx
+++ b/content/200-orm/500-reference/100-prisma-schema-reference.mdx
@@ -161,6 +161,8 @@ Defines a [generator](/orm/prisma-schema/overview/generators) in the Prisma sche
 
 ### Fields for `prisma-client-js` provider
 
+This is the default generator for Prisma ORM 6.x and earlier versions. Learn more about [generators](/orm/prisma-schema/overview/generators#prisma-client-js).
+
 A `generator` block accepts the following fields:
 
 | Name              | Required | Type                                     | Description                                                                                                                                                                                                |
@@ -179,6 +181,14 @@ We recommend defining a custom output path, adding the path to `.gitignore`, and
 :::
 
 ### Fields for `prisma-client` provider (Preview)
+
+The ESM-first client generator that offers greater control and flexibility across different JavaScript environments. It generates plain TypeScript code into a custom directory, providing full visibility over the generated code. Learn more about [the new `prisma-client` generator](/orm/prisma-schema/overview/generators#prisma-client-preview).
+
+:::note
+
+The `prisma-client` generator will be the default generator in Prisma ORM 7.0 and we recommend migrating to it as soon as possible.
+
+:::
 
 A `generator` block accepts the following fields:
 

--- a/content/600-about/20-style-guide/03-spelling-punctuation-formatting.mdx
+++ b/content/600-about/20-style-guide/03-spelling-punctuation-formatting.mdx
@@ -71,7 +71,7 @@ Tables and lists are often the most concise way to present information. Use thes
 
 ## Hyphens
 
-Use hyphens according to these [rules](https://www.grammarbook.com/punctuation/hyphens.asp).
+Use hyphens according to these [rules](https://www.grammarly.com/blog/punctuation-capitalization/hyphen/).
 
 Sometimes there are some terms where it's not clear whether to use a hyphen or not. To strive for consistency, we list those terms here.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated multi-file Prisma schema guidance with a simplified example and a note recommending using the Prisma Config to specify schema location; added tips on migrations directory placement.
  - Clarified generator defaults: prisma-client-js is the default for Prisma ORM 6.x and earlier; added preview details for the ESM-first prisma-client generator and migration recommendation for Prisma ORM 7.0.
  - Advised setting a custom output path and running prisma generate via build/postinstall.
  - Updated hyphen usage reference link.
- Style
  - Minor formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->