### PR TITLE
fix(github-webhook): fix incorrect env var name

### DIFF
--- a/apps/docs/src/app/api/github-webhook/route.ts
+++ b/apps/docs/src/app/api/github-webhook/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
     `https://api.github.com/orgs/prisma/teams/dev-connections-write/memberships/${pr.user.login}`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.BOT_TOKEN_PR_LINEAR_WEBHOOK!}`,
+        Authorization: `Bearer ${process.env.BOT_TOKEN_GITHUB_PR_LINEAR_WEBHOOK!}`,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub API authentication configuration for webhook integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->