### PR TITLE
fix(site): pricing page mobile above-fold visibility

### DIFF
--- a/apps/site/src/app/pricing/pricing-hero-plans.tsx
+++ b/apps/site/src/app/pricing/pricing-hero-plans.tsx
@@ -37,7 +37,7 @@ export function PricingHeroPlans({
 
   return (
     <>
-      <section className="relative pt-16 pb-8 md:pt-28 md:pb-16 px-4">
+      <section className="relative pt-28 pb-8 md:pt-28 md:pb-16 px-4 ">
         <div className="absolute inset-0 bg-[radial-gradient(80%_60%_at_50%_0%,rgba(20,184,166,0.22),transparent_60%)] pointer-events-none" />
         <div className="relative max-w-[1200px] mx-auto flex flex-col items-center gap-3 md:gap-6">
           <Badge

--- a/apps/site/src/app/pricing/pricing-hero-plans.tsx
+++ b/apps/site/src/app/pricing/pricing-hero-plans.tsx
@@ -37,9 +37,9 @@ export function PricingHeroPlans({
 
   return (
     <>
-      <section className="relative pt-28 pb-16 px-4">
+      <section className="relative pt-16 pb-8 md:pt-28 md:pb-16 px-4">
         <div className="absolute inset-0 bg-[radial-gradient(80%_60%_at_50%_0%,rgba(20,184,166,0.22),transparent_60%)] pointer-events-none" />
-        <div className="relative max-w-[1200px] mx-auto flex flex-col items-center gap-6">
+        <div className="relative max-w-[1200px] mx-auto flex flex-col items-center gap-3 md:gap-6">
           <Badge
             color="ppg"
             size="lg"
@@ -51,16 +51,16 @@ export function PricingHeroPlans({
               </>
             }
           />
-          <h1 className="stretch-display m-0 text-center text-foreground-neutral text-5xl md:text-7xl leading-tight font-sans-display [font-variation-settings:'wght'_900]">
+          <h1 className="stretch-display m-0 text-center text-foreground-neutral text-3xl md:text-7xl leading-tight font-sans-display [font-variation-settings:'wght'_900]">
             Scale as You Grow <br /> with Prisma Postgres
           </h1>
-          <p className="m-0 text-center text-xl text-foreground-neutral-weak">
+          <p className="m-0 text-center text-base md:text-xl text-foreground-neutral-weak">
             Operation-based pricing. We only charge for what you use.
           </p>
         </div>
       </section>
 
-      <section className="px-4 py-12">
+      <section className="px-4 py-6 md:py-12">
         <div className="max-w-[1288px] mx-auto">
           <div className="mb-6 flex justify-end">
             <Select value={currency} onValueChange={(value) => onCurrencyChange(value as Symbol)}>


### PR DESCRIPTION
## Summary
- Reduces pricing hero H1 size (`text-5xl` → `text-3xl`), subtitle size, section padding, and element gaps on mobile breakpoints
- Ensures at least one pricing plan card is visible above the fold on mobile devices
- Desktop layout is completely unchanged — all reductions use `md:` prefixed classes to preserve original values

## Context
SEO audit item #12: "No pricing info visible above fold on mobile — H1 consumes entire viewport." This impacts mobile UX, conversion rate, and Google's mobile-first indexing.

## Test plan
- [ ] Verify pricing page desktop layout is unchanged
- [ ] Verify pricing page mobile view shows at least one plan card above the fold
- [ ] Check Vercel preview on a real mobile device or Chrome DevTools mobile emulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Optimized pricing page layout for smaller screens by reducing vertical spacing in hero and pricing sections.
  * Adjusted responsive typography: smaller headline and description sizes on narrow viewports while preserving larger sizes on medium+ displays.
  * Maintains visual consistency across breakpoints with tighter gaps and reduced padding on mobile for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->