### PR TITLE
fix: DC-5427 Update --code-bg

### DIFF
--- a/src/css/theming.css
+++ b/src/css/theming.css
@@ -564,7 +564,7 @@ html[data-theme="dark"] {
     --shadow-card-bg: var(--gray-1000);
     --badge-color: rgb(247, 250, 252);
     --badge-bg-color: rgb(45, 55, 72);
-    --code-bg: #1a202c;
+    
 
     --ifm-card-background-color: var(--gray-900);
     --main-bgd-color: #1a202c;

--- a/src/css/theming.css
+++ b/src/css/theming.css
@@ -226,7 +226,6 @@ html[data-theme="dark"] {
   --ifm-color-content: rgb(247, 250, 252);
   --ifm-navbar-link-color: #e2e8f0;
   --ifm-footer-background-color: rgb(26, 32, 44);
-  --code-bg: #1a202c;
   --ifm-hover-overlay: var(--teal-700);
   /* Generic */
   --ifm-btn-border-color-active: #718096;
@@ -564,7 +563,6 @@ html[data-theme="dark"] {
     --shadow-card-bg: var(--gray-1000);
     --badge-color: rgb(247, 250, 252);
     --badge-bg-color: rgb(45, 55, 72);
-    
 
     --ifm-card-background-color: var(--gray-900);
     --main-bgd-color: #1a202c;


### PR DESCRIPTION
Fixes #DC-5427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Removed an explicit dark-mode override for code block backgrounds so code snippets now inherit the global theme.
  - Users may notice a subtle change to code block backgrounds in dark mode for improved visual consistency with the rest of the app.
  - No behavioral or functional changes; this is purely a visual theming refinement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->