### PR TITLE
fix(newsletter): rss feed link missing `s` in `https`

### DIFF
--- a/apps/site/src/app/newsletter/page.tsx
+++ b/apps/site/src/app/newsletter/page.tsx
@@ -29,7 +29,7 @@ type RssItem = {
 
 async function getLatestBlogPosts(count = 3): Promise<RssItem[]> {
   try {
-    const res = await fetch("http://www.prisma.io/blog/rss.xml", {
+    const res = await fetch("https://www.prisma.io/blog/rss.xml", {
       next: { revalidate: 3600 },
     });
     const xml = await res.text();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated newsletter RSS feed URL to use secure HTTPS protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->