### PR TITLE
fix: removed EA tag

### DIFF
--- a/apps/docs/content/docs/postgres/database/postgres-extensions.mdx
+++ b/apps/docs/content/docs/postgres/database/postgres-extensions.mdx
@@ -1,10 +1,9 @@
 ---
-title: PostgreSQL extensions
-description: Enable and use PostgreSQL extensions with Prisma Postgres.
-badge: early-access
+title: Extensions
+description: Enable and use standard PostgreSQL extensions with Prisma Postgres.
 url: /postgres/database/postgres-extensions
 metaTitle: Postgres extensions
-metaDescription: Learn about using Postgres extensions with Prisma Postgres
+metaDescription: Learn about Postgres extensions with Prisma Postgres
 ---
 
 Prisma Postgres supports standard [PostgreSQL extensions](https://www.postgresql.org/docs/current/sql-createextension.html). Extensions add extra functionality to your database. Things like vector search, full-text search, fuzzy matching, and cryptographic functions.


### PR DESCRIPTION
This PR removes the EA tag for Prisma Postgres Extensions, and renames the page to be called "Extensions" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PostgreSQL extensions documentation page with refined titles and descriptions.
  * Removed early-access designation from the extensions documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->