### PR TITLE
fix(blog): add missing /blog prefix to post card URLs

### DIFF
--- a/apps/blog/src/app/(blog)/page.tsx
+++ b/apps/blog/src/app/(blog)/page.tsx
@@ -143,7 +143,7 @@ export default async function BlogHome({
     }
 
     return {
-      url: post.url,
+      url: withBlogBasePath(post.url),
       title: data.title as string,
       date: dateISO,
       excerpt: data.metaDescription as string,


### PR DESCRIPTION
## Summary
- Blog post links from the listing page used `post.url` directly (e.g. `/my-post`) instead of `withBlogBasePath(post.url)` (e.g. `/blog/my-post`), causing 404s when clicking any post
- Most visible from filtered views like `/blog?tag=announcement` but affects all post links on the listing page
- One-line fix: apply the same `withBlogBasePath()` already used for image sources on line 151

## Test plan
- [ ] Go to `/blog?tag=announcement`, click any post — should navigate to `/blog/<slug>` instead of 404
- [ ] Go to `/blog` (unfiltered), click any post — should still work
- [ ] Verify post card links include `/blog` prefix in the href

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blog post links to properly include the base path prefix when navigating between articles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->