### PR TITLE
Remove migrate option from config reference

### DIFF
--- a/content/200-orm/500-reference/325-prisma-config-reference.mdx
+++ b/content/200-orm/500-reference/325-prisma-config-reference.mdx
@@ -114,14 +114,6 @@ Configures how Prisma ORM locates and loads your schema file(s). Can be a file o
 | -------- | -------- | -------- | ---------------------------------------------- |
 | `schema` | `string` | No       | `./prisma/schema.prisma` and `./schema.prisma` |
 
-### `migrate`
-
-Configures how Prisma Migrate communicates with your underlying database. See sub-options below for details.
-
-| Property  | Type     | Required | Default |
-| --------- | -------- | -------- | ------- |
-| `migrate` | `object` | No       | `{}`    |
-
 ### `adapter`
 
 A function that returns a Prisma driver adapter instance which is used by the Prisma CLI to run migrations. The function should return a `Promise` that resolves to a valid Prisma driver adapter.


### PR DESCRIPTION
Seems like migrate option is removed in https://github.com/prisma/prisma/commit/0eab16051a3dbd205c5d76f8ca7540531053c819 but it was still in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma Config reference by removing the “migrate” option section.
  * Deleted the associated description and table for the removed option.
  * Preserved and clarified the remaining documented options (e.g., schema, adapter).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->