### PR TITLE
fix: DC-5453 Update highlighted code padding

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1569,6 +1569,11 @@ code:not(pre > code) {
   background-color: var(--code-inline-bgd-color);
 }
 
+pre > code {
+  border-top-right-radius: 0 !important;
+  border-top-left-radius: 0 !important;
+}
+
 .anchor code {
   font-size: inherit;
   display: inline-block;

--- a/src/theme/CodeBlock/Line/styles.module.scss
+++ b/src/theme/CodeBlock/Line/styles.module.scss
@@ -113,6 +113,6 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
   }
 }
 
-:global(code:has(.added-line) > span) {
-  padding-left: 32px !important;
-}
+:global(code:has(.theme-code-block-added-line, .theme-code-block-deleted-line, .theme-code-block-edited-line) > span) {
+   padding-left: 32px !important;
+ }

--- a/src/theme/CodeBlock/Line/styles.module.scss
+++ b/src/theme/CodeBlock/Line/styles.module.scss
@@ -10,7 +10,7 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
 :global(.theme-code-block-added-line)::before {
   content: "+" !important;
   position: absolute;
-  left: 16px;
+  left: 8px;
   color: #47bb78;
 }
 :global(.theme-code-block-deleted-line) {
@@ -22,7 +22,7 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
 :global(.theme-code-block-deleted-line)::before {
   content: "-" !important;
   position: absolute;
-  left: 16px;
+  left: 8px;
   color: #e53e3e;
 }
 
@@ -35,7 +35,7 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
 :global(.theme-code-block-edited-line)::before {
   content: "✎" !important;
   position: absolute;
-  left: 16px;
+  left: 8px;
   color: #a0aec0;
 }
 
@@ -111,4 +111,8 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
   .codeHighlighted {
     margin-left: calc(var(--ifm-pre-padding) + 8.41px);
   }
+}
+
+:global(code:has(.added-line) > span) {
+  padding-left: 32px !important;
 }


### PR DESCRIPTION
Fixes #DC-5453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Removed top corner rounding for code blocks nested in pre to improve visual consistency.
  - Tightened horizontal alignment of diff markers (added/deleted/edited lines) so markers sit closer to content.
  - Increased left padding for lines with changes to improve readability and separation.
  - Changes are purely presentational; no functional behavior altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->