### PR TITLE
fix: update error handling in Prisma Client API reference when record is not found

### DIFF
--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -929,7 +929,7 @@ prisma:query COMMIT
 | -------------------------- | ------------------------------ | --------------------------------------------------------------- |
 | JavaScript object (typed)  | `User`                         |                                                                 |
 | JavaScript object (plain)  | `{ name: "Alice Wonderland" }` | Use `select` and `include` to determine which fields to return. |
-| `RecordNotFound` exception |                                | Exception is thrown if record does not exist.                   |
+| `PrismaClientKnownRequestError` (code `P2025`) |                                | Thrown if the record to update does not exist. See [Error reference](/orm/reference/error-reference#p2025)                   |
 
 #### Remarks
 
@@ -1184,7 +1184,7 @@ To delete records that match a certain criteria, use [`deleteMany`](#deletemany)
 | -------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
 | JavaScript object (typed)  | `User`                         | The `User` record that was deleted.                                                                           |
 | JavaScript object (plain)  | `{ name: "Alice Wonderland" }` | Data from the `User` record that was deleted. Use `select` and `include` to determine which fields to return. |
-| `RecordNotFound` exception |                                | Throws an exception if record does not exist.                                                                 |
+| `PrismaClientKnownRequestError` (code `P2025`) |                                | Thrown if the record to delete does not exist. See [Error reference](/orm/reference/error-reference#p2025)                   |                                                               |
 
 #### Remarks
 


### PR DESCRIPTION
Fixes: https://github.com/prisma/docs/issues/6979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated error handling guidance for update/delete operations when a record is missing, replacing references to RecordNotFound with PrismaClientKnownRequestError (P2025).
  - Clarified Return type/Error reference sections and linked to the central error reference for details.
  - Improves accuracy, consistency, and discoverability of not-found error handling in the docs.
  - No runtime behavior changes; this is a documentation-only update to reflect the current error surfaced to developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->