### PR TITLE
feat(docs): add clarification on database upsert criteria

### DIFF
--- a/apps/docs/content/docs.v6/orm/reference/prisma-client-reference.mdx
+++ b/apps/docs/content/docs.v6/orm/reference/prisma-client-reference.mdx
@@ -1063,6 +1063,7 @@ Prisma Client uses a database upsert for an `upsert` query when the query meets 
 - The query modifies only one model
 - There is only one unique field in the `upsert`'s `where` option
 - The unique field in the `where` option and the unique field in the `create` option have the same value
+- The update clause is not empty
 
 If your query does not meet these criteria, then Prisma Client handles the upsert itself.
 


### PR DESCRIPTION
See https://github.com/prisma/prisma/issues/20229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma Client reference documentation to clarify the criteria for `upsert` query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->