### PR TITLE
feat: add deprecation warning for metrics

### DIFF
--- a/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
@@ -6,17 +6,25 @@ sidebar_class_name: preview-badge
 toc_max_heading_level: 4
 ---
 
-<TopBlock>
 
 Prisma Client metrics give you a detailed insight into how Prisma Client interacts with your database. You can use this insight to help diagnose performance issues with your application.
 
-<Admonition type="info">
+:::info 
 
 If you want an even more detailed insight into your Prisma Client's performance, at the level of individual operations, see [Tracing](/orm/prisma-client/observability-and-logging/opentelemetry-tracing).
 
-</Admonition>
+:::
 
-</TopBlock>
+:::warning[`metrics` preview feature is deprecated]
+
+The `metrics` preview feature has been **deprecated** as of [Prisma ORM v6.14.0](https://github.com/prisma/prisma/releases/tag/6.14.0) and will be removed in Prisma ORM v7.  
+
+Metrics were originally introduced to provide insights into query and connection behavior. With the changes in the new [query compiler architecture](/orm/prisma-client/setup-and-configuration/no-rust-engine), these values no longer reflect the system reliably. Because of this, we are not continuing support for this feature. 
+
+If you need visibility into query or connection pool behavior, we recommend using the *native metrics provided by your database driver* (for example, pool statistics) or setting up *OpenTelemetry* for a more complete observability solution.  
+
+:::
+
 
 ## About metrics
 

--- a/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
@@ -19,11 +19,14 @@ If you want an even more detailed insight into your Prisma Client's performance,
 
 The `metrics` preview feature has been **deprecated** as of [Prisma ORM v6.14.0](https://github.com/prisma/prisma/releases/tag/6.14.0) and will be removed in Prisma ORM v7.  
 
+The feature is not supported when using Prisma ORM with the  [query compiler architecture](/orm/prisma-client/setup-and-configuration/no-rust-engine) (setting `engineType` to 'client' in the `generator` block of your `schema.prisma` file).
+
 Metrics were originally introduced to provide insights into query and connection behavior. With the changes in the new [query compiler architecture](/orm/prisma-client/setup-and-configuration/no-rust-engine), these values no longer reflect the system reliably. Because of this, we are not continuing support for this feature. 
 
 If you need visibility into query or connection pool behavior, we recommend using the *native metrics provided by your database driver* (for example, pool statistics) or setting up *OpenTelemetry* for a more complete observability solution.  
 
 :::
+
 
 
 ## About metrics

--- a/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
@@ -71,7 +71,7 @@ The `metrics` preview feature is **only available in Prisma ORM versions ≤6.13
 
 To use Prisma Client metrics, you must do the following:
 
-1. [Install compatible Prisma ORM dependencies](#1-install-compatible-prisma-orm-dependencies).
+1. [Install compatible Prisma ORM dependencies](#1-install-up-to-date-prisma-orm-dependencies).
 1. [Enable the `metrics` feature flag in your Prisma schema file](#2-enable-the-feature-flag-in-the-prisma-schema-file).
 
 ### 1. Install up-to-date Prisma ORM dependencies

--- a/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/240-metrics.mdx
@@ -19,6 +19,8 @@ If you want an even more detailed insight into your Prisma Client's performance,
 
 The `metrics` preview feature has been **deprecated** as of [Prisma ORM v6.14.0](https://github.com/prisma/prisma/releases/tag/6.14.0) and will be removed in Prisma ORM v7.  
 
+**The `metrics` preview feature is only available in Prisma ORM versions ≤6.13.x.** If you are using Prisma ORM v6.14.0 or later, the `$metrics` API is no longer available.
+
 The feature is not supported when using Prisma ORM with the  [query compiler architecture](/orm/prisma-client/setup-and-configuration/no-rust-engine) (setting `engineType` to 'client' in the `generator` block of your `schema.prisma` file).
 
 Metrics were originally introduced to provide insights into query and connection behavior. With the changes in the new [query compiler architecture](/orm/prisma-client/setup-and-configuration/no-rust-engine), these values no longer reflect the system reliably. Because of this, we are not continuing support for this feature. 
@@ -61,18 +63,33 @@ You can [add global labels to your metrics data](#global-labels) to help you gro
 
 ## Prerequisites
 
+:::warning[Version compatibility]
+
+The `metrics` preview feature is **only available in Prisma ORM versions ≤6.13.x**. It has been removed in v6.14.0 and later versions.
+
+:::
+
 To use Prisma Client metrics, you must do the following:
 
-1. [Install the appropriate dependencies](#1-install-up-to-date-prisma-orm-dependencies).
+1. [Install compatible Prisma ORM dependencies](#1-install-compatible-prisma-orm-dependencies).
 1. [Enable the `metrics` feature flag in your Prisma schema file](#2-enable-the-feature-flag-in-the-prisma-schema-file).
 
 ### 1. Install up-to-date Prisma ORM dependencies
 
-Use version `3.15.0` or higher of the `prisma` and `@prisma/client` npm packages.
+You must use a version between `3.15.0` and `6.13.x` of the `prisma` and `@prisma/client` npm packages.
+
+**Install a compatible version:**
 
 ```terminal
-npm install prisma@latest --save-dev
-npm install @prisma/client@latest
+npm install prisma@6.13.0 --save-dev
+npm install @prisma/client@6.13.0
+```
+
+**Or use a version range that stays within the compatible range:**
+
+```terminal
+npm install prisma@">=3.15.0 <6.14.0" --save-dev
+npm install @prisma/client@">=3.15.0 <6.14.0"
 ```
 
 ### 2. Enable the feature flag in the Prisma schema file


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Metrics docs now include a prominent deprecation warning: metrics preview deprecated in Prisma ORM v6.14.0 and planned for removal in v7.
  - Clarified compatibility: metrics supported only in Prisma ORM ≤6.13.x, unavailable in v6.14.0+; metrics blocked when engineType uses the client query compiler.
  - Installation and prerequisites updated with explicit bounded version guidance (e.g., 3.15.0–6.13.x) and concrete install commands; recommends native DB driver metrics or OpenTelemetry as alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->