### PR TITLE
docs: improve docs about prisma-client imports

### DIFF
--- a/content/200-orm/100-prisma-schema/10-overview/02-data-sources.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/02-data-sources.mdx
@@ -4,8 +4,6 @@ metaTitle: 'Data sources (Reference)'
 metaDescription: 'Data sources enable Prisma to connect to your database. This page explains how to configure data sources in your Prisma schema.'
 ---
 
-<TopBlock>
-
 A data source determines how Prisma ORM connects to your database, and is represented by the [`datasource`](/orm/reference/prisma-schema-reference#datasource) block in the Prisma schema. The following data source uses the `postgresql` provider and includes a connection URL:
 
 ```prisma
@@ -21,8 +19,6 @@ A Prisma schema can only have _one_ data source. However, you can:
 - [Specify a different URL for Prisma Migrate's shadow database if you are working with cloud-hosted development databases](/orm/prisma-migrate/understanding-prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually)
 
 > **Note**: Multiple provider support was removed in 2.22.0. Please see [Deprecation of provider array notation](https://github.com/prisma/prisma/issues/3834) for more information.
-
-</TopBlock>
 
 ## Securing database connections
 

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -303,7 +303,7 @@ Isolated access to user defined enum types and values.
 
 - Contains no transitive dependencies and is very slim.
 - Can be used on backend and frontend.
-- Prefer this for optimal tree shacking and typecheck performance when accessing enums.
+- Prefer this for optimal tree shaking and typecheck performance when accessing enums.
 
 Example:
 

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -239,7 +239,7 @@ Below are the options for the `prisma-client` generator:
 
 ### Importing types
 
-The new `prisma-client` generator creates individual `.ts` files which allow for a more fine granular import of types. This can improve compile and typecheck performance and be useful for tree-shacking, too. 
+The new `prisma-client` generator creates individual `.ts` files which allow for a more fine granular import of types. This can improve compile and typecheck performance and be useful for tree-shaking, too. 
 You can still use the top level barrel files that export all types through a single import.
 
 The overall structure of the generated output looks like this:

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -265,35 +265,35 @@ For use in your server code.
 
 - Provides access to the `PrismaClient` instance and all model and utility types. 
 - Provides best compatibility with the `prisma-client-js` generated output.
-- Contains transitive dependencies on server only packages so cannot be used in browser contexts.
+- Contains transitive dependencies on server only-packages, so cannot be used in browser contexts.
 
 Example:
-```
+
+```ts
 import { Prisma, type Post, PrismaClient } from `./generated/prisma/client`
 ```
 
 #### `browser.ts`
 
-For using types in your frontend aka browser code. 
+For using types in your frontend (i.e. code that runs in the browser). 
 
-- Contains no transitive dependencies on node.js or other server only packages. 
-- Contains no real `PrismaClient`.
+- Contains no transitive dependencies on Node.js or other server-only packages. 
+- Contains no real `PrismaClient` constructor.
 - Contains all model and enum types and values.
 - Provides access to various utilities like `Prisma.JsonNull` and `Prisma.Decimal`.
 - Available since `v6.16.0`.
 
 :::note
 
-The old `prisma-client-js` generator created a node_modules package and used export maps to dynamically provide a browser compatible export of the generated prisma client.
-As the new `prisma-client` generator creates direct TypeScript source code and no package.json anymore, this approach is not possible. 
-Hence you need to be explicit about your imports and whether things run on server or client! 
+The old `prisma-client-js` generator created a `node_modules` package and used export maps to dynamically provide a browser compatible export of the generated Prisma Client library. As the new `prisma-client` generator creates direct TypeScript source code and no `package.json` file anymore, this approach is not possible. Hence you need to be explicit about your imports and whether things run on server or client! 
 
-You can still wrap the generated code in a package and use a similar approach on your own.
+You can still wrap the generated code in a package and use a similar approach as with `prisma-client-js` on your own.
 
 :::
 
 Example:
-```
+
+```ts
 import { Prisma, type Post } from `./generated/prisma/browser`
 ```
 
@@ -306,7 +306,8 @@ Isolated access to user defined enum types and values.
 - Prefer this for optimal tree shacking and typecheck performance when accessing enums.
 
 Example:
-```
+
+```ts
 import { MyEnum } from `./generated/prisma/enums`
 ```
 
@@ -315,7 +316,7 @@ import { MyEnum } from `./generated/prisma/enums`
 Isolated access to all model types.
 
 - Can be used on backend and frontend.
-- Contains all models including their derived utility types like `<ModelName>WhereInput` or `<ModelName>UpdateInput>.
+- Contains all models including their derived utility types like `<ModelName>WhereInput` or `<ModelName>UpdateInput>`.
 
 :::note
 
@@ -331,12 +332,12 @@ import type { UserModel, PostModel, PostWhereInput, UserUpdateInput } from `./ge
 ```
 
 
-#### `models/<ModelName>.ts
+#### `models/<ModelName>.ts`
 
 Isolated access to the types for an individual model.
 
 - Can be used on backend and frontend.
-- Contains the models including its derived utility types like `<ModelName>WhereInput` or `<ModelName>UpdateInput>.
+- Contains the models including its derived utility types like `<ModelName>WhereInput` or `<ModelName>UpdateInput>`.
 
 :::note
 
@@ -345,7 +346,8 @@ The plain model type is exposed here as `<ModelName>Model` (e.g. `PostModel`).
 :::
 
 Example:
-```
+
+```ts
 import type { UserModel, UserWhereInput, UserUpdateInput } from `./generated/prisma/models/User`
 ```
 
@@ -355,16 +357,20 @@ import type { UserModel, UserWhereInput, UserUpdateInput } from `./generated/pri
 Provides shared utility types that you should rarely directly need.
 
 Example: 
-```
+
+```ts
 import type { IntFilter } from `./generated/prisma/commonInputTypes`
 ```
 
 #### `internal/*`
 
-:warning: Do not directly import from these files! They are not part of the stable API of the generated code and can change at any time in breaking ways.
+:::warnin
+
+Do not directly import from these files! They are not part of the stable API of the generated code and can change at any time in breaking ways.
 
 Usually anything you might need from there is exposed via `browser.ts` or `client.ts` under the `Prisma` namespace.
 
+:::
 
 ### Breaking changes from `prisma-client-js`
 

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -364,7 +364,7 @@ import type { IntFilter } from `./generated/prisma/commonInputTypes`
 
 #### `internal/*`
 
-:::warnin
+:::warning
 
 Do not directly import from these files! They are not part of the stable API of the generated code and can change at any time in breaking ways.
 

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -92,7 +92,7 @@ If you use macOS ARM64 (`darwin-arm64`), then the binary file that was compiled 
 
 The new `prisma-client` generator offers greater control and flexibility when using Prisma ORM across different JavaScript environments (such as ESM, Bun, Deno, ...).
 
-It generates Prisma Client into a custom directory in your application's codebase that's specified via the `output` field on the `generator` block. This gives you full visibility and control over the generated code. It also [splits](#output-splitting-and-importing-types) the generated Prisma Client library into multiple files.
+It generates Prisma Client into a custom directory in your application's codebase that's specified via the `output` field on the `generator` block. This gives you full visibility and control over the generated code. It also [splits](#importing-types) the generated Prisma Client library into multiple files.
 
 This generator ensures you can bundle your application code exactly the way you want, without relying on hidden or automatic behaviors.
 

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -237,7 +237,7 @@ Below are the options for the `prisma-client` generator:
 
 :::
 
-### Importing Types
+### Importing types
 
 The new `prisma-client` generator creates individual `.ts` files which allow for a more fine granular import of types. This can improve compile and typecheck performance and be useful for tree-shacking, too. 
 You can still use the top level barrel files that export all types through a single import.

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -237,23 +237,12 @@ Below are the options for the `prisma-client` generator:
 
 :::
 
-### Output splitting and importing types
+### Importing Types
 
-The `prisma-client-js` generator used to generate all typings into a single `index.d.ts` file, which could lead to [slowing down editors](https://github.com/prisma/prisma/issues/4807) (e.g. breaking auto-complete) with large schemas.
+The new `prisma-client` generator creates individual `.ts` files which allow for a more fine granular import of types. This can improve compile and typecheck performance and be useful for tree-shacking, too. 
+You can still use the top level barrel files that export all types through a single import.
 
-The new `prisma-client` generator now splits the generated Prisma Client library into multiple files and thus avoids the problems of a single, large output file.
-
-**Before** (`prisma-client-js`)
-
-```
-generated/
-└── prisma
-    ├── client.ts
-    ├── index.ts # -> this is split into multiple files in 6.7.0
-    └── libquery_engine-darwin.dylib.node
-```
-
-**After** (`prisma-client`)
+The overall structure of the generated output looks like this:
 
 ```
 generated/
@@ -263,14 +252,118 @@ generated/
     ├── commonInputTypes.ts
     ├── enums.ts
     ├── internal
-    │   ├── class.ts
-    │   ├── prismaNamespace.ts
-    │   └── prismaNamespaceBrowser.ts
+    │   ├── ...
     ├── models
     │   ├── Post.ts
     │   └── User.ts
     └── models.ts
 ```
+
+#### `client.ts`
+
+For use in your server code. 
+
+- Provides access to the `PrismaClient` instance and all model and utility types. 
+- Provides best compatibility with the `prisma-client-js` generated output.
+- Contains transitive dependencies on server only packages so cannot be used in browser contexts.
+
+Example:
+```
+import { Prisma, type Post, PrismaClient } from `./generated/prisma/client`
+```
+
+#### `browser.ts`
+
+For using types in your frontend aka browser code. 
+
+- Contains no transitive dependencies on node.js or other server only packages. 
+- Contains no real `PrismaClient`.
+- Contains all model and enum types and values.
+- Provides access to various utilities like `Prisma.JsonNull` and `Prisma.Decimal`.
+
+:::note
+
+The old `prisma-client-js` generator created a node_modules package and used export maps to dynamically provide a browser compatible export of the generated prisma client.
+As the new `prisma-client` generator creates direct TypeScript source code and no package.json anymore, this approach is not possible. 
+Hence you need to be explicit about your imports and whether things run on server or client! 
+
+You can still wrap the generated code in a package and use a similar approach on your own.
+
+:::
+
+Example:
+```
+import { Prisma, type Post } from `./generated/prisma/browser`
+```
+
+#### `enums.ts`
+
+Isolated access to user defined enum types and values.
+
+- Contains no transitive dependencies and is very slim.
+- Can be used on backend and frontend.
+- Prefer this for optimal tree shacking and typecheck performance when accessing enums.
+
+Example:
+```
+import { MyEnum } from `./generated/prisma/enums`
+```
+
+#### `models.ts`
+
+Isolated access to all model types.
+
+- Can be used on backend and frontend.
+- Contains all models including their derived utility types like `<ModelName>WhereInput` or `<ModelName>UpdateInput>.
+
+:::note
+
+Plain model types are exposed here as `<ModelName>Model` (e.g. `PostModel`). This is in contrast to the exposed name in `client.ts` and `browser.ts` which is simply `<ModelName>` (e.g. `Post`).
+
+This is necessary due to internal constraints to avoid potential naming conflicts with internal types.
+
+:::
+
+Example:
+```
+import type { UserModel, PostModel, PostWhereInput, UserUpdateInput } from `./generated/prisma/models`
+```
+
+
+#### `models/<ModelName>.ts
+
+Isolated access to the types for an individual model.
+
+- Can be used on backend and frontend.
+- Contains the models including its derived utility types like `<ModelName>WhereInput` or `<ModelName>UpdateInput>.
+
+:::note
+
+The plain model type is exposed here as `<ModelName>Model` (e.g. `PostModel`).
+
+:::
+
+Example:
+```
+import type { UserModel, UserWhereInput, UserUpdateInput } from `./generated/prisma/models/User`
+```
+
+
+#### `commonInputTypes.ts`
+
+Provides shared utility types that you should rarely directly need.
+
+Example: 
+```
+import type { IntFilter } from `./generated/prisma/commonInputTypes`
+```
+
+#### `internal/*`
+
+:warning: Do not directly import from these files! They are not part of the stable API of the generated code and can change at any time in breaking ways.
+
+Usually anything you might need from there is exposed via `browser.ts` or `client.ts` under the `Prisma` namespace.
+
 
 ### Breaking changes from `prisma-client-js`
 

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -280,6 +280,7 @@ For using types in your frontend aka browser code.
 - Contains no real `PrismaClient`.
 - Contains all model and enum types and values.
 - Provides access to various utilities like `Prisma.JsonNull` and `Prisma.Decimal`.
+- Available since `v6.16.0`.
 
 :::note
 

--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -270,7 +270,7 @@ For use in your server code.
 Example:
 
 ```ts
-import { Prisma, type Post, PrismaClient } from `./generated/prisma/client`
+import { Prisma, type Post, PrismaClient } from "./generated/prisma/client"
 ```
 
 #### `browser.ts`
@@ -294,7 +294,7 @@ You can still wrap the generated code in a package and use a similar approach as
 Example:
 
 ```ts
-import { Prisma, type Post } from `./generated/prisma/browser`
+import { Prisma, type Post } from "./generated/prisma/browser"
 ```
 
 #### `enums.ts`
@@ -308,7 +308,7 @@ Isolated access to user defined enum types and values.
 Example:
 
 ```ts
-import { MyEnum } from `./generated/prisma/enums`
+import { MyEnum } from "./generated/prisma/enums"
 ```
 
 #### `models.ts`
@@ -327,8 +327,9 @@ This is necessary due to internal constraints to avoid potential naming conflict
 :::
 
 Example:
-```
-import type { UserModel, PostModel, PostWhereInput, UserUpdateInput } from `./generated/prisma/models`
+
+```ts
+import type { UserModel, PostModel, PostWhereInput, UserUpdateInput } from "./generated/prisma/models"
 ```
 
 
@@ -348,7 +349,7 @@ The plain model type is exposed here as `<ModelName>Model` (e.g. `PostModel`).
 Example:
 
 ```ts
-import type { UserModel, UserWhereInput, UserUpdateInput } from `./generated/prisma/models/User`
+import type { UserModel, UserWhereInput, UserUpdateInput } from "./generated/prisma/models/User"
 ```
 
 
@@ -359,12 +360,12 @@ Provides shared utility types that you should rarely directly need.
 Example: 
 
 ```ts
-import type { IntFilter } from `./generated/prisma/commonInputTypes`
+import type { IntFilter } from "./generated/prisma/commonInputTypes"
 ```
 
 #### `internal/*`
 
-:::warnin
+:::warning
 
 Do not directly import from these files! They are not part of the stable API of the generated code and can change at any time in breaking ways.
 


### PR DESCRIPTION
This PR expands the section about how imports with the new `prisma-client` generator work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized generator docs: replaced the old "output-splitting-and-importing-types" narrative with a dedicated "Importing types" section.
  * Documented a new multi-file generated output layout with per-file usage notes and clearer server vs. browser import guidance.
  * Added cautions about import explicitness and preserved guidance for packaging generated code.
  * Updated breaking changes: generator now requires an output path; recommends TypeScript’s satisfies for type validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->