### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,2 +1,15 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Creates `.claude/settings.json` with `block-no-verify@1.1.2` as a `PreToolUse` Bash hook to prevent Claude Code agents from bypassing git hooks via the hook-skip flag.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block.

Closes #7676

---

_Disclosure: I am the author and maintainer of `block-no-verify`._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for internal development tooling and validation processes.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->