### PR TITLE
fix: DC-4975 update redirects list

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -564,7 +564,6 @@
 /postgres/database/api-reference/management-api /docs/postgres/introduction/management-api
 /postgres/database/error-reference /docs/postgres/database/api-reference/error-reference
 /postgres/integrations/vscode-extension /postgres/integrations/vscode
-/postgres/introduction/management-api#post-databasesdatabaseidbackupsbackupidrestore /postgres/introduction/management-api#post-projectsprojectiddatabases
 
 ### Dynamic redirects ###
 /faq/* https://v1.prisma.io/docs/1.34/faq/:splat


### PR DESCRIPTION
Fixes #DC-4975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a static redirect from /postgres/introduction/management-api#post-databasesdatabaseidbackupsbackupidrestore to /postgres/introduction/management-api#post-projectsprojectiddatabases; visits to the legacy anchor will no longer auto-redirect.
  * All other static redirects remain unchanged, including those under /postgres/database/api-reference/management-api.
  * Dynamic redirects are unaffected.
  * No changes to site content or navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->