### PR TITLE
fix(blog): use UTC timezone in formatDate to prevent off-by-one day

### DIFF
--- a/apps/blog/src/lib/format.ts
+++ b/apps/blog/src/lib/format.ts
@@ -6,6 +6,7 @@ export const formatDate = (iso: string) => {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
   });
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date formatting to consistently display dates in UTC timezone, ensuring uniform date representation across all user locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->