### PR TITLE
Add usage instructions for using Rust free ORM with Prisma Postgres/Accelerate

### DIFF
--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/300-no-rust-engine.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/300-no-rust-engine.mdx
@@ -214,6 +214,42 @@ const prisma = new PrismaClient({ adapter })
 
 If you went through the previous steps, you can query your database as you're used to with Prisma Client. No other changes are needed.
 
+## Usage with Prisma Accelerate or Prisma Postgres
+
+When using the Rust-free version of Prisma ORM with [Prisma Accelerate](/accelerate) or [Prisma Postgres](/postgres), you **should not** use driver adapters. Instead, you can directly instantiate Prisma Client with the appropriate extension.
+
+### 1. Set `engineType` on the `generator` block
+
+```prisma file=schema.prisma
+generator client {
+  provider        = "prisma-client" // or `prisma-client-js`
+  output          = "../generated/prisma"
+  engineType      = "client" // enable Prisma ORM without Rust
+}
+```
+
+### 2. Re-generate Prisma Client
+
+To make the configuration take effect, you need re-generate Prisma Client:
+
+```terminal
+npx prisma generate
+```
+
+### 3. Instantiate Prisma Client with Accelerate
+
+Import and instantiate Prisma Client with the Accelerate extension:
+
+```typescript
+import { PrismaClient } from "./generated/prisma";
+import { withAccelerate } from "@prisma/extension-accelerate";
+
+const prisma = new PrismaClient().$extends(withAccelerate());
+```
+### 4. Query your database
+
+If you went through the previous steps, you can query your database as you're used to with Prisma Client. No other changes are needed.
+
 ## Usage with older versions (Preview)
 
 The Rust-free version of Prisma ORM has been in Preview from versions v6.7.0 to v.6.14.0. Expand below if you're using any of these versions and are unable to upgrade to the latest one.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a new section, “Usage with Prisma Accelerate or Prisma Postgres,” explaining how to use Prisma Client without Rust engines. Covers setting engineType="client" in the generator, re-generenerating the client, extending with Accelerate, and running queries without changes. Clarifies that driver adapters should not be used with this approach and includes compatibility notes for the previous Preview guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->