### PR TITLE
fix(site): DR-7903 remove Optimize section from pricing page

### DIFF
--- a/apps/site/src/app/pricing/pricing-data.ts
+++ b/apps/site/src/app/pricing/pricing-data.ts
@@ -11,17 +11,7 @@ export const symbols = {
   USD: "$",
 } as const;
 
-export type Symbol =
-  | "EUR"
-  | "AUD"
-  | "INR"
-  | "GBP"
-  | "CAD"
-  | "BRL"
-  | "JPY"
-  | "CNY"
-  | "KRW"
-  | "USD";
+export type Symbol = "EUR" | "AUD" | "INR" | "GBP" | "CAD" | "BRL" | "JPY" | "CNY" | "KRW" | "USD";
 
 export type CurrencyMap = Record<Symbol, string>;
 
@@ -30,7 +20,7 @@ export type PlanPoint =
   | {
       text: string;
       price: CurrencyMap;
-    }
+    };
 
 export type PricingPlan = {
   title: string;
@@ -49,15 +39,9 @@ export type UsagePricing = {
 };
 
 /** Formats a single numeric amount with every supported currency symbol. */
-export function formatAmountForAllCurrencies(
-  amount: number,
-  digits: number,
-): CurrencyMap {
+export function formatAmountForAllCurrencies(amount: number, digits: number): CurrencyMap {
   return Object.fromEntries(
-    Object.entries(symbols).map(([code, symbol]) => [
-      code,
-      `${symbol}${amount.toFixed(digits)}`,
-    ]),
+    Object.entries(symbols).map(([code, symbol]) => [code, `${symbol}${amount.toFixed(digits)}`]),
   ) as CurrencyMap;
 }
 
@@ -189,14 +173,14 @@ export const comparisonSections = [
   {
     title: "Global Cache",
     rows: [
-      ["Cache tag invalidations", "-", "-", "$0.002 per 1,000, max 10,000 per day", "$0.001 per 1,000, max 100,000 per day"],
+      [
+        "Cache tag invalidations",
+        "-",
+        "-",
+        "$0.002 per 1,000, max 10,000 per day",
+        "$0.001 per 1,000, max 100,000 per day",
+      ],
       ["Cache purge requests", "5 per hour", "5 per hour", "10 per hour", "20 per hour"],
-    ],
-  },
-  {
-    title: "Database optimizations",
-    rows: [
-      ["Query insights", "✓", "✓", "✓", "✓"],
     ],
   },
   {
@@ -216,12 +200,12 @@ export const faqs: Array<{ question: string; answer: string }> = [
   {
     question: "What is an operation?",
     answer:
-      "<p>Each action you perform, whether it’s a create, read, update, or delete query against your Prisma Postgres database counts as a single operation. Even if Prisma issues multiple database queries behind the scenes to fulfill your request, it’s still billed as one operation.</p><p>By treating simple lookups and complex queries the same, you can directly correlate your database usage and costs with your product usage and user behavior. There’s no need to track write-heavy workloads or worry about bandwidth per operation: each of them is counted and billed the same, making your usage and budgeting simple and straightforward. You can learn more about <a class=\"underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak\" href=\"https://www.prisma.io/blog/operations-based-billing#what-is-an-operation\">our operations-based pricing model</a> in our blog post.</p>",
+      '<p>Each action you perform, whether it’s a create, read, update, or delete query against your Prisma Postgres database counts as a single operation. Even if Prisma issues multiple database queries behind the scenes to fulfill your request, it’s still billed as one operation.</p><p>By treating simple lookups and complex queries the same, you can directly correlate your database usage and costs with your product usage and user behavior. There’s no need to track write-heavy workloads or worry about bandwidth per operation: each of them is counted and billed the same, making your usage and budgeting simple and straightforward. You can learn more about <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/blog/operations-based-billing#what-is-an-operation">our operations-based pricing model</a> in our blog post.</p>',
   },
   {
     question: "How many operations do I need for my project?",
     answer:
-      "<p>While the answer to this question will vary from project to project, there are a couple of ways to get an idea of what you will need:</p><ul><li>If you already have a database with another provider, you can often look in their dashboard to see your current usage. The number of queries will be a good hint to the approximate number of operations you’ll use.</li><li>If you already use the Prisma ORM, you can enable the <a class=\"underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak\" href=\"https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/metrics\">metrics</a> feature to begin tracking your usage, which is an easy and accurate way to see your current usage.</li><li>If you’re starting a new project, we encourage you to just get started and see how many queries you typically use. We offer a free plan with 100,000 operations <strong>per month</strong>, meaning you can confidently get started without paying anything. From our experience, 100,000 operations per month is more than enough to get started with a project and serve your first users.</li></ul><p>You can find an <a class=\"underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak\" href=\"https://www.prisma.io/blog/operations-based-billing#calculation-example\">example calculation </a>for a medium-sized workload in our blog post about our operations-based pricing model.</p>",
+      '<p>While the answer to this question will vary from project to project, there are a couple of ways to get an idea of what you will need:</p><ul><li>If you already have a database with another provider, you can often look in their dashboard to see your current usage. The number of queries will be a good hint to the approximate number of operations you’ll use.</li><li>If you already use the Prisma ORM, you can enable the <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/metrics">metrics</a> feature to begin tracking your usage, which is an easy and accurate way to see your current usage.</li><li>If you’re starting a new project, we encourage you to just get started and see how many queries you typically use. We offer a free plan with 100,000 operations <strong>per month</strong>, meaning you can confidently get started without paying anything. From our experience, 100,000 operations per month is more than enough to get started with a project and serve your first users.</li></ul><p>You can find an <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/blog/operations-based-billing#calculation-example">example calculation </a>for a medium-sized workload in our blog post about our operations-based pricing model.</p>',
   },
   {
     question: "Can I use Prisma Postgres for free?",
@@ -241,12 +225,12 @@ export const faqs: Array<{ question: string; answer: string }> = [
   {
     question: "What’s the difference between usage pricing and traditional database pricing?",
     answer:
-      "<p>Traditional pricing is where you choose a fixed database size and price, and the amount you pay is generally predictable. But that comes at the expense of flexibility, meaning it’s much harder to scale up and down with your application’s demands. This is usually fine for a small test database, but for production workloads, it can be burdensome: If you have low-traffic periods, and high-traffic periods (most production apps do) then you either under-provision and risk having downtime in busy periods, or you over-provision and pay a lot more for your database.</p><p>With usage pricing, you only pay for what you need, when you need it. If your app has a quiet period, you’ll pay less. If things get busy, we can simply scale up to handle it for you. Prisma Postgres comes with budget controls, so you can always stay in control of your spending, while taking advantage of the flexibility. You can learn more <a class=\"underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak\" href=\"https://www.prisma.io/blog/operations-based-billing#why-is-an-operations-based-pricing-model-better?utm_source=pricing_website&amp;utm_content=faq\">on why operations-based pricing is better</a> in our blog post.</p>",
+      '<p>Traditional pricing is where you choose a fixed database size and price, and the amount you pay is generally predictable. But that comes at the expense of flexibility, meaning it’s much harder to scale up and down with your application’s demands. This is usually fine for a small test database, but for production workloads, it can be burdensome: If you have low-traffic periods, and high-traffic periods (most production apps do) then you either under-provision and risk having downtime in busy periods, or you over-provision and pay a lot more for your database.</p><p>With usage pricing, you only pay for what you need, when you need it. If your app has a quiet period, you’ll pay less. If things get busy, we can simply scale up to handle it for you. Prisma Postgres comes with budget controls, so you can always stay in control of your spending, while taking advantage of the flexibility. You can learn more <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/blog/operations-based-billing#why-is-an-operations-based-pricing-model-better?utm_source=pricing_website&amp;utm_content=faq">on why operations-based pricing is better</a> in our blog post.</p>',
   },
   {
     question: "How is Prisma’s pricing different to others?",
     answer:
-      "<p>Prisma’s pricing is designed to provide maximum flexibility to developers, while aiming to be as intuitive as possible.</p><p>We charge primarily by <em>operation</em>, which is counted each time you invoke the Prisma ORM client to create, read, update or delete a record. Additionally we also charge for <em>storage</em>. All with a very generous free threshold each month.</p><p>We don’t charge by data transfer (bandwidth) or by compute/memory hours, simply because we felt that these metrics are more difficult to grasp as a developer.</p><p>We created a pricing model to more closely match how you use your database as a developer, not how the infrastructure works. You can learn more about our <a class=\"underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak\" href=\"https://www.prisma.io/blog/operations-based-billing#a-simpler-approach-to-database-pricing\">approach to an operations-based database pricing model in this blog post</a>.</p>",
+      '<p>Prisma’s pricing is designed to provide maximum flexibility to developers, while aiming to be as intuitive as possible.</p><p>We charge primarily by <em>operation</em>, which is counted each time you invoke the Prisma ORM client to create, read, update or delete a record. Additionally we also charge for <em>storage</em>. All with a very generous free threshold each month.</p><p>We don’t charge by data transfer (bandwidth) or by compute/memory hours, simply because we felt that these metrics are more difficult to grasp as a developer.</p><p>We created a pricing model to more closely match how you use your database as a developer, not how the infrastructure works. You can learn more about our <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/blog/operations-based-billing#a-simpler-approach-to-database-pricing">approach to an operations-based database pricing model in this blog post</a>.</p>',
   },
   {
     question: "How can I compare Prisma pricing to other providers?",
@@ -261,11 +245,11 @@ export const faqs: Array<{ question: string; answer: string }> = [
   {
     question: "I'm an early stage startup, do you offer any discounts?",
     answer:
-      "<p>Building a startup is hard. Prisma helps you stay laser-focused on what matters the most, which is building features and winning users.</p><p>We offer $10k in credits to eligible startups. Learn more at <a class=\"underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak\" href=\"https://prisma.io/startups\">prisma.io/startups</a>.</p>",
+      '<p>Building a startup is hard. Prisma helps you stay laser-focused on what matters the most, which is building features and winning users.</p><p>We offer $10k in credits to eligible startups. Learn more at <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://prisma.io/startups">prisma.io/startups</a>.</p>',
   },
   {
     question: "How do I upgrade my plan if I am using Prisma Postgres via Vercel?",
     answer:
-      "<p>If you're using Prisma Postgres via Vercel, your billing is handled directly by Vercel. To upgrade your plan, you'll need to do so in the Vercel Dashboard. The instructions are available in our <a class=\"underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak\" href=\"https://www.prisma.io/docs/postgres/more/faq#how-do-i-upgrade-my-plan-if-i-am-using-prisma-postgres-via-vercel\">docs</a>.</p>",
+      '<p>If you\'re using Prisma Postgres via Vercel, your billing is handled directly by Vercel. To upgrade your plan, you\'ll need to do so in the Vercel Dashboard. The instructions are available in our <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/docs/postgres/more/faq#how-do-i-upgrade-my-plan-if-i-am-using-prisma-postgres-via-vercel">docs</a>.</p>',
   },
 ];


### PR DESCRIPTION
## Summary

- Removes the **Database optimizations** section (containing the "Query insights" row) from the comparison table on the pricing page
- Change is in `comparisonSections` in `pricing-data.ts`

## Linear

https://linear.app/prisma-company/issue/DR-7903/remove-optimize-section-from-the-pricing-page

## Test plan

- [ ] Open the Vercel preview link for this PR
- [ ] Navigate to `/pricing`
- [ ] Scroll down to the **Compare plans** table
- [ ] Confirm the **Database optimizations** section (Query insights row) is no longer present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined pricing comparison sections and FAQ content formatting to enhance consistency and readability across the pricing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->