### PR TITLE
Updated Prisma guide for Nuxt 4 compatibility

### DIFF
--- a/content/800-guides/100-nuxt.mdx
+++ b/content/800-guides/100-nuxt.mdx
@@ -152,7 +152,7 @@ With Prisma configured, the next step is to update your application code to fetc
    ```html file=app/app.vue
    <template>
      <div>
-       <NuxtIsland name="User" />
+       <User />
      </div>
    </template>
    ```

--- a/content/800-guides/100-nuxt.mdx
+++ b/content/800-guides/100-nuxt.mdx
@@ -129,10 +129,10 @@ Next, stop the server, as we need to make some code changes.
 
 With Prisma configured, the next step is to update your application code to fetch and display data from your database.
 
-1. In the root directory of your project, create a folder named `components`.
+1. In the `app` folder of your project, create a folder named `components`.
 
 2. Inside the `components` folder, create a file named `User.server.vue`. This server component will fetch and display the name of the first user from the database:  
-   ```html file=components/User.server.vue
+   ```html file=app/components/User.server.vue
    <script setup>
       import { withAccelerate } from "@prisma/extension-accelerate";
       const prisma = usePrismaClient().$extends(withAccelerate());
@@ -148,11 +148,11 @@ With Prisma configured, the next step is to update your application code to fetc
      We're extending the `usePrismaClient()` composable with the `withAccelerate()` extension method to ensure [compatibility with Prisma Postgres](/postgres/introduction/overview#using-the-client-extension-for-prisma-accelerate-required). This extension will also allow you to [cache your queries](/postgres/database/caching).
    :::
 
-3. Modify the `app.vue` file in the root directory to include the new server component using Nuxt Islands:  
-   ```html file=app.vue
+3. Modify the `app.vue` file in the `app` folder to include the new server component using Nuxt Islands:  
+   ```html file=app/app.vue
    <template>
      <div>
-       <NuxtIsland name="User"></NuxtIsland>
+       <NuxtIsland name="User" />
      </div>
    </template>
    ```


### PR DESCRIPTION
I noticed that the Prisma guide for Nuxt is still referencing **Nuxt 3**.  
Since **Nuxt 4** has been released, the documentation should be updated accordingly.  

### References
- [Nuxt 4.1 Release Blog Post](https://nuxt.com/blog/v4-1)  
- [Nuxt 4 – Directory Structure Guide](https://nuxt.com/docs/4.x/guide/directory-structure/nuxt)  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Nuxt guide to use the app directory structure and revised example file paths.
  * Replaced Nuxt Island usage in examples with a direct component invocation.
  * Kept data-fetch guidance and behavior unchanged; aligned snippets for consistency and easier copy-paste.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->