### PR TITLE
fix import paths in getting started tutorials

### DIFF
--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-cockroachdb.mdx
@@ -24,7 +24,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```ts file=index.ts showLineNumbers
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-mysql.mdx
@@ -24,7 +24,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```ts file=index.ts showLineNumbers
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-planetscale.mdx
@@ -24,7 +24,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```ts file=index.ts showLineNumbers
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-postgresql.mdx
@@ -23,7 +23,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```ts file=index.ts showLineNumbers
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/110-relational-databases/250-querying-the-database-typescript-sqlserver.mdx
@@ -24,7 +24,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```ts file=index.ts showLineNumbers
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
@@ -22,7 +22,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```js file=index.ts copy
-import { PrismaClient } from "./generated/prisma"
+import { PrismaClient } from './generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
@@ -22,7 +22,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```js file=index.ts copy
-import { PrismaClient } from './generated/prisma'
+import { PrismaClient } from "./generated/prisma"
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/250-querying-the-database-typescript-mongodb.mdx
@@ -22,7 +22,7 @@ For the purpose of this guide however, you'll just create a plain Node.js script
 Create a new file named `index.ts` and add the following code to it:
 
 ```js file=index.ts copy
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
+++ b/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
@@ -163,7 +163,7 @@ npx prisma migrate dev --name init
 Paste the following boilerplate into `index.ts`:
 
 ```ts file=index.ts
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 import { withAccelerate } from '@prisma/extension-accelerate'
 
 const prisma = new PrismaClient().$extends(withAccelerate())
@@ -190,7 +190,7 @@ This code contains a `main` function that's invoked at the end of the script. It
 Let's start with a small query to create a new `User` record in the database and log the resulting object to the console. Add the following code to your `index.ts` file:
 
 ```ts file=index.ts
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 import { withAccelerate } from '@prisma/extension-accelerate'
 
 const prisma = new PrismaClient().$extends(withAccelerate())
@@ -248,7 +248,7 @@ Prisma ORM offers various queries to read data from your database. In this secti
 Delete the previous Prisma ORM query and add the new `findMany` query instead:
 
 ```ts file=index.ts
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 import { withAccelerate } from '@prisma/extension-accelerate'
 
 const prisma = new PrismaClient().$extends(withAccelerate())
@@ -302,7 +302,7 @@ One of the main features of Prisma ORM is the ease of working with [relations](/
 First, adjust your script to include the nested query:
 
 ```ts file=index.ts
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 import { withAccelerate } from '@prisma/extension-accelerate'
 
 const prisma = new PrismaClient().$extends(withAccelerate())
@@ -367,7 +367,7 @@ npx tsx index.ts
 In order to also retrieve the `Post` records that belong to a `User`, you can use the `include` option via the `posts` relation field:
 
 ```ts file=index.ts
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma'
 import { withAccelerate } from '@prisma/extension-accelerate'
 
 const prisma = new PrismaClient().$extends(withAccelerate())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated TypeScript database querying guides (CockroachDB, MySQL, PlanetScale, PostgreSQL, SQL Server, MongoDB) to reference a locally generated Prisma Client; example usage and behavior unchanged.
  - Aligned Prisma Postgres CLI guide examples to the same import approach for consistency across setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->