### PR TITLE
Update Vercel Edge Deployment guide

### DIFF
--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
@@ -9,7 +9,23 @@ sidebar_class_name: preview-badge
 
 This page covers everything you need to know to deploy an app that uses Prisma Client for talking to a database in [Vercel Edge Middleware](https://vercel.com/docs/functions/edge-middleware) or a [Vercel Function](https://vercel.com/docs/functions) deployed to the [Vercel Edge Runtime](https://vercel.com/docs/functions/runtimes/edge-runtime).
 
-To deploy a Vercel Function to the Vercel Edge Runtime, you can set `export const runtime = 'edge'` outside the request handler of the Vercel Function.
+Vercel supports both Node.js and edge runtimes for Vercel Functions. The Node.js runtime is the default and recommended for most use cases.
+
+:::note
+
+By default, Vercel Functions use the Node.js runtime. You can explicitly set the runtime if needed:
+
+```typescript
+export const runtime = 'edge'; // 'nodejs' is the default
+ 
+export function GET(request: Request) {
+  return new Response(`I am a Vercel Function!`, {
+    status: 200,
+  });
+}
+```
+
+:::
 
 :::tip Use Prisma ORM without Rust binaries
 
@@ -222,8 +238,6 @@ import { NextResponse } from 'next/server'
 import { PrismaClient } from '@prisma/client'
 import { PrismaNeon } from '@prisma/adapter-neon'
 
-export const runtime = 'edge'
-
 export async function GET(request: Request) {
   const adapter = new PrismaNeon({ connectionString: process.env.POSTGRES_PRISMA_URL })
   const prisma = new PrismaClient({ adapter })
@@ -345,8 +359,6 @@ import { NextResponse } from 'next/server'
 import { PrismaClient } from '@prisma/client'
 import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
 
-export const runtime = 'edge'
-
 export async function GET(request: Request) {
   const adapter = new PrismaPlanetScale({ url: process.env.DATABASE_URL })
   const prisma = new PrismaClient({ adapter })
@@ -466,8 +478,6 @@ Here is a sample code snippet that you can use to instantiate `PrismaClient` and
 import { NextResponse } from 'next/server'
 import { PrismaClient } from '@prisma/client'
 import { PrismaNeon } from '@prisma/adapter-neon'
-
-export const runtime = 'edge'
 
 export async function GET(request: Request) {
   const adapter = new PrismaNeon({ connectionString: process.env.DATABASE_URL })

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/485-deploy-to-vercel.mdx
@@ -238,6 +238,8 @@ import { NextResponse } from 'next/server'
 import { PrismaClient } from '@prisma/client'
 import { PrismaNeon } from '@prisma/adapter-neon'
 
+export const runtime = 'nodejs' // can also be set to 'edge'
+
 export async function GET(request: Request) {
   const adapter = new PrismaNeon({ connectionString: process.env.POSTGRES_PRISMA_URL })
   const prisma = new PrismaClient({ adapter })
@@ -359,6 +361,8 @@ import { NextResponse } from 'next/server'
 import { PrismaClient } from '@prisma/client'
 import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
 
+export const runtime = 'nodejs' // can also be set to 'edge'
+
 export async function GET(request: Request) {
   const adapter = new PrismaPlanetScale({ url: process.env.DATABASE_URL })
   const prisma = new PrismaClient({ adapter })
@@ -478,6 +482,8 @@ Here is a sample code snippet that you can use to instantiate `PrismaClient` and
 import { NextResponse } from 'next/server'
 import { PrismaClient } from '@prisma/client'
 import { PrismaNeon } from '@prisma/adapter-neon'
+
+export const runtime = 'nodejs' // can also be set to 'edge'
 
 export async function GET(request: Request) {
   const adapter = new PrismaNeon({ connectionString: process.env.DATABASE_URL })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Vercel deployment guidance: Node.js is now the default runtime, with both Node.js and Edge runtimes supported.
  * Added a note explaining how to explicitly opt into the Edge runtime, including a simple illustrative example.
  * Updated deployment examples to default to Node.js and included guidance on switching to Edge when desired, improving clarity for choosing the appropriate runtime during Prisma deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->