### PR TITLE
fix(blog): redirect `/{tag}` to `/?tag=${tag}`

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -205,6 +205,17 @@ const allowedDevOrigins = (
 const config = {
   reactCompiler: true,
   async redirects() {
+    const tagSlugs = [
+      "announcement",
+      "data-platform",
+      "education",
+      "orm",
+      "prisma-postgres",
+      "release",
+      "serverless",
+      "user-success-story",
+    ];
+
     return [
       {
         source: "/",
@@ -212,6 +223,11 @@ const config = {
         permanent: false,
         basePath: false,
       },
+      ...tagSlugs.map((tag) => ({
+        source: `/${tag}`,
+        destination: `/?tag=${tag}`,
+        permanent: true,
+      })),
     ];
   },
   async rewrites() {

--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -206,6 +206,7 @@ const config = {
   reactCompiler: true,
   async redirects() {
     const tagSlugs = [
+      "ai",
       "announcement",
       "data-platform",
       "education",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permanent redirects for blog tag pages, enabling direct URL access to tagged content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->