### PR TITLE
docs(generators): add tip for tsx users about importFileExtension

### DIFF
--- a/apps/docs/content/docs/orm/prisma-schema/overview/generators.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/overview/generators.mdx
@@ -154,6 +154,22 @@ Below are the options for the `prisma-client` generator:
 
 :::
 
+:::tip
+
+**Using `tsx` as your TypeScript runner?** If you see `Cannot find module './internal/class.js'` errors at runtime, set `importFileExtension = "ts"` in your generator block:
+
+```prisma
+generator client {
+  provider            = "prisma-client"
+  output              = "../src/generated/prisma"
+  importFileExtension = "ts"
+}
+```
+
+This happens because the generated client uses `.js` extensions in its import statements (ESM convention), but `tsx` cannot resolve `.js` imports to the corresponding `.ts` files on disk. Setting `importFileExtension = "ts"` ensures the generated imports match what `tsx` expects.
+
+:::
+
 ### Importing types
 
 The new `prisma-client` generator creates individual `.ts` files which allow for a more fine granular import of types. This can improve compile and typecheck performance and be useful for tree-shaking, too.


### PR DESCRIPTION
## Summary
- Adds a tip in the generators reference explaining the `importFileExtension = "ts"` fix for `tsx` users
- Addresses the common `Cannot find module './internal/class.js'` error when running Prisma 7's generated client with `tsx`

## Context
This is a frequently asked question in Prisma Discussions ([#29318](https://github.com/prisma/prisma/discussions/29318), [#29347](https://github.com/prisma/prisma/discussions/29347)). The generated client uses `.js` import extensions (ESM convention), but `tsx` cannot resolve `.js` to `.ts` files on disk. The fix is simple (`importFileExtension = "ts"`), but users struggle to find it since the current docs don't mention `tsx` specifically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation providing guidance on resolving `tsx` runtime module resolution errors with Prisma. The section includes a practical configuration example and explains how aligning the import file extension setting to `ts` resolves conflicts between generated client imports and `tsx`'s module resolution expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->