### PR TITLE
fix(docs): load Promptwatch analytics via next/script

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -41,6 +41,11 @@ export default function Layout({ children }: { children: ReactNode }) {
           crossOrigin="anonymous"
           data-auto-add-css="false"
         />
+        <Script
+          src="https://ingest.promptwatch.com/js/client.min.js"
+          strategy="afterInteractive"
+          data-project-id="25f18e15-6306-4faa-b5c2-8078804778ac"
+        />
       </head>
       <body className="flex flex-col min-h-screen">
         <Provider>{children}</Provider>

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -45,6 +45,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           src="https://ingest.promptwatch.com/js/client.min.js"
           strategy="afterInteractive"
           data-project-id="25f18e15-6306-4faa-b5c2-8078804778ac"
+          data-cookieyes="cookieyes-analytics"
         />
       </head>
       <body className="flex flex-col min-h-screen">
@@ -53,6 +54,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           async
           src="https://cdn.tolt.io/tolt.js"
           data-tolt="fda67739-7ed0-42d2-b716-6da0edbec191"
+          data-cookieyes="cookieyes-analytics"
         />
         <Script
           async


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an additional client-side script that loads after the page becomes interactive.
  * Updated an existing client-side script to include a cookie-consent attribute for alignment with site consent settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->