### PR TITLE
fix: DC-5582 Update topsection and content dbswitchers 

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-cockroachdb.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Start from scratch with Prisma ORM using JavaScript and CockroachDB 
 metaDescription: 'Learn how to create a new Node.js project from scratch by connecting Prisma ORM to your CockroachDB database and generating a Prisma Client for database access.'
 hide_table_of_contents: true
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-cockroachdb

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-mysql.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Start from scratch with Prisma ORM using JavaScript and MySQL (15 mi
 metaDescription: 'Learn how to create a new Node.js project from scratch by connecting Prisma ORM to your MySQL database and generating a Prisma Client for database access.'
 hide_table_of_contents: true
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-mysql

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-planetscale.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Start from scratch with Prisma ORM using JavaScript and PlanetScale 
 metaDescription: 'Learn how to create a new Node.js project from scratch by connecting Prisma ORM to your PlanetScale database and generating a Prisma Client for database access.'
 hide_table_of_contents: true
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-planetscale

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-postgresql.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Start from scratch with Prisma ORM using JavaScript and PostgreSQL (
 metaDescription: 'Learn how to create a new Node.js project from scratch by connecting Prisma ORM to your PostgreSQL database and generating a Prisma Client for database access.'
 hide_table_of_contents: true
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-postgresql

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-sqlserver.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Start from scratch with Prisma ORM using JavaScript and SQL Server (
 metaDescription: 'Learn how to create a new Node.js project from scratch by connecting Prisma ORM to your SQL Server database and generating a Prisma Client for database access.'
 hide_table_of_contents: true
 langSwitcher: ['typescript', 'node']
-dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
+dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar
 pagination_next: getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-node-sqlserver

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-prismaPostgres.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-prismaPostgres.mdx
@@ -4,7 +4,7 @@ sidebar_label: 'Relational databases'
 metaTitle: 'Start from scratch with Prisma ORM using TypeScript and Prisma Postgres (15 min)'
 metaDescription: 'Learn how to create a new TypeScript project from scratch by connecting Prisma ORM to your Prisma Postgres database and generating a Prisma Client for database access.'
 hide_table_of_contents: true
-langSwitcher: ['typescript', 'node']
+langSwitcher: ['typescript']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
 sidebar_custom_props: { badge: '15 min' }
 sidebar_class_name: hidden-sidebar

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-prismaPostgres.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/100-connect-your-database-typescript-prismaPostgres.mdx
@@ -3,7 +3,7 @@ title: 'Connect your database using TypeScript and Prisma Postgres'
 sidebar_label: 'Connect your database'
 metaTitle: 'Connect your database using TypeScript and Prisma Postgres'
 metaDescription: 'Connect your database to your project using TypeScript and Prisma Postgres'
-langSwitcher: ['typescript', 'node']
+langSwitcher: ['typescript']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
 sidebar_class_name: 'hidden-sidebar tech-switch'
 hide_table_of_contents: true

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-prismaPostgres.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/150-using-prisma-migrate-typescript-prismaPostgres.mdx
@@ -3,7 +3,7 @@ title: 'Using Prisma Migrate with TypeScript and Prisma Postgres'
 sidebar_label: 'Using Prisma Migrate'
 metaTitle: 'Using Prisma Migrate with TypeScript and Prisma Postgres'
 metaDescription: 'Create database tables with Prisma Migrate using TypeScript and Prisma Postgres'
-langSwitcher: ['typescript', 'node']
+langSwitcher: ['typescript']
 sidebar_class_name: hidden-sidebar
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
 hide_table_of_contents: true

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-prismaPostgres.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/200-install-prisma-client-typescript-prismaPostgres.mdx
@@ -3,7 +3,7 @@ title: 'Install Prisma Client (TypeScript and Prisma Postgres)'
 sidebar_label: 'Install Prisma Client'
 metaTitle: 'Install Prisma Client: TypeScript and Prisma Postgres'
 metaDescription: 'Install and generate Prisma Client in your project using TypeScript and Prisma Postgres'
-langSwitcher: ['typescript', 'node']
+langSwitcher: ['typescript']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
 sidebar_class_name: hidden-sidebar
 hide_table_of_contents: true

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-prismaPostgres.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-typescript-prismaPostgres.mdx
@@ -3,7 +3,7 @@ title: 'Querying the database using TypeScript and Prisma Postgres'
 sidebar_label: 'Querying the database'
 metaTitle: 'Querying the database using TypeScript and Prisma Postgres'
 metaDescription: 'Write data to and query the database using TypeScript and Prisma Postgres'
-langSwitcher: ['typescript', 'node']
+langSwitcher: ['typescript']
 dbSwitcher: ['postgresql', 'mysql', 'sqlserver', 'planetscale', 'cockroachdb', 'prismaPostgres']
 hide_table_of_contents: true
 sidebar_class_name: hidden-sidebar

--- a/src/components/shortcodes/styles.module.scss
+++ b/src/components/shortcodes/styles.module.scss
@@ -30,9 +30,11 @@
 }
 
 .selectItem {
+  margin: 0;
   a {
     display: flex;
     align-items: center;
+    text-decoration: none !important;
 
     img {
       margin-right: 10px;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Streamlined database options by removing Prisma Postgres from the database switcher across relevant getting-started pages; PostgreSQL, MySQL, SQL Server, PlanetScale, and CockroachDB remain.
  - Added slug-based switching to ensure consistent navigation between database variants.
  - Simplified language options on Prisma Postgres tutorials by limiting the language switcher to TypeScript.
- Style
  - Improved list appearance by removing link underlines and standardizing spacing in selectable items for clearer, cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->